### PR TITLE
docs: describe capsules as AOS components

### DIFF
--- a/capsules/capsule-cli/Capsule.toml
+++ b/capsules/capsule-cli/Capsule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "astrid-capsule-cli"
 version = "0.2.0"
-description = "Native Unix Socket bridge for the Astrid CLI frontend."
+description = "Native Unix socket bridge for the Unicity AOS command surface."
 
 [[component]]
 id = "main"

--- a/capsules/capsule-forge/Capsule.toml
+++ b/capsules/capsule-forge/Capsule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "astrid-capsule-forge"
 version = "0.1.0"
-description = "Capsule-authoring forge — tools and a Skill that teach a fresh LLM to build Astrid capsules"
+description = "Capsule-authoring forge for Unicity AOS components"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 astrid-version = ">=0.7.0"
 

--- a/capsules/capsule-forge/Cargo.toml
+++ b/capsules/capsule-forge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-forge"
 version = "0.1.0"
 edition = "2024"
-description = "Capsule-authoring forge — tools and a Skill that teach a fresh LLM to build Astrid capsules"
+description = "Capsule-authoring forge for Unicity AOS components"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/capsules/capsule-fs/Capsule.toml
+++ b/capsules/capsule-fs/Capsule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "astrid-capsule-fs"
 version = "0.2.0"
-description = "Core filesystem tools for the Astrid OS"
+description = "Core filesystem tools for Unicity AOS"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 astrid-version = ">=0.1.0"
 

--- a/capsules/capsule-fs/Cargo.toml
+++ b/capsules/capsule-fs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-fs"
 version = "0.2.0"
 edition = "2024"
-description = "Core filesystem tools for the Astrid microkernel"
+description = "Core filesystem tools for Unicity AOS"
 publish = false
 
 [lib]

--- a/capsules/capsule-http/Capsule.toml
+++ b/capsules/capsule-http/Capsule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "astrid-capsule-http"
 version = "0.1.1"
-description = "HTTP fetch tool for Astrid agents"
+description = "HTTP fetch tool for Unicity AOS agents"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 astrid-version = ">=0.1.0"
 

--- a/capsules/capsule-http/Cargo.toml
+++ b/capsules/capsule-http/Cargo.toml
@@ -3,7 +3,7 @@ name = "astrid-capsule-http"
 version = "0.1.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
-description = "HTTP fetch tool for Astrid agents"
+description = "HTTP fetch tool for Unicity AOS agents"
 publish = false
 
 [lib]

--- a/capsules/capsule-identity/Cargo.toml
+++ b/capsules/capsule-identity/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-identity"
 version = "0.2.0"
 edition = "2024"
-description = "Context Builder Capsule for Astrid OS"
+description = "Context builder capsule for Unicity AOS"
 publish = false
 
 [lib]

--- a/capsules/capsule-memory/Cargo.toml
+++ b/capsules/capsule-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-memory"
 version = "0.2.0"
 edition = "2024"
-description = "Cross-session memory capsule for Astrid OS"
+description = "Cross-session memory capsule for Unicity AOS"
 publish = false
 
 [lib]

--- a/capsules/capsule-openai-compat/Cargo.toml
+++ b/capsules/capsule-openai-compat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-openai-compat"
 version = "0.2.0"
 edition = "2024"
-description = "OpenAI-compatible LLM provider capsule for Astrid OS"
+description = "OpenAI-compatible LLM provider capsule for Unicity AOS"
 publish = false
 
 [lib]

--- a/capsules/capsule-openai/Cargo.toml
+++ b/capsules/capsule-openai/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-openai"
 version = "0.2.0"
 edition = "2024"
-description = "Native OpenAI LLM provider capsule for Astrid OS"
+description = "Native OpenAI LLM provider capsule for Unicity AOS"
 publish = false
 
 [lib]

--- a/capsules/capsule-registry/Cargo.toml
+++ b/capsules/capsule-registry/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-registry"
 version = "0.2.0"
 edition = "2024"
-description = "LLM provider registry capsule for Astrid OS"
+description = "LLM provider registry capsule for Unicity AOS"
 publish = false
 
 [lib]

