### PR TITLE
ci: fetch runtime releases from astrid-runtime

### DIFF
--- a/capsules/capsule-agents/.github/workflows/release.yml
+++ b/capsules/capsule-agents/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-cli/.github/workflows/release.yml
+++ b/capsules/capsule-cli/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-context-engine/.github/workflows/release.yml
+++ b/capsules/capsule-context-engine/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-fs/.github/workflows/release.yml
+++ b/capsules/capsule-fs/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-hook-bridge/.github/workflows/release.yml
+++ b/capsules/capsule-hook-bridge/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-http/.github/workflows/release.yml
+++ b/capsules/capsule-http/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-identity/.github/workflows/release.yml
+++ b/capsules/capsule-identity/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-memory/.github/workflows/release.yml
+++ b/capsules/capsule-memory/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-openai-compat/.github/workflows/release.yml
+++ b/capsules/capsule-openai-compat/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-openai/.github/workflows/release.yml
+++ b/capsules/capsule-openai/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-prompt-builder/.github/workflows/release.yml
+++ b/capsules/capsule-prompt-builder/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-react/.github/workflows/release.yml
+++ b/capsules/capsule-react/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-registry/.github/workflows/release.yml
+++ b/capsules/capsule-registry/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-router/.github/workflows/release.yml
+++ b/capsules/capsule-router/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-session/.github/workflows/release.yml
+++ b/capsules/capsule-session/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-shell/.github/workflows/release.yml
+++ b/capsules/capsule-shell/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-skills/.github/workflows/release.yml
+++ b/capsules/capsule-skills/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-system/.github/workflows/release.yml
+++ b/capsules/capsule-system/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"

--- a/capsules/capsule-users/.github/workflows/release.yml
+++ b/capsules/capsule-users/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download --repo unicity-astrid/astrid \
+          gh release download --repo astrid-runtime/astrid \
             --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
           tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
           echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Summary
- point all capsule release workflows at the Astrid Runtime repository
- retain release asset names, astrid-build invocation, signing flow, and capsule artifact identities unchanged

## Validation
- parsed every capsule release workflow as YAML
- git diff --check
- verified no stale unicity-astrid runtime release source remains