### PR TITLE
docs: present capsules as Unicity AOS components

### DIFF
--- a/capsules/capsule-cli/README.md
+++ b/capsules/capsule-cli/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The CLI proxy for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The CLI proxy for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is the display server. It bridges the gap between the kernel's IPC event bus and the TUI frontend running on the other side of a Unix domain socket.
 

--- a/capsules/capsule-context-engine/README.md
+++ b/capsules/capsule-context-engine/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The context window compaction engine for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The context window compaction engine for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is the memory manager. When the conversation grows beyond the LLM's context window, this capsule decides what stays and what gets trimmed.
 

--- a/capsules/capsule-fs/README.md
+++ b/capsules/capsule-fs/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**Filesystem tools for [Astrid OS](https://github.com/unicity-astrid/astrid) agents.**
+**Filesystem tools for [Unicity AOS](https://github.com/unicity-aos/aos-ce) agents.**
 
 In the OS model, this capsule is the coreutils package. It gives agents the ability to read, write, search, and navigate the workspace filesystem through the kernel's VFS airlock.
 

--- a/capsules/capsule-hook-bridge/README.md
+++ b/capsules/capsule-hook-bridge/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The lifecycle-to-hook mapper for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The lifecycle-to-hook mapper for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is the interrupt dispatcher. The kernel emits raw lifecycle events. This capsule translates each one to a named semantic hook, fans out to subscriber capsules via `hooks::trigger`, and applies a merge strategy to the collected responses.
 

--- a/capsules/capsule-http/README.md
+++ b/capsules/capsule-http/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**HTTP fetch tool for [Astrid OS](https://github.com/unicity-astrid/astrid) agents.**
+**HTTP fetch tool for [Unicity AOS](https://github.com/unicity-aos/aos-ce) agents.**
 
 In the OS model, this capsule is the network stack's user-space interface. It gives agents native HTTP access without shelling out to `curl`, with SSRF protection enforced at the host layer.
 

--- a/capsules/capsule-identity/README.md
+++ b/capsules/capsule-identity/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The identity and system prompt builder for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The identity and system prompt builder for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is `/etc/profile`. It owns the agent's spark identity, persists it as capsule state, and assembles the identity plus environment context into a system prompt.
 

--- a/capsules/capsule-memory/README.md
+++ b/capsules/capsule-memory/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**Cross-session memory for [Astrid OS](https://github.com/unicity-astrid/astrid) agents.**
+**Cross-session memory for [Unicity AOS](https://github.com/unicity-aos/aos-ce) agents.**
 
 In the OS model, this capsule is the persistent swap file. It carries context across session boundaries so the agent remembers what happened last time.
 

--- a/capsules/capsule-openai-compat/README.md
+++ b/capsules/capsule-openai-compat/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The OpenAI-compatible LLM provider for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The OpenAI-compatible LLM provider for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is a device driver. It translates between Astrid's standardized LLM
 event protocol and any OpenAI-compatible Chat Completions API -- the same way a device driver

--- a/capsules/capsule-openai/README.md
+++ b/capsules/capsule-openai/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The native OpenAI LLM provider for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The native OpenAI LLM provider for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is a device driver. It translates between Astrid's standardized LLM
 event protocol and OpenAI's Responses API -- with full support for OpenAI-specific features that

--- a/capsules/capsule-prompt-builder/README.md
+++ b/capsules/capsule-prompt-builder/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The prompt assembly pipeline for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The prompt assembly pipeline for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is the linker. It takes contributions from multiple plugin capsules and merges them into a single, final prompt that the LLM actually sees.
 

--- a/capsules/capsule-react/README.md
+++ b/capsules/capsule-react/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The ReAct loop coordinator for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The ReAct loop coordinator for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is the shell. It drives the reasoning-and-action cycle that makes an agent an agent: fetch context, think, act, observe, repeat.
 

--- a/capsules/capsule-registry/README.md
+++ b/capsules/capsule-registry/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The LLM provider registry for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The LLM provider registry for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is the device manager. It discovers which LLM provider capsules are loaded, resolves their IPC routing topics, and manages which model is currently active.
 

--- a/capsules/capsule-router/README.md
+++ b/capsules/capsule-router/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The tool execution router for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The tool execution router for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is the syscall dispatcher. It sits between the react loop and every tool capsule, validating requests and routing them to the correct IPC topic.
 

--- a/capsules/capsule-session/README.md
+++ b/capsules/capsule-session/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The conversation session store for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The conversation session store for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is the filesystem for conversations. Dumb, trustworthy, append-only. It holds clean messages: what the user said, what the assistant replied, what tools returned. It never transforms anything. Clean in, clean out.
 

--- a/capsules/capsule-shell/README.md
+++ b/capsules/capsule-shell/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**Shell execution tools for [Astrid OS](https://github.com/unicity-astrid/astrid) agents.**
+**Shell execution tools for [Unicity AOS](https://github.com/unicity-aos/aos-ce) agents.**
 
 In the OS model, this capsule is the process spawner with a built-in safety net. It gives agents shell access while blocking catastrophic commands before they ever reach the human approval prompt.
 

--- a/capsules/capsule-skills/README.md
+++ b/capsules/capsule-skills/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The skills loader for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**The skills loader for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is the package manager's index. It discovers skill definitions from the workspace and global directories so the agent knows what commands are available.
 

--- a/capsules/capsule-system/README.md
+++ b/capsules/capsule-system/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**System management tools for [Astrid OS](https://github.com/unicity-astrid/astrid) agents.**
+**System management tools for [Unicity AOS](https://github.com/unicity-aos/aos-ce) agents.**
 
 This capsule gives the LLM typed tools to inspect and manage its own runtime. It's what makes Astrid self-evolving -- the agent can inspect installed capsules, read interface contracts, and understand the health of its own system.
 

--- a/capsules/capsule-telegram/README.md
+++ b/capsules/capsule-telegram/README.md
@@ -1,6 +1,6 @@
 # capsule-telegram
 
-Telegram Bot uplink capsule for [Astrid OS](https://github.com/unicity-astrid/astrid) — bridges the Telegram Bot API to the kernel IPC bus, giving your Astrid agent a Telegram chat interface.
+Telegram Bot uplink capsule for [Unicity AOS](https://github.com/unicity-aos/aos-ce) — bridges the Telegram Bot API to the kernel IPC bus, giving your Unicity AOS agent a Telegram chat interface.
 
 ## Features
 

--- a/capsules/capsule-users/README.md
+++ b/capsules/capsule-users/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**Within-principal user identity store for [Astrid OS](https://github.com/unicity-astrid/astrid).**
+**Within-principal user identity store for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 This capsule owns the cross-platform user-identity surface that used to live inside the kernel (`astrid-core::identity`, `astrid-storage::identity`, the `identity` host fn). It maps platform-specific IDs (Discord, Telegram, Nostr, web passkeys, …) onto canonical `AstridUserId`s — without making the kernel grow new types every time a frontend lands.
 


### PR DESCRIPTION
## Summary
- update each capsule README introduction to present the component as part of Unicity AOS
- replace stale customer-facing unicity-astrid repository links with the AOS product repository
- retain published capsule names, artifact filenames, engine CLI commands, WIT namespaces, IPC topics, SDK dependencies, compatibility fields, and historical issue references

## Validation
- git diff --check
- verified no targeted Astrid OS product links remain; the one historical issue reference is intentionally retained for provenance