### PR TITLE
feat: add explicit legacy runtime migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,10 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 [[package]]
 name = "unicity-aos-bootstrap"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/crates/unicity-aos-bootstrap/Cargo.toml
+++ b/crates/unicity-aos-bootstrap/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 license = "Apache-2.0"
 description = "Product-owned runtime layout and launcher for Unicity AOS."
 
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
 [[bin]]
 name = "unicity"
 path = "src/main.rs"

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -6,9 +6,13 @@
 //! environment or rewrites a standalone runtime installation.
 
 use std::ffi::{OsStr, OsString};
+use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus};
+
+mod migration;
+pub use migration::MigrationOutcome;
 
 /// Product state owned by one Unicity AOS installation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,10 +87,36 @@ impl AosHome {
         self.root.join("runtime")
     }
 
+    /// The receipt written only after a successful standalone-runtime import.
+    #[must_use]
+    pub fn migration_receipt(&self) -> PathBuf {
+        self.root.join("migrations/astrid-home-v1.json")
+    }
+
+    /// The conventional standalone Astrid Runtime home that first-run AOS can offer
+    /// to import. This does not inspect `ASTRID_HOME`: an override may name another
+    /// product or service installation and must be supplied explicitly by the user.
+    pub fn default_legacy_runtime_home() -> io::Result<PathBuf> {
+        let home = default_home(&|name| std::env::var_os(name))?;
+        Ok(PathBuf::from(home).join(".astrid"))
+    }
+
     /// The installed bundled-runtime executable.
     #[must_use]
     pub fn runtime_binary(&self) -> PathBuf {
         self.runtime_home().join("bin").join(runtime_binary_name())
+    }
+
+    /// Import a standalone Astrid Runtime home into this product installation.
+    ///
+    /// This is an explicit copy operation. It leaves the standalone source in
+    /// place so the operator retains a rollback path and historical provenance.
+    ///
+    /// # Errors
+    /// Returns an error for unsafe paths, a running source runtime, an
+    /// incompatible target, or a failed staging/validation operation.
+    pub fn migrate_runtime_from(&self, source: impl AsRef<Path>) -> io::Result<MigrationOutcome> {
+        migration::migrate_runtime(self, source.as_ref())
     }
 
     /// Create the product and bundled-runtime state directories.
