### PR TITLE
feat: select Unicity CE for product init

### DIFF
--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -10,12 +10,15 @@ use std::process::ExitCode;
 
 use unicity_aos_bootstrap::AosHome;
 
+const UNICITY_CE_DISTRO: &str = "https://raw.githubusercontent.com/unicity-aos/aos-ce/main/distros/community/unicity-ce/Distro.toml";
+
 #[cfg(unix)]
 fn main() -> ExitCode {
     let args: Vec<OsString> = std::env::args_os().skip(1).collect();
     if let Some(exit_code) = handle_product_command(&args) {
         return exit_code;
     }
+    let args = product_runtime_args(args);
 
     let home = match AosHome::resolve() {
         Ok(home) => home,
@@ -40,6 +43,7 @@ fn main() -> ExitCode {
     if let Some(exit_code) = handle_product_command(&args) {
         return exit_code;
     }
+    let args = product_runtime_args(args);
 
     let home = match AosHome::resolve() {
         Ok(home) => home,
@@ -80,8 +84,44 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
             Some(ExitCode::FAILURE)
         }
         Some("migrate") => Some(handle_migrate_command(&args[1..])),
+        Some("init") if has_distro_override(&args[1..]) => {
+            eprintln!(
+                "unicity init always installs Unicity CE; use `astrid init` for another distro"
+            );
+            Some(ExitCode::FAILURE)
+        }
+        Some("init") if has_help_flag(&args[1..]) => {
+            print_init_help();
+            Some(ExitCode::SUCCESS)
+        }
         Some(_) => None,
     }
+}
+
+fn product_runtime_args(args: Vec<OsString>) -> Vec<OsString> {
+    if args.first().is_some_and(|arg| arg == "init") {
+        let mut runtime_args = vec![
+            OsString::from("init"),
+            OsString::from("--distro"),
+            OsString::from(UNICITY_CE_DISTRO),
+        ];
+        runtime_args.extend(args.into_iter().skip(1));
+        runtime_args
+    } else {
+        args
+    }
+}
+
+fn has_distro_override(args: &[OsString]) -> bool {
+    args.iter().any(|arg| {
+        arg.as_os_str() == OsStr::new("--distro")
+            || arg.to_str().is_some_and(|arg| arg.starts_with("--distro="))
+    })
+}
+
+fn has_help_flag(args: &[OsString]) -> bool {
+    args.iter()
+        .any(|arg| matches!(arg.to_str(), Some("-h" | "--help")))
 }
 
 fn offer_first_run_migration() -> Option<ExitCode> {
@@ -169,6 +209,50 @@ fn handle_migrate_command(args: &[OsString]) -> ExitCode {
 
 fn print_help() {
     println!(
-        "Unicity AOS\n\nUsage:\n  unicity migrate runtime --from <absolute-legacy-home>\n  unicity <runtime command> [arguments...]\n\nUnicity delegates local runtime and operator commands to its bundled Astrid Runtime.\nThe runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME).\n\n`unicity self-update` is intentionally disabled; AOS updates use the product updater."
+        "Unicity AOS\n\nUsage:\n  unicity init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n  unicity migrate runtime --from <absolute-legacy-home>\n  unicity <runtime command> [arguments...]\n\n`unicity init` installs the pinned Unicity CE distribution. Unicity delegates runtime and operator commands to its bundled Astrid Runtime. The runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME).\n\n`unicity self-update` is intentionally disabled; AOS updates use the product updater."
     );
+}
+
+fn print_init_help() {
+    println!(
+        "Unicity AOS\n\nUsage:\n  unicity init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n\nInstalls Unicity CE from the product-pinned distribution manifest. For a different distro, use the Astrid Runtime CLI directly."
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::{UNICITY_CE_DISTRO, has_distro_override, product_runtime_args};
+
+    #[test]
+    fn product_init_pins_unicity_ce_and_preserves_flags() {
+        let args = product_runtime_args(vec![
+            OsString::from("init"),
+            OsString::from("--yes"),
+            OsString::from("--var"),
+            OsString::from("model=gpt-5"),
+        ]);
+        assert_eq!(
+            args,
+            [
+                "init",
+                "--distro",
+                UNICITY_CE_DISTRO,
+                "--yes",
+                "--var",
+                "model=gpt-5"
+            ]
+        );
+    }
+
+    #[test]
+    fn product_init_rejects_distro_overrides() {
+        assert!(has_distro_override(&[
+            OsString::from("--distro"),
+            OsString::from("other")
+        ]));
+        assert!(has_distro_override(&[OsString::from("--distro=other")]));
+        assert!(!has_distro_override(&[OsString::from("--yes")]));
+    }
 }


### PR DESCRIPTION
## Summary
- make unicity init product-owned and select the Unicity CE manifest
- preserve supported init flags while preventing an accidental alternate-distro override
- provide product-specific init help and regression coverage

## Release note
The current bootstrap follows the AOS CE main manifest. It becomes an immutable product pin only when Unicity publishes a signed, versioned distro artifact.

## Boundary
Alternative distro selection remains an Astrid Runtime CLI operation until Unicity owns a product catalog and resolver.

## Validation
- cargo fmt
- cargo test -p unicity-aos-bootstrap --quiet
- cargo clippy -p unicity-aos-bootstrap --all-targets -- -D warnings
- git diff --check