### PR TITLE
chore: source Unicity CE capsules from AOS

### DIFF
--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -36,13 +36,13 @@ openai_max_tokens = { description = "Max output tokens", default = "128000" }
 
 [[capsule]]
 name = "astrid-capsule-cli"
-source = "@unicity-astrid/capsule-cli"
+source = "@unicity-aos/capsule-cli"
 version = "0.2.0"
 role = "uplink"
 
 [[capsule]]
 name = "astrid-capsule-registry"
-source = "@unicity-astrid/capsule-registry"
+source = "@unicity-aos/capsule-registry"
 version = "0.2.0"
 role = "uplink"
 
@@ -52,7 +52,7 @@ role = "uplink"
 
 [[capsule]]
 name = "astrid-capsule-openai-compat"
-source = "@unicity-astrid/capsule-openai-compat"
+source = "@unicity-aos/capsule-openai-compat"
 version = "0.2.0"
 group = "llm"
 env = { api_key = "{{ openai_api_key }}", base_url = "{{ openai_base_url }}", model = "{{ openai_model }}", temperature = "{{ openai_temperature }}", max_output_tokens = "{{ openai_max_tokens }}" }
@@ -63,42 +63,42 @@ env = { api_key = "{{ openai_api_key }}", base_url = "{{ openai_base_url }}", mo
 
 [[capsule]]
 name = "astrid-capsule-react"
-source = "@unicity-astrid/capsule-react"
+source = "@unicity-aos/capsule-react"
 version = "0.2.2"
 
 [[capsule]]
 name = "astrid-capsule-session"
-source = "@unicity-astrid/capsule-session"
+source = "@unicity-aos/capsule-session"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-identity"
-source = "@unicity-astrid/capsule-identity"
+source = "@unicity-aos/capsule-identity"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-users"
-source = "@unicity-astrid/capsule-users"
+source = "@unicity-aos/capsule-users"
 version = "0.1.0"
 
 [[capsule]]
 name = "astrid-capsule-router"
-source = "@unicity-astrid/capsule-router"
+source = "@unicity-aos/capsule-router"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-prompt-builder"
-source = "@unicity-astrid/capsule-prompt-builder"
+source = "@unicity-aos/capsule-prompt-builder"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-context-engine"
-source = "@unicity-astrid/capsule-context-engine"
+source = "@unicity-aos/capsule-context-engine"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-hook-bridge"
-source = "@unicity-astrid/capsule-hook-bridge"
+source = "@unicity-aos/capsule-hook-bridge"
 version = "0.2.0"
 
 # ---------------------------------------------------------------------------
@@ -107,22 +107,22 @@ version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-shell"
-source = "@unicity-astrid/capsule-shell"
+source = "@unicity-aos/capsule-shell"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-http"
-source = "@unicity-astrid/capsule-http"
+source = "@unicity-aos/capsule-http"
 version = "0.1.1"
 
 [[capsule]]
 name = "astrid-capsule-fs"
-source = "@unicity-astrid/capsule-fs"
+source = "@unicity-aos/capsule-fs"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-system"
-source = "@unicity-astrid/capsule-system"
+source = "@unicity-aos/capsule-system"
 version = "0.2.0"
 
 # ---------------------------------------------------------------------------
@@ -131,17 +131,17 @@ version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-skills"
-source = "@unicity-astrid/capsule-skills"
+source = "@unicity-aos/capsule-skills"
 version = "0.2.0"
 
 [[capsule]]
 name = "astrid-capsule-agents"
-source = "@unicity-astrid/capsule-agents"
+source = "@unicity-aos/capsule-agents"
 version = "0.2.0"
 env = { cwd_dir = ".astrid" }
 
 [[capsule]]
 name = "astrid-capsule-memory"
-source = "@unicity-astrid/capsule-memory"
+source = "@unicity-aos/capsule-memory"
 version = "0.2.0"
 env = { cwd_dir = ".astrid" }


### PR DESCRIPTION
## Summary
- switch every Unicity CE capsule source from the legacy organization to its verified Unicity AOS repository
- preserve published capsule package names, artifact identities, WIT namespaces, and runtime compatibility requirements
- make fresh Unicity CE installs resolve product-owned capsule sources directly

## Compatibility
Historical distros continue to need legacy organization aliases or redirects. This PR changes only the fresh Unicity CE source mapping.

## Validation
- verified all referenced capsule repositories under unicity-aos
- cargo fmt --check
- cargo check --workspace
- cargo test -p unicity-aos-bootstrap --quiet
- git diff --check