### PR TITLE
feat: establish the Unicity CE release boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,10 +1072,11 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicity-aos-bootstrap"
-version = "0.1.0"
+version = "2026.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "toml",
 ]
 
 [[package]]

--- a/crates/unicity-aos-bootstrap/Cargo.toml
+++ b/crates/unicity-aos-bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicity-aos-bootstrap"
-version = "0.1.0"
+version = "2026.1.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Product-owned runtime layout and launcher for Unicity AOS."
@@ -8,6 +8,9 @@ description = "Product-owned runtime layout and launcher for Unicity AOS."
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+
+[dev-dependencies]
+toml.workspace = true
 
 [[bin]]
 name = "unicity"

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -318,7 +318,7 @@ const fn runtime_binary_name() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{AosHome, runtime_binary_name};
+    use super::{AosHome, UNICITY_CE_MANIFEST, runtime_binary_name};
     use std::ffi::OsString;
     use std::fs;
     use std::io::ErrorKind;
@@ -430,5 +430,15 @@ mod tests {
                 .contains("id = \"unicity-ce\"")
         );
         fs::remove_dir_all(root).expect("remove temporary product home");
+    }
+
+    #[test]
+    fn bundled_distro_version_matches_the_product_release() {
+        let manifest: toml::Value = UNICITY_CE_MANIFEST.parse().expect("parse bundled manifest");
+        assert_eq!(
+            manifest["distro"]["version"].as_str(),
+            Some(env!("CARGO_PKG_VERSION")),
+            "the product binary and bundled Unicity CE manifest must release together"
+        );
     }
 }

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -14,6 +14,8 @@ use std::process::{Child, Command, ExitStatus};
 mod migration;
 pub use migration::MigrationOutcome;
 
+const UNICITY_CE_MANIFEST: &str = include_str!("../../../distros/community/unicity-ce/Distro.toml");
+
 /// Product state owned by one Unicity AOS installation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AosHome {