@@ -97,7 +127,7 @@ impl AosHome {
     /// # Errors
     /// Returns an error when the directories cannot be created.
     pub fn ensure_layout(&self) -> io::Result<()> {
-        std::fs::create_dir_all(self.runtime_home())
+        fs::create_dir_all(self.runtime_home())
     }
 
     /// Build a command for the bundled runtime with a process-local home.

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -5,6 +5,7 @@
 //! bundled runtime, scoped to this installation's private `ASTRID_HOME`.
 
 use std::ffi::OsString;
+use std::io::{self, IsTerminal, Write};
 use std::process::ExitCode;
 
 use unicity_aos_bootstrap::AosHome;
@@ -60,7 +61,11 @@ fn main() -> ExitCode {
 
 fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
     match args.first().and_then(|arg| arg.to_str()) {
-        None | Some("-h" | "--help") => {
+        None => offer_first_run_migration().or_else(|| {
+            print_help();
+            Some(ExitCode::SUCCESS)
+        }),
+        Some("-h" | "--help") => {
             print_help();
             Some(ExitCode::SUCCESS)
         }
@@ -74,12 +79,96 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
             );
             Some(ExitCode::FAILURE)
         }
+        Some("migrate") => Some(handle_migrate_command(&args[1..])),
         Some(_) => None,
+    }
+}
+
+fn offer_first_run_migration() -> Option<ExitCode> {
+    if !io::stdin().is_terminal() {
+        return None;
+    }
+    let home = AosHome::resolve().ok()?;
+    if home.migration_receipt().is_file() {
+        return None;
+    }
+    let source = AosHome::default_legacy_runtime_home().ok()?;
+    if !source.is_dir() {
+        return None;
+    }
+
+    println!(
+        "Found a standalone Astrid Runtime home at {}.",
+        source.display()
+    );
+    println!(
+        "Unicity can copy compatible runtime state into {}. The existing home will stay unchanged.",
+        home.runtime_home().display()
+    );
+    print!("Import it now? [y/N] ");
+    io::stdout().flush().ok()?;
+    let mut answer = String::new();
+    io::stdin().read_line(&mut answer).ok()?;
+    if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+        println!(
+            "Skipped. You can import later with `unicity migrate runtime --from {}`.",
+            source.display()
+        );
+        return Some(ExitCode::SUCCESS);
+    }
+
+    match home.migrate_runtime_from(&source) {
+        Ok(unicity_aos_bootstrap::MigrationOutcome::Migrated) => {
+            println!(
+                "Unicity AOS: imported the standalone runtime; the source was left unchanged."
+            );
+            Some(ExitCode::SUCCESS)
+        }
+        Ok(unicity_aos_bootstrap::MigrationOutcome::AlreadyMigrated) => Some(ExitCode::SUCCESS),
+        Err(error) => {
+            eprintln!("unicity: runtime migration failed: {error}");
+            Some(ExitCode::FAILURE)
+        }
+    }
+}
+
+fn handle_migrate_command(args: &[OsString]) -> ExitCode {
+    let [subcommand, flag, source] = args else {
+        eprintln!("Usage: unicity migrate runtime --from <absolute-legacy-home>");
+        return ExitCode::FAILURE;
+    };
+    if subcommand != "runtime" || flag != "--from" {
+        eprintln!("Usage: unicity migrate runtime --from <absolute-legacy-home>");
+        return ExitCode::FAILURE;
+    }
+
+    let home = match AosHome::resolve() {
+        Ok(home) => home,
+        Err(error) => {
+            eprintln!("unicity: failed to resolve product home: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    match home.migrate_runtime_from(source) {
+        Ok(unicity_aos_bootstrap::MigrationOutcome::Migrated) => {
+            println!(
+                "Unicity AOS: imported the standalone runtime; the source was left unchanged."
+            );
+            ExitCode::SUCCESS
+        }
+        Ok(unicity_aos_bootstrap::MigrationOutcome::AlreadyMigrated) => {
+            println!("Unicity AOS: this runtime migration is already complete.");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("unicity: runtime migration failed: {error}");
+            ExitCode::FAILURE
+        }
     }
 }
 
 fn print_help() {
     println!(
-        "Unicity AOS\n\nUsage:\n  unicity <runtime command> [arguments...]\n\nUnicity delegates local runtime and operator commands to its bundled Astrid Runtime.\nThe runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME).\n\n`unicity self-update` is intentionally disabled; AOS updates use the product updater."
+        "Unicity AOS\n\nUsage:\n  unicity migrate runtime --from <absolute-legacy-home>\n  unicity <runtime command> [arguments...]\n\nUnicity delegates local runtime and operator commands to its bundled Astrid Runtime.\nThe runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME).\n\n`unicity self-update` is intentionally disabled; AOS updates use the product updater."
     );
 }

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -4,7 +4,7 @@
 //! binary therefore delegates runtime and operator commands directly to its
 //! bundled runtime, scoped to this installation's private `ASTRID_HOME`.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io::{self, IsTerminal, Write};
 use std::process::ExitCode;
 
@@ -137,7 +137,7 @@ fn handle_migrate_command(args: &[OsString]) -> ExitCode {
         eprintln!("Usage: unicity migrate runtime --from <absolute-legacy-home>");
         return ExitCode::FAILURE;
     };
-    if subcommand != "runtime" || flag != "--from" {
+    if subcommand.as_os_str() != OsStr::new("runtime") || flag.as_os_str() != OsStr::new("--from") {
         eprintln!("Usage: unicity migrate runtime --from <absolute-legacy-home>");
         return ExitCode::FAILURE;
     }
@@ -149,7 +149,7 @@ fn handle_migrate_command(args: &[OsString]) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    match home.migrate_runtime_from(source) {
+    match home.migrate_runtime_from(std::path::Path::new(source)) {
         Ok(unicity_aos_bootstrap::MigrationOutcome::Migrated) => {
             println!(
                 "Unicity AOS: imported the standalone runtime; the source was left unchanged."

--- a/crates/unicity-aos-bootstrap/src/migration.rs
+++ b/crates/unicity-aos-bootstrap/src/migration.rs
@@ -88,8 +88,14 @@ pub(crate) fn migrate_runtime(home: &AosHome, source: &Path) -> io::Result<Migra
         if !receipt_matches(&staging, &receipt)? {
             return invalid("staged runtime did not validate against its import manifest");
         }
-        replace_target(&target, &staging)?;
-        write_receipt(&receipt_path, &receipt)?;
+        let staged_receipt = write_staged_receipt(&receipt_path, &receipt)?;
+        let backup = replace_target(&target, &staging)?;
+        if let Err(error) = finalize_receipt(&staged_receipt, &receipt_path) {
+            let _ = fs::remove_file(&staged_receipt);
+            rollback_target(&target, &backup)?;
+            return Err(error);
+        }
+        remove_backup(&backup)?;
         Ok(())
     })();
     if result.is_err() && staging.exists() {
@@ -116,7 +122,13 @@ fn validate_target(target: &Path) -> io::Result<()> {
         return invalid("bundled product runtime is not installed");
     }
     let allowed = target.join("bin").join(runtime_binary_name());
-    if !allowed.is_file() {
+    let metadata = fs::symlink_metadata(&allowed).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "bundled product runtime executable is not installed",
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
         return invalid("bundled product runtime executable is not installed");
     }
     for entry in fs::read_dir(target)? {
@@ -248,7 +260,7 @@ fn copy_executable(source: &Path, destination: &Path) -> io::Result<()> {
     fs::set_permissions(destination, metadata.permissions())
 }
 
-fn replace_target(target: &Path, staging: &Path) -> io::Result<()> {
+fn replace_target(target: &Path, staging: &Path) -> io::Result<PathBuf> {
     let backup = target.with_extension("pre-migration");
     if backup.exists() {
         return invalid("previous product runtime backup exists; inspect it before migration");
@@ -257,11 +269,26 @@ fn replace_target(target: &Path, staging: &Path) -> io::Result<()> {
         fs::rename(target, &backup)?;
     }
     if let Err(error) = fs::rename(staging, target) {
-        if backup.exists() {
-            let _ = fs::rename(&backup, target);
-        }
+        let _ = fs::rename(&backup, target);
         return Err(error);
     }
+    Ok(backup)
+}
+
+fn rollback_target(target: &Path, backup: &Path) -> io::Result<()> {
+    let failed_target = target.with_extension("failed-migration");
+    if failed_target.exists() {
+        return invalid("failed migration target already exists; manual recovery is required");
+    }
+    fs::rename(target, &failed_target)?;
+    if let Err(error) = fs::rename(backup, target) {
+        let _ = fs::rename(&failed_target, target);
+        return Err(error);
+    }
+    fs::remove_dir_all(failed_target)
+}
+
+fn remove_backup(backup: &Path) -> io::Result<()> {
     if backup.exists() {
         fs::remove_dir_all(backup)?;
     }
@@ -285,10 +312,14 @@ fn receipt_matches(root: &Path, receipt: &Receipt) -> io::Result<bool> {
     })
 }
 
-fn write_receipt(path: &Path, receipt: &Receipt) -> io::Result<()> {
+fn write_staged_receipt(path: &Path, receipt: &Receipt) -> io::Result<PathBuf> {
     let temporary = path.with_extension("tmp");
     let bytes = serde_json::to_vec_pretty(receipt).map_err(io::Error::other)?;
     fs::write(&temporary, bytes)?;
+    Ok(temporary)
+}
+
+fn finalize_receipt(temporary: &Path, path: &Path) -> io::Result<()> {
     fs::rename(temporary, path)
 }
 
@@ -442,6 +473,33 @@ mod tests {
             fs::read(product.runtime_home().join("bin/astrid")).unwrap(),
             b"bundled-binary"
         );
+        fs::remove_dir_all(root).expect("remove fixture root");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_a_symlinked_bundled_runtime_executable() {
+        use std::os::unix::fs::symlink;
+
+        let root = fixture_root("runtime-binary-symlink");
+        let source = root.join("legacy");
+        let product = AosHome::from_root(root.join("product"));
+        write(&source, "keys/runtime.key", b"runtime-key");
+        write(
+            &product.runtime_home(),
+            "bin/runtime-target",
+            b"bundled-binary",
+        );
+        symlink(
+            product.runtime_home().join("bin/runtime-target"),
+            product.runtime_home().join("bin/astrid"),
+        )
+        .expect("create bundled binary symlink");
+
+        let error =
+            migrate_runtime(&product, &source).expect_err("binary symlink must be rejected");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(!product.runtime_home().join("keys/runtime.key").exists());
         fs::remove_dir_all(root).expect("remove fixture root");
     }
 }

--- a/crates/unicity-aos-bootstrap/src/migration.rs
+++ b/crates/unicity-aos-bootstrap/src/migration.rs
@@ -1,0 +1,447 @@
+//! Explicit, staged import of a standalone Astrid Runtime home.
+
+use std::fs::{self, File};
+use std::io::{self};
+use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{AosHome, runtime_binary_name};
+
+const PERSISTENT_TOP_LEVEL: &[&str] = &["keys", "secrets", "var", "wit", "home"];
+const EPHEMERAL_TOP_LEVEL: &[&str] = &["run", "log", "cow"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MigrationOutcome {
+    Migrated,
+    AlreadyMigrated,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Receipt {
+    source: PathBuf,
+    entries: Vec<Entry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Entry {
+    path: PathBuf,
+    bytes: u64,
+}
+
+pub(crate) fn migrate_runtime(home: &AosHome, source: &Path) -> io::Result<MigrationOutcome> {
+    let source = checked_root(source, "legacy runtime home")?;
+    let target = home.runtime_home();
+    if source == target {
+        return invalid("legacy runtime home and product runtime home must differ");
+    }
+    if source.join("run/system.sock").exists() {
+        return invalid("stop the standalone runtime before migration");
+    }
+
+    let receipt_path = home.migration_receipt();
+    if receipt_path.is_file() {
+        let receipt: Receipt = read_receipt(&receipt_path)?;
+        if receipt.source == source && receipt_matches(&target, &receipt)? {
+            return Ok(MigrationOutcome::AlreadyMigrated);
+        }
+        return invalid(
+            "an existing migration receipt does not match the requested source or target",
+        );
+    }
+
+    validate_target(&target)?;
+    create_private_dir(&home.root().join("migrations"))?;
+    let staging = home.root().join(format!(
+        ".runtime-import-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    if staging.exists() {
+        return invalid(
+            "a previous migration staging directory exists; inspect and remove it before retrying",
+        );
+    }
+
+    let result = (|| {
+        create_private_dir(&staging)?;
+        copy_product_binary(&target, &staging)?;
+        let mut entries = Vec::new();
+        for name in PERSISTENT_TOP_LEVEL {
+            copy_if_present(
+                &source.join(name),
+                &staging.join(name),
+                Path::new(name),
+                &mut entries,
+            )?;
+        }
+        copy_wasm_blobs(&source.join("bin"), &staging.join("bin"), &mut entries)?;
+        ensure_no_ephemeral_data(&staging)?;
+        let receipt = Receipt {
+            source: source.clone(),
+            entries,
+        };
+        if !receipt_matches(&staging, &receipt)? {
+            return invalid("staged runtime did not validate against its import manifest");
+        }
+        replace_target(&target, &staging)?;
+        write_receipt(&receipt_path, &receipt)?;
+        Ok(())
+    })();
+    if result.is_err() && staging.exists() {
+        let _ = fs::remove_dir_all(&staging);
+    }
+    result.map(|()| MigrationOutcome::Migrated)
+}
+
+fn checked_root(path: &Path, description: &str) -> io::Result<PathBuf> {
+    if !path.is_absolute() {
+        return invalid(&format!("{description} must be an absolute path"));
+    }
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return invalid(&format!(
+            "{description} must be a real directory, not a symlink"
+        ));
+    }
+    path.canonicalize()
+}
+
+fn validate_target(target: &Path) -> io::Result<()> {
+    if !target.is_dir() {
+        return invalid("bundled product runtime is not installed");
+    }
+    let allowed = target.join("bin").join(runtime_binary_name());
+    if !allowed.is_file() {
+        return invalid("bundled product runtime executable is not installed");
+    }
+    for entry in fs::read_dir(target)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path == target.join("bin") {
+            for nested in fs::read_dir(&path)? {
+                let nested = nested?;
+                if nested.path() != allowed {
+                    return invalid(
+                        "product runtime home contains data; migration refuses to merge state",
+                    );
+                }
+            }
+        } else {
+            return invalid("product runtime home contains data; migration refuses to merge state");
+        }
+    }
+    Ok(())
+}
+
+fn copy_product_binary(target: &Path, staging: &Path) -> io::Result<()> {
+    let source = target.join("bin").join(runtime_binary_name());
+    let destination = staging.join("bin").join(runtime_binary_name());
+    copy_executable(&source, &destination)
+}
+
+fn copy_if_present(
+    source: &Path,
+    destination: &Path,
+    relative: &Path,
+    entries: &mut Vec<Entry>,
+) -> io::Result<()> {
+    if source.exists() {
+        copy_tree(source, destination, relative, entries)?;
+    }
+    Ok(())
+}
+
+fn copy_wasm_blobs(source: &Path, destination: &Path, entries: &mut Vec<Entry>) -> io::Result<()> {
+    if !source.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let path = entry.path();
+        if path.is_file()
+            && Path::new(&name)
+                .extension()
+                .is_some_and(|ext| ext == "wasm")
+        {
+            let relative = PathBuf::from("bin").join(&name);
+            copy_file(&path, &destination.join(&name))?;
+            entries.push(Entry {
+                path: relative,
+                bytes: fs::metadata(path)?.len(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn copy_tree(
+    source: &Path,
+    destination: &Path,
+    relative: &Path,
+    entries: &mut Vec<Entry>,
+) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(source)?;
+    if metadata.file_type().is_symlink() {
+        return invalid("legacy runtime contains a symlink; migration refuses to follow links");
+    }
+    if metadata.is_file() {
+        copy_file(source, destination)?;
+        entries.push(Entry {
+            path: relative.to_path_buf(),
+            bytes: metadata.len(),
+        });
+        return Ok(());
+    }
+    if !metadata.is_dir() {
+        return invalid("legacy runtime contains a non-regular file");
+    }
+    create_private_dir(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        if Path::new(&name)
+            .components()
+            .any(|part| matches!(part, Component::ParentDir))
+        {
+            return invalid("unsafe legacy runtime path");
+        }
+        copy_tree(
+            &entry.path(),
+            &destination.join(&name),
+            &relative.join(name),
+            entries,
+        )?;
+    }
+    Ok(())
+}
+
+fn copy_file(source: &Path, destination: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(source)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return invalid("migration only copies regular files");
+    }
+    if let Some(parent) = destination.parent() {
+        create_private_dir(parent)?;
+    }
+    let mut input = File::open(source)?;
+    let mut output = File::create(destination)?;
+    io::copy(&mut input, &mut output)?;
+    output.sync_all()?;
+    set_private_permissions(destination, false)
+}
+
+fn copy_executable(source: &Path, destination: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(source)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return invalid("bundled runtime executable must be a regular file");
+    }
+    if let Some(parent) = destination.parent() {
+        create_private_dir(parent)?;
+    }
+    fs::copy(source, destination)?;
+    fs::set_permissions(destination, metadata.permissions())
+}
+
+fn replace_target(target: &Path, staging: &Path) -> io::Result<()> {
+    let backup = target.with_extension("pre-migration");
+    if backup.exists() {
+        return invalid("previous product runtime backup exists; inspect it before migration");
+    }
+    if target.exists() {
+        fs::rename(target, &backup)?;
+    }
+    if let Err(error) = fs::rename(staging, target) {
+        if backup.exists() {
+            let _ = fs::rename(&backup, target);
+        }
+        return Err(error);
+    }
+    if backup.exists() {
+        fs::remove_dir_all(backup)?;
+    }
+    Ok(())
+}
+
+fn ensure_no_ephemeral_data(staging: &Path) -> io::Result<()> {
+    if EPHEMERAL_TOP_LEVEL
+        .iter()
+        .any(|name| staging.join(name).exists())
+    {
+        return invalid("ephemeral runtime data entered migration staging");
+    }
+    Ok(())
+}
+
+fn receipt_matches(root: &Path, receipt: &Receipt) -> io::Result<bool> {
+    receipt.entries.iter().try_fold(true, |valid, entry| {
+        let path = root.join(&entry.path);
+        Ok(valid && path.is_file() && fs::metadata(path)?.len() == entry.bytes)
+    })
+}
+
+fn write_receipt(path: &Path, receipt: &Receipt) -> io::Result<()> {
+    let temporary = path.with_extension("tmp");
+    let bytes = serde_json::to_vec_pretty(receipt).map_err(io::Error::other)?;
+    fs::write(&temporary, bytes)?;
+    fs::rename(temporary, path)
+}
+
+fn create_private_dir(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+    set_private_permissions(path, true)
+}
+
+fn read_receipt(path: &Path) -> io::Result<Receipt> {
+    serde_json::from_slice(&fs::read(path)?).map_err(io::Error::other)
+}
+
+#[cfg(unix)]
+fn set_private_permissions(path: &Path, directory: bool) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(
+        path,
+        fs::Permissions::from_mode(if directory { 0o700 } else { 0o600 }),
+    )
+}
+
+#[cfg(not(unix))]
+fn set_private_permissions(_path: &Path, _directory: bool) -> io::Result<()> {
+    Ok(())
+}
+
+fn invalid<T>(message: &str) -> io::Result<T> {
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        message.to_owned(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{MigrationOutcome, migrate_runtime};
+    use crate::AosHome;
+
+    fn fixture_root(name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "unicity-aos-{name}-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).expect("create fixture root");
+        root
+    }
+
+    fn write(root: &Path, relative: &str, content: &[u8]) {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().expect("fixture parent")).expect("create fixture parent");
+        fs::write(path, content).expect("write fixture file");
+    }
+
+    #[test]
+    fn imports_persistent_state_without_live_or_legacy_binaries() {
+        let root = fixture_root("runtime-migration");
+        let source = root.join("legacy");
+        let product = AosHome::from_root(root.join("product"));
+        write(&source, "keys/runtime.key", b"runtime-key");
+        write(&source, "secrets/provider", b"provider-secret");
+        write(&source, "var/state.db", b"state");
+        write(&source, "wit/store/contracts.wit", b"wit");
+        write(&source, "home/alice/.local/audit/chain", b"audit");
+        write(&source, "bin/capsule.wasm", b"wasm");
+        write(&source, "bin/astrid", b"legacy-binary");
+        write(&source, "run/ready", b"live-state");
+        write(&source, "log/daemon.log", b"log");
+        write(&product.runtime_home(), "bin/astrid", b"bundled-binary");
+
+        assert_eq!(
+            migrate_runtime(&product, &source).expect("migration succeeds"),
+            MigrationOutcome::Migrated
+        );
+        let runtime = product.runtime_home();
+        assert_eq!(
+            fs::read(runtime.join("keys/runtime.key")).unwrap(),
+            b"runtime-key"
+        );
+        assert_eq!(
+            fs::read(runtime.join("secrets/provider")).unwrap(),
+            b"provider-secret"
+        );
+        assert_eq!(fs::read(runtime.join("bin/capsule.wasm")).unwrap(), b"wasm");
+        assert_eq!(
+            fs::read(runtime.join("bin/astrid")).unwrap(),
+            b"bundled-binary"
+        );
+        assert!(!runtime.join("run").exists());
+        assert!(!runtime.join("log").exists());
+        assert_eq!(
+            fs::read(source.join("keys/runtime.key")).unwrap(),
+            b"runtime-key"
+        );
+        assert!(
+            product
+                .root()
+                .join("migrations/astrid-home-v1.json")
+                .is_file()
+        );
+        assert_eq!(
+            migrate_runtime(&product, &source).expect("matching migration is idempotent"),
+            MigrationOutcome::AlreadyMigrated
+        );
+        fs::remove_dir_all(root).expect("remove fixture root");
+    }
+
+    #[test]
+    fn refuses_to_merge_into_existing_runtime_state() {
+        let root = fixture_root("runtime-existing-target");
+        let source = root.join("legacy");
+        let product = AosHome::from_root(root.join("product"));
+        write(&source, "keys/runtime.key", b"runtime-key");
+        write(&product.runtime_home(), "bin/astrid", b"bundled-binary");
+        write(&product.runtime_home(), "var/state.db", b"existing-state");
+
+        let error =
+            migrate_runtime(&product, &source).expect_err("existing runtime state must not merge");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(
+            fs::read(product.runtime_home().join("var/state.db")).unwrap(),
+            b"existing-state"
+        );
+        fs::remove_dir_all(root).expect("remove fixture root");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_symlinked_legacy_content() {
+        use std::os::unix::fs::symlink;
+
+        let root = fixture_root("runtime-symlink");
+        let source = root.join("legacy");
+        let product = AosHome::from_root(root.join("product"));
+        write(&source, "outside-key", b"runtime-key");
+        fs::create_dir_all(source.join("keys")).expect("create keys directory");
+        symlink(source.join("outside-key"), source.join("keys/runtime.key"))
+            .expect("create legacy symlink");
+        write(&product.runtime_home(), "bin/astrid", b"bundled-binary");
+
+        let error = migrate_runtime(&product, &source).expect_err("symlink must be rejected");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(!product.runtime_home().join("keys/runtime.key").exists());
+        assert_eq!(
+            fs::read(product.runtime_home().join("bin/astrid")).unwrap(),
+            b"bundled-binary"
+        );
+        fs::remove_dir_all(root).expect("remove fixture root");
+    }
+}


### PR DESCRIPTION
## Summary
- add an opt-in unicity migrate runtime --from absolute-legacy-home flow
- offer a terminal-only first-run import for the conventional standalone home, defaulting to no
- stage, validate, and atomically replace the bundled runtime state while preserving the source
- reject live sockets, symlinks, unsafe target merges, and legacy binary replacement

## Validation
- cargo fmt
- cargo test -p unicity-aos-bootstrap --quiet
- cargo clippy -p unicity-aos-bootstrap --all-targets -- -D warnings