### PR TITLE
feat: add Unicity runtime command delegation

### DIFF
--- a/crates/unicity-aos-bootstrap/Cargo.toml
+++ b/crates/unicity-aos-bootstrap/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Product-owned runtime layout and launcher for Unicity AOS."
+
+[[bin]]
+name = "unicity"
+path = "src/main.rs"

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -5,10 +5,10 @@
 //! to the bundled runtime process only; it never changes the caller's process
 //! environment or rewrites a standalone runtime installation.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
+use std::process::{Child, Command, ExitStatus};
 
 /// Product state owned by one Unicity AOS installation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -107,8 +107,23 @@ impl AosHome {
     /// shell, another AOS install, or a standalone Astrid Runtime installation.
     #[must_use]
     pub fn runtime_command(&self) -> Command {
+        self.runtime_command_with_args(std::iter::empty::<&OsStr>())
+    }
+
+    /// Build a command for the bundled runtime with product CLI arguments.
+    ///
+    /// The command is executed directly, not through a shell. This preserves
+    /// argument boundaries and leaves the runtime in charge of its established
+    /// local socket, credentials, and operator protocol.
+    #[must_use]
+    pub fn runtime_command_with_args<I, S>(&self, args: I) -> Command
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
         let mut command = Command::new(self.runtime_binary());
         command.env("ASTRID_HOME", self.runtime_home());
+        command.args(args);
         command
     }
 
@@ -117,6 +132,22 @@ impl AosHome {
     /// # Errors
     /// Returns an error when the bundled executable is absent or cannot start.
     pub fn spawn_runtime(&self) -> io::Result<Child> {
+        self.spawn_runtime_with_args(std::iter::empty::<&OsStr>())
+    }
+
+    /// Spawn the bundled runtime with product CLI arguments.
+    ///
+    /// Unicity AOS is a trusted distribution built on Astrid Runtime, so this
+    /// path uses the runtime's normal local operator credentials. The runtime
+    /// home remains scoped to this AOS installation.
+    ///
+    /// # Errors
+    /// Returns an error when the bundled executable is absent or cannot start.
+    pub fn spawn_runtime_with_args<I, S>(&self, args: I) -> io::Result<Child>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
         let binary = self.runtime_binary();
         if !binary.is_file() {
             return Err(io::Error::new(
@@ -128,7 +159,23 @@ impl AosHome {
             ));
         }
         self.ensure_layout()?;
-        self.runtime_command().spawn()
+        self.runtime_command_with_args(args).spawn()
+    }
+
+    /// Run an Astrid Runtime command as an AOS product command.
+    ///
+    /// The runtime remains the authority for socket authentication and local
+    /// credentials. Unicity provides only product-owned installation state and
+    /// preserves the runtime's exit status for scripts and service managers.
+    ///
+    /// # Errors
+    /// Returns an error when the bundled executable is absent or cannot start.
+    pub fn run_runtime_with_args<I, S>(&self, args: I) -> io::Result<ExitStatus>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.spawn_runtime_with_args(args)?.wait()
     }
 }
 
@@ -215,6 +262,19 @@ mod tests {
             .expect("runtime command sets ASTRID_HOME");
 
         assert_eq!(runtime_home, "/tmp/unicity-aos-test/runtime");
+    }
+
+    #[test]
+    fn runtime_command_forwards_product_cli_arguments_without_a_shell() {
+        let home = AosHome::from_root("/tmp/unicity-aos-test");
+        let command = home.runtime_command_with_args(["status", "--json"]);
+        let args: Vec<_> = command.get_args().collect();
+
+        assert_eq!(args, ["status", "--json"]);
+        assert_eq!(
+            command.get_program(),
+            "/tmp/unicity-aos-test/runtime/bin/astrid"
+        );
     }
 
     #[test]

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -148,18 +148,27 @@ impl AosHome {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        let binary = self.runtime_binary();
-        if !binary.is_file() {
-            return Err(io::Error::new(
-                io::ErrorKind::NotFound,
-                format!(
-                    "bundled runtime executable not found at {}",
-                    binary.display()
-                ),
-            ));
-        }
-        self.ensure_layout()?;
+        self.ensure_runtime_available()?;
         self.runtime_command_with_args(args).spawn()
+    }
+
+    /// Replace the current Unix process with a bundled runtime command.
+    ///
+    /// `exec` preserves the runtime's signal and exit semantics for terminal
+    /// users and service managers; it never returns on success.
+    ///
+    /// # Errors
+    /// Returns an error when the bundled executable is absent or cannot start.
+    #[cfg(unix)]
+    pub fn exec_runtime_with_args<I, S>(&self, args: I) -> io::Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        use std::os::unix::process::CommandExt;
+
+        self.ensure_runtime_available()?;
+        Err(self.runtime_command_with_args(args).exec())
     }
 
     /// Run an Astrid Runtime command as an AOS product command.
@@ -176,6 +185,20 @@ impl AosHome {
         S: AsRef<OsStr>,
     {
         self.spawn_runtime_with_args(args)?.wait()
+    }
+
+    fn ensure_runtime_available(&self) -> io::Result<()> {
+        let binary = self.runtime_binary();
+        if !binary.is_file() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "bundled runtime executable not found at {}",
+                    binary.display()
+                ),
+            ));
+        }
+        self.ensure_layout()
     }
 }
 
@@ -232,7 +255,7 @@ const fn runtime_binary_name() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::AosHome;
+    use super::{AosHome, runtime_binary_name};
     use std::ffi::OsString;
     use std::io::ErrorKind;
     use std::path::PathBuf;
@@ -247,7 +270,7 @@ mod tests {
         );
         assert_eq!(
             home.runtime_binary(),
-            PathBuf::from("/tmp/unicity-aos-test/runtime/bin/astrid")
+            home.runtime_home().join("bin").join(runtime_binary_name())
         );
     }
 
@@ -271,10 +294,7 @@ mod tests {
         let args: Vec<_> = command.get_args().collect();
 
         assert_eq!(args, ["status", "--json"]);
-        assert_eq!(
-            command.get_program(),
-            "/tmp/unicity-aos-test/runtime/bin/astrid"
-        );
+        assert_eq!(command.get_program(), home.runtime_binary());
     }
 
     #[test]

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -1,0 +1,44 @@
+//! `unicity` — the product command surface for Unicity AOS.
+//!
+//! Unicity AOS is a trusted distribution built on Astrid Runtime. The product
+//! binary therefore delegates runtime and operator commands directly to its
+//! bundled runtime, scoped to this installation's private `ASTRID_HOME`.
+
+use std::ffi::OsString;
+use std::process::ExitCode;
+
+use unicity_aos_bootstrap::AosHome;
+
+fn main() -> ExitCode {
+    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
+    if matches!(
+        args.first().and_then(|arg| arg.to_str()),
+        Some("-h" | "--help")
+    ) {
+        print_help();
+        return ExitCode::SUCCESS;
+    }
+
+    let home = match AosHome::resolve() {
+        Ok(home) => home,
+        Err(error) => {
+            eprintln!("unicity: failed to resolve product home: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match home.run_runtime_with_args(args) {
+        Ok(status) if status.success() => ExitCode::SUCCESS,
+        Ok(status) => ExitCode::from(status.code().unwrap_or(1).clamp(1, i32::from(u8::MAX)) as u8),
+        Err(error) => {
+            eprintln!("unicity: failed to start bundled runtime: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn print_help() {
+    println!(
+        "Unicity AOS\n\nUsage:\n  unicity <runtime command> [arguments...]\n\nUnicity delegates local runtime and operator commands to its bundled Astrid Runtime.\nThe runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME)."
+    );
+}

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -9,14 +9,35 @@ use std::process::ExitCode;
 
 use unicity_aos_bootstrap::AosHome;
 
+#[cfg(unix)]
 fn main() -> ExitCode {
     let args: Vec<OsString> = std::env::args_os().skip(1).collect();
-    if matches!(
-        args.first().and_then(|arg| arg.to_str()),
-        Some("-h" | "--help")
-    ) {
-        print_help();
-        return ExitCode::SUCCESS;
+    if let Some(exit_code) = handle_product_command(&args) {
+        return exit_code;
+    }
+
+    let home = match AosHome::resolve() {
+        Ok(home) => home,
+        Err(error) => {
+            eprintln!("unicity: failed to resolve product home: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match home.exec_runtime_with_args(args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("unicity: failed to start bundled runtime: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn main() -> ExitCode {
+    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
+    if let Some(exit_code) = handle_product_command(&args) {
+        return exit_code;
     }
 
     let home = match AosHome::resolve() {
@@ -37,8 +58,28 @@ fn main() -> ExitCode {
     }
 }
 
+fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
+    match args.first().and_then(|arg| arg.to_str()) {
+        None | Some("-h" | "--help") => {
+            print_help();
+            Some(ExitCode::SUCCESS)
+        }
+        Some("-V" | "--version") => {
+            println!("Unicity AOS {}", env!("CARGO_PKG_VERSION"));
+            Some(ExitCode::SUCCESS)
+        }
+        Some("self-update" | "self_update") => {
+            eprintln!(
+                "unicity: runtime self-update is disabled; update Unicity AOS through its product updater"
+            );
+            Some(ExitCode::FAILURE)
+        }
+        Some(_) => None,
+    }
+}
+
 fn print_help() {
     println!(
-        "Unicity AOS\n\nUsage:\n  unicity <runtime command> [arguments...]\n\nUnicity delegates local runtime and operator commands to its bundled Astrid Runtime.\nThe runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME)."
+        "Unicity AOS\n\nUsage:\n  unicity <runtime command> [arguments...]\n\nUnicity delegates local runtime and operator commands to its bundled Astrid Runtime.\nThe runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME).\n\n`unicity self-update` is intentionally disabled; AOS updates use the product updater."
     );
 }


### PR DESCRIPTION
## Summary

Make `unicity` the trusted product command layer over the bundled Astrid Runtime.

## Changes

- add the `unicity` binary
- scope every delegated command to the AOS-owned runtime home
- forward arguments directly without a shell or copied runtime secrets
- preserve runtime exit status for scripts and service managers

## Verification

- `cargo test -p unicity-aos-bootstrap --quiet`
- `cargo clippy -p unicity-aos-bootstrap --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`