--- a/capsules/capsule-router/Capsule.toml
+++ b/capsules/capsule-router/Capsule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "astrid-capsule-router"
 version = "0.2.0"
-description = "Tool execution routing middleware for Astrid OS"
+description = "Tool execution routing middleware for Unicity AOS"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 astrid-version = ">=0.1.0"
 

--- a/capsules/capsule-router/Cargo.toml
+++ b/capsules/capsule-router/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-router"
 version = "0.2.0"
 edition = "2024"
-description = "Tool execution routing middleware for Astrid OS"
+description = "Tool execution routing middleware for Unicity AOS"
 publish = false
 
 [lib]

--- a/capsules/capsule-session/Cargo.toml
+++ b/capsules/capsule-session/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-session"
 version = "0.2.0"
 edition = "2024"
-description = "Persistent conversation session store for Astrid OS"
+description = "Persistent conversation session store for Unicity AOS"
 publish = false
 
 [lib]

--- a/capsules/capsule-shell/Capsule.toml
+++ b/capsules/capsule-shell/Capsule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "astrid-capsule-shell"
 version = "0.2.0"
-description = "Core shell execution tools for the Astrid OS"
+description = "Core shell execution tools for Unicity AOS"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 astrid-version = ">=0.1.0"
 

--- a/capsules/capsule-shell/Cargo.toml
+++ b/capsules/capsule-shell/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-shell"
 version = "0.2.0"
 edition = "2024"
-description = "Core shell execution tools for the Astrid microkernel"
+description = "Core shell execution tools for Unicity AOS"
 publish = false
 
 [lib]

--- a/capsules/capsule-skills/Cargo.toml
+++ b/capsules/capsule-skills/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-skills"
 version = "0.2.0"
 edition = "2024"
-description = "Skills Loader for the Astrid OS"
+description = "Skills loader for Unicity AOS"
 publish = false
 
 [lib]

--- a/capsules/capsule-system/Cargo.toml
+++ b/capsules/capsule-system/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-system"
 version = "0.2.0"
 edition = "2024"
-description = "System management tools for the Astrid microkernel"
+description = "System management tools for Unicity AOS"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/capsules/capsule-telegram/Capsule.toml
+++ b/capsules/capsule-telegram/Capsule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "astrid-capsule-telegram"
 version = "0.1.0"
-description = "Telegram Bot frontend for Astrid OS — bridges the Telegram Bot API to the kernel IPC bus."
+description = "Telegram Bot frontend for Unicity AOS — bridges the Telegram Bot API to the kernel IPC bus."
 authors = ["Unicity Labs <info@unicity-labs.com>"]
 astrid-version = ">=0.5.0"
 

--- a/capsules/capsule-telegram/Cargo.toml
+++ b/capsules/capsule-telegram/Cargo.toml
@@ -3,7 +3,7 @@ name = "astrid-capsule-telegram"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
-description = "Telegram Bot uplink capsule for Astrid OS"
+description = "Telegram Bot uplink capsule for Unicity AOS"
 
 [lib]
 crate-type = ["cdylib"]

--- a/capsules/capsule-users/Capsule.toml
+++ b/capsules/capsule-users/Capsule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "astrid-capsule-users"
 version = "0.1.0"
-description = "Within-principal user identity store — platform-to-AstridUserId mapping over IPC"
+description = "Within-principal user identity store — platform-to-user-ID mapping over IPC"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 astrid-version = ">=0.1.0"
 

--- a/capsules/capsule-users/Cargo.toml
+++ b/capsules/capsule-users/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astrid-capsule-users"
 version = "0.1.0"
 edition = "2024"
-description = "Within-principal user identity store for Astrid OS"
+description = "Within-principal user identity store for Unicity AOS"
 publish = false
 
 [lib]


### PR DESCRIPTION
## Summary
- replace customer-facing Astrid product wording in Cargo and Capsule descriptions with Unicity AOS wording
- retain every package name, capsule manifest name, artifact filename, SDK dependency, runtime compatibility field, WIT namespace, and IPC topic unchanged

## Validation
- git diff --check
- cargo metadata --locked --format-version 1 --no-deps
- verified no remaining customer-facing Astrid wording in capsule description fields