### PR TITLE
fix: report migration receipt handoff errors

### DIFF
--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -153,6 +153,10 @@ impl AosHome {
     }
 
     /// Legacy product distro locks preserved by the last runtime import.
+    ///
+    /// # Errors
+    /// Returns an error when no migration receipt exists or the receipt cannot be
+    /// read or decoded.
     pub fn imported_legacy_distros(&self) -> io::Result<Vec<LegacyDistro>> {
         migration::imported_legacy_distros(self)
     }
@@ -445,5 +449,16 @@ mod tests {
             Some(env!("CARGO_PKG_VERSION")),
             "the product binary and bundled Unicity CE manifest must release together"
         );
+    }
+
+    #[test]
+    fn missing_migration_receipt_is_reported_to_callers() {
+        let root = temporary_home();
+        let home = AosHome::from_root(&root);
+
+        let error = home
+            .imported_legacy_distros()
+            .expect_err("missing receipt must not look like an empty import");
+        assert_eq!(error.kind(), ErrorKind::NotFound);
     }
 }

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -216,8 +216,12 @@ fn handle_migrate_command(args: &[OsString]) -> ExitCode {
 }
 
 fn print_legacy_distro_handoff(home: &AosHome) {
-    let Ok(distros) = home.imported_legacy_distros() else {
-        return;
+    let distros = match home.imported_legacy_distros() {
+        Ok(distros) => distros,
+        Err(error) => {
+            eprintln!("aos: migrated runtime, but could not read the migration receipt: {error}");
+            return;
+        }
     };
     if !distros.is_empty() {
         println!(


### PR DESCRIPTION
## Summary
- warn when a completed migration receipt cannot be read for the distro handoff
- document `imported_legacy_distros` error behavior
- cover the missing-receipt result

## Verification
- `cargo test -p unicity-aos-bootstrap --quiet`
- `cargo clippy -p unicity-aos-bootstrap --all-targets -- -D warnings`