@@ -91,6 +93,37 @@ impl AosHome {
     #[must_use]
     pub fn migration_receipt(&self) -> PathBuf {
         self.root.join("migrations/astrid-home-v1.json")
+    }
+
+    /// Product-managed location for the Unicity CE manifest bundled with this AOS
+    /// release.
+    #[must_use]
+    pub fn unicity_ce_manifest_path(&self) -> PathBuf {
+        self.root
+            .join("distributions")
+            .join("unicity-ce")
+            .join("Distro.toml")
+    }
+
+    /// Materialize the Unicity CE manifest embedded in this product binary.
+    ///
+    /// The product CLI hands this local path to the neutral runtime, so first-run
+    /// provisioning uses the manifest shipped with the installed AOS release rather
+    /// than following a mutable repository branch.
+    ///
+    /// # Errors
+    /// Returns an error when the product manifest cannot be written atomically.
+    pub fn ensure_unicity_ce_manifest(&self) -> io::Result<PathBuf> {
+        let path = self.unicity_ce_manifest_path();
+        if fs::read(&path).ok().as_deref() == Some(UNICITY_CE_MANIFEST.as_bytes()) {
+            return Ok(path);
+        }
+        let parent = path.parent().expect("manifest path has a parent");
+        fs::create_dir_all(parent)?;
+        let temporary = path.with_extension("toml.tmp");
+        fs::write(&temporary, UNICITY_CE_MANIFEST)?;
+        fs::rename(&temporary, &path)?;
+        Ok(path)
     }
 
     /// The conventional standalone Astrid Runtime home that first-run AOS can offer
@@ -287,8 +320,21 @@ const fn runtime_binary_name() -> &'static str {
 mod tests {
     use super::{AosHome, runtime_binary_name};
     use std::ffi::OsString;
+    use std::fs;
     use std::io::ErrorKind;
     use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temporary_home() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "unicity-aos-bundled-manifest-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ))
+    }
 
     #[test]
     fn runtime_is_scoped_beneath_the_product_home() {
@@ -359,5 +405,30 @@ mod tests {
         })
         .expect_err("empty host home must fail");
         assert_eq!(error.kind(), ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn bundled_unicity_ce_manifest_is_restored_at_its_product_path() {
+        let root = temporary_home();
+        let home = AosHome::from_root(&root);
+        let path = home
+            .ensure_unicity_ce_manifest()
+            .expect("write bundled manifest");
+        assert_eq!(path, root.join("distributions/unicity-ce/Distro.toml"));
+        assert!(
+            fs::read_to_string(&path)
+                .expect("read manifest")
+                .contains("id = \"unicity-ce\"")
+        );
+
+        fs::write(&path, "tampered").expect("tamper product manifest");
+        home.ensure_unicity_ce_manifest()
+            .expect("restore bundled manifest");
+        assert!(
+            fs::read_to_string(path)
+                .expect("read restored manifest")
+                .contains("id = \"unicity-ce\"")
+        );
+        fs::remove_dir_all(root).expect("remove temporary product home");
     }
 }

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -10,20 +10,23 @@ use std::process::ExitCode;
 
 use unicity_aos_bootstrap::AosHome;
 
-const UNICITY_CE_DISTRO: &str = "https://raw.githubusercontent.com/unicity-aos/aos-ce/main/distros/community/unicity-ce/Distro.toml";
-
 #[cfg(unix)]
 fn main() -> ExitCode {
     let args: Vec<OsString> = std::env::args_os().skip(1).collect();
     if let Some(exit_code) = handle_product_command(&args) {
         return exit_code;
     }
-    let args = product_runtime_args(args);
-
     let home = match AosHome::resolve() {
         Ok(home) => home,
         Err(error) => {
             eprintln!("unicity: failed to resolve product home: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let args = match product_runtime_args(&home, args) {
+        Ok(args) => args,
+        Err(error) => {
+            eprintln!("unicity: failed to prepare Unicity CE: {error}");
             return ExitCode::FAILURE;
         }
     };
@@ -43,12 +46,17 @@ fn main() -> ExitCode {
     if let Some(exit_code) = handle_product_command(&args) {
         return exit_code;
     }
-    let args = product_runtime_args(args);
-
     let home = match AosHome::resolve() {
         Ok(home) => home,
         Err(error) => {
             eprintln!("unicity: failed to resolve product home: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let args = match product_runtime_args(&home, args) {
+        Ok(args) => args,
+        Err(error) => {
+            eprintln!("unicity: failed to prepare Unicity CE: {error}");
             return ExitCode::FAILURE;
         }
     };
@@ -98,17 +106,17 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
     }
 }
 
-fn product_runtime_args(args: Vec<OsString>) -> Vec<OsString> {
+fn product_runtime_args(home: &AosHome, args: Vec<OsString>) -> io::Result<Vec<OsString>> {
     if args.first().is_some_and(|arg| arg == "init") {
         let mut runtime_args = vec![
             OsString::from("init"),
             OsString::from("--distro"),
-            OsString::from(UNICITY_CE_DISTRO),
+            home.ensure_unicity_ce_manifest()?.into_os_string(),
         ];
         runtime_args.extend(args.into_iter().skip(1));
-        runtime_args
+        Ok(runtime_args)
     } else {
-        args
+        Ok(args)
     }
 }
 
@@ -209,41 +217,60 @@ fn handle_migrate_command(args: &[OsString]) -> ExitCode {
 
 fn print_help() {
     println!(
-        "Unicity AOS\n\nUsage:\n  unicity init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n  unicity migrate runtime --from <absolute-legacy-home>\n  unicity <runtime command> [arguments...]\n\n`unicity init` installs the pinned Unicity CE distribution. Unicity delegates runtime and operator commands to its bundled Astrid Runtime. The runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME).\n\n`unicity self-update` is intentionally disabled; AOS updates use the product updater."
+        "Unicity AOS\n\nUsage:\n  unicity init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n  unicity migrate runtime --from <absolute-legacy-home>\n  unicity <runtime command> [arguments...]\n\n`unicity init` installs the Unicity CE manifest bundled with this product release. Unicity delegates runtime and operator commands to its bundled Astrid Runtime. The runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME).\n\n`unicity self-update` is intentionally disabled; AOS updates use the product updater."
     );
 }
 
 fn print_init_help() {
     println!(
-        "Unicity AOS\n\nUsage:\n  unicity init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n\nInstalls Unicity CE from the product-pinned distribution manifest. For a different distro, use the Astrid Runtime CLI directly."
+        "Unicity AOS\n\nUsage:\n  unicity init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n\nInstalls Unicity CE from the manifest bundled with this product release. For a different distro, use the Astrid Runtime CLI directly."
     );
 }
 
 #[cfg(test)]
 mod tests {
     use std::ffi::OsString;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{UNICITY_CE_DISTRO, has_distro_override, product_runtime_args};
+    use super::{has_distro_override, product_runtime_args};
+    use unicity_aos_bootstrap::AosHome;
+
+    fn temporary_home() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "unicity-aos-product-init-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ))
+    }
 
     #[test]
     fn product_init_pins_unicity_ce_and_preserves_flags() {
-        let args = product_runtime_args(vec![
-            OsString::from("init"),
-            OsString::from("--yes"),
-            OsString::from("--var"),
-            OsString::from("model=gpt-5"),
-        ]);
+        let root = temporary_home();
+        let home = AosHome::from_root(&root);
+        let args = product_runtime_args(
+            &home,
+            vec![
+                OsString::from("init"),
+                OsString::from("--yes"),
+                OsString::from("--var"),
+                OsString::from("model=gpt-5"),
+            ],
+        )
+        .expect("materialize product manifest");
         assert_eq!(
-            args,
-            [
-                "init",
-                "--distro",
-                UNICITY_CE_DISTRO,
-                "--yes",
-                "--var",
-                "model=gpt-5"
-            ]
+            [&args[0], &args[1], &args[3], &args[4], &args[5]],
+            ["init", "--distro", "--yes", "--var", "model=gpt-5"]
         );
+        assert_eq!(
+            args[2],
+            root.join("distributions/unicity-ce/Distro.toml")
+                .into_os_string()
+        );
+        fs::remove_dir_all(root).expect("remove temporary product home");
     }
 
     #[test]

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -36,13 +36,13 @@ openai_max_tokens = { description = "Max output tokens", default = "128000" }
 
 [[capsule]]
 name = "astrid-capsule-cli"
-source = "@unicity-astrid/capsule-cli"
+source = "@unicity-aos/capsule-cli"
 version = "0.2.0"
 role = "uplink"
 
 [[capsule]]
 name = "astrid-capsule-registry"
-source = "@unicity-astrid/capsule-registry"
+source = "@unicity-aos/capsule-registry"
 version = "0.2.0"
 role = "uplink"
 
@@ -52,7 +52,7 @@ role = "uplink"
 
 [[capsule]]
 name = "astrid-capsule-openai-compat"
-source = "@unicity-astrid/capsule-openai-compat"
+source = "@unicity-aos/capsule-openai-compat"
 version = "0.2.0"
 group = "llm"
 env = { api_key = "{{ openai_api_key }}", base_url = "{{ openai_base_url }}", model = "{{ openai_model }}", temperature = "{{ openai_temperature }}", max_output_tokens = "{{ openai_max_tokens }}" }
@@ -63,42 +63,42 @@ env = { api_key = "{{ openai_api_key }}", base_url = "{{ openai_base_url }}", mo
 
 [[capsule]]
 name = "astrid-capsule-react"
-source = "@unicity-astrid/capsule-react"
+source = "@unicity-aos/capsule-react"
 version = "0.2.2"
 
 [[capsule]]
 name = "astrid-capsule-session"
-source = "@unicity-astrid/capsule-session"
+source = "@unicity-aos/capsule-session"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-identity"
-source = "@unicity-astrid/capsule-identity"
+source = "@unicity-aos/capsule-identity"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-users"
-source = "@unicity-astrid/capsule-users"
+source = "@unicity-aos/capsule-users"
 version = "0.1.0"
 
 [[capsule]]
 name = "astrid-capsule-router"
-source = "@unicity-astrid/capsule-router"
+source = "@unicity-aos/capsule-router"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-prompt-builder"
-source = "@unicity-astrid/capsule-prompt-builder"
+source = "@unicity-aos/capsule-prompt-builder"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-context-engine"
-source = "@unicity-astrid/capsule-context-engine"
+source = "@unicity-aos/capsule-context-engine"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-hook-bridge"
-source = "@unicity-astrid/capsule-hook-bridge"
+source = "@unicity-aos/capsule-hook-bridge"
 version = "0.2.0"
 
 # ---------------------------------------------------------------------------
@@ -107,22 +107,22 @@ version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-shell"
-source = "@unicity-astrid/capsule-shell"
+source = "@unicity-aos/capsule-shell"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-http"
-source = "@unicity-astrid/capsule-http"
+source = "@unicity-aos/capsule-http"
 version = "0.1.1"
 
 [[capsule]]
 name = "astrid-capsule-fs"
-source = "@unicity-astrid/capsule-fs"
+source = "@unicity-aos/capsule-fs"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-system"
-source = "@unicity-astrid/capsule-system"
+source = "@unicity-aos/capsule-system"
 version = "0.2.0"
 
 # ---------------------------------------------------------------------------
@@ -131,17 +131,17 @@ version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-skills"
-source = "@unicity-astrid/capsule-skills"
+source = "@unicity-aos/capsule-skills"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-agents"
-source = "@unicity-astrid/capsule-agents"
+source = "@unicity-aos/capsule-agents"
 version = "0.2.0"
 env = { cwd_dir = ".astrid" }
 
 [[capsule]]
 name = "astrid-capsule-memory"
-source = "@unicity-astrid/capsule-memory"
+source = "@unicity-aos/capsule-memory"
 version = "0.2.0"
 env = { cwd_dir = ".astrid" }


### PR DESCRIPTION
## Summary
- embed and atomically materialize the Unicity CE Distro.toml with the installed product
- make unicity init use that local release manifest rather than a mutable source branch
- move the customer product CLI to calendar SemVer 2026.1.0
- enforce in tests that the bundled distro and product binary release at the same version
- resolve every fresh Unicity CE capsule from its verified unicity-aos repository while preserving published package and ABI identities
- restore the bundled manifest if local product state is altered

## Boundary
The installed product binary is now the immutable Unicity CE manifest boundary, and fresh installs resolve product-owned capsule sources directly. Historical distros retain their legacy source mapping until an explicit alias/redirect migration. Detached signing and provenance attach to the distributed release artifact next; runtime and ABI compatibility remain separate Astrid contracts.

## Validation
- verified all referenced capsule repositories under unicity-aos
- cargo fmt
- cargo test -p unicity-aos-bootstrap --quiet
- cargo clippy -p unicity-aos-bootstrap --all-targets -- -D warnings
- cargo check --workspace
- git diff --check