### PR TITLE
feat: add signed AOS release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,24 +21,34 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "1.95.0"
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  release-contract:
+    name: Release contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - run: sh -n install.sh
+      - run: python3 scripts/validate-release-contract.py
+      - run: bash scripts/test-package-release.sh
+      - run: bash scripts/test-install.sh
+
   community-wasm:
     name: Community WASM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "1.95.0"
           components: clippy
           targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo metadata --locked --format-version 1 --no-deps
       - run: cargo check --locked --workspace --exclude astrid-capsule-telegram --exclude unicity-aos-bootstrap --target wasm32-unknown-unknown
       - run: cargo clippy --locked --workspace --exclude astrid-capsule-telegram --exclude unicity-aos-bootstrap --target wasm32-unknown-unknown -- -D warnings
@@ -47,12 +57,12 @@ jobs:
     name: Product native
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "1.95.0"
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --locked -p unicity-aos-bootstrap
       - run: cargo clippy --locked -p unicity-aos-bootstrap -- -D warnings
 
@@ -60,10 +70,10 @@ jobs:
     name: Telegram WASI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: "1.95.0"
           targets: wasm32-wasip1
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo check --locked -p astrid-capsule-telegram --target wasm32-wasip1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,196 @@
+name: Release Unicity AOS
+
+on:
+  push:
+    tags:
+      - '20[0-9][0-9].*'
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validate-release:
+    name: Validate release identity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Match product, distro, and tag versions
+        run: |
+          python3 scripts/validate-release-contract.py
+          PRODUCT=$(sed -n 's/^version = "\([^"]*\)"/\1/p' crates/unicity-aos-bootstrap/Cargo.toml | head -n1)
+          printf '%s\n' "$GITHUB_REF_NAME" | grep -Eq '^20[0-9]{2}\.[0-9]+\.[0-9]+$'
+          test "$PRODUCT" = "$GITHUB_REF_NAME"
+      - run: bash scripts/test-package-release.sh
+      - run: bash scripts/test-install.sh
+      - run: sh -n install.sh
+
+  build:
+    name: Build (${{ matrix.target }})
+    needs: validate-release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: '1.95.0'
+          targets: ${{ matrix.target }}
+      - name: Install Linux ARM linker
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: aos-release-${{ matrix.target }}
+      - name: Load runtime compatibility pins
+        run: |
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import tomllib
+          with open("release/runtime-compatibility.toml", "rb") as file:
+              metadata = tomllib.load(file)["runtime"]
+          print(f"RUNTIME_VERSION={metadata['version']}")
+          print(f"RUNTIME_TAG={metadata['tag']}")
+          print(f"RUNTIME_REPOSITORY={metadata['repository']}")
+          print(f"RUNTIME_IDENTITY={metadata['release-workflow-identity']}")
+          PY
+      - name: Build product binary
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: cargo build --locked --release --target "${{ matrix.target }}" -p unicity-aos-bootstrap
+      - name: Download pinned runtime release
+        run: |
+          ASSET="astrid-${RUNTIME_VERSION}-${{ matrix.target }}.tar.gz"
+          BASE="https://github.com/${RUNTIME_REPOSITORY}/releases/download/${RUNTIME_TAG}"
+          curl --proto '=https' --tlsv1.2 -fsSLO "$BASE/$ASSET"
+          curl --proto '=https' --tlsv1.2 -fsSLO "$BASE/SHA256SUMS.txt"
+          curl --proto '=https' --tlsv1.2 -fsSLo "$ASSET.sigstore.json" "$BASE/$ASSET.sigstore.json"
+          EXPECTED=$(awk -v asset="$ASSET" '$2 == asset { print $1; exit }' SHA256SUMS.txt)
+          test -n "$EXPECTED"
+          if command -v sha256sum >/dev/null 2>&1; then
+            echo "$EXPECTED  $ASSET" | sha256sum -c -
+          else
+            echo "$EXPECTED  $ASSET" | shasum -a 256 -c -
+          fi
+          echo "RUNTIME_ASSET=$ASSET" >> "$GITHUB_ENV"
+          echo "RUNTIME_SHA256=$EXPECTED" >> "$GITHUB_ENV"
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Verify runtime release identity
+        run: |
+          cosign verify-blob \
+            --bundle "$RUNTIME_ASSET.sigstore.json" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity "$RUNTIME_IDENTITY" \
+            "$RUNTIME_ASSET"
+      - name: Compose product bundle
+        run: |
+          scripts/package-release.sh \
+            "${{ matrix.target }}" \
+            "target/${{ matrix.target }}/release/aos" \
+            "$RUNTIME_ASSET" \
+            "$RUNTIME_SHA256" \
+            artifacts
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: aos-${{ matrix.target }}
+          path: artifacts/*.tar.gz
+
+  github-release:
+    name: Publish signed release
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Load runtime compatibility pins
+        run: |
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import tomllib
+          with open("release/runtime-compatibility.toml", "rb") as file:
+              metadata = tomllib.load(file)["runtime"]
+          print(f"RUNTIME_TAG={metadata['tag']}")
+          PY
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          pattern: aos-*
+          merge-multiple: true
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum -- ./*.tar.gz | sed 's#  \./#  #' > SHA256SUMS.txt
+          cp ../release/runtime-compatibility.toml .
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            artifacts/*.tar.gz
+            artifacts/SHA256SUMS.txt
+            artifacts/runtime-compatibility.toml
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Sign release assets
+        env:
+          COSIGN_YES: 'true'
+        run: |
+          cd artifacts
+          for asset in ./*.tar.gz SHA256SUMS.txt runtime-compatibility.toml; do
+            cosign sign-blob --yes --bundle "${asset}.sigstore.json" "$asset"
+          done
+      - name: Write release notes
+        run: |
+          cat > release-notes.md <<EOF
+          Unicity AOS Community Edition ${GITHUB_REF_NAME}.
+
+          This product release bundles Astrid Runtime ${RUNTIME_TAG}. The exact runtime release identity, WIT commit, and compatibility pins are published in \`runtime-compatibility.toml\` and in every archive's \`release-manifest.json\`.
+
+          Install or upgrade:
+
+          \`\`\`sh
+          curl -fsSL https://aos.unicity.ai/install.sh | sh
+          \`\`\`
+          EOF
+      - uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          files: |
+            artifacts/*.tar.gz
+            artifacts/SHA256SUMS.txt
+            artifacts/runtime-compatibility.toml
+            artifacts/*.sigstore.json
+          body_path: release-notes.md
+      - name: Notify Homebrew tap
+        env:
+          GH_TOKEN: ${{ secrets.TAP_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "TAP_DISPATCH_TOKEN is not configured; run the tap's Update AOS formula workflow manually."
+            exit 0
+          fi
+          gh api repos/unicity-aos/homebrew-tap/dispatches \
+            -f event_type=aos-release \
+            -f "client_payload[version]=${GITHUB_REF_NAME}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [2026.1.0] - 2026-07-14
+
+### Added
+
+- The `aos` product command and product-owned `~/.unicity-os` state boundary.
+- A pinned Unicity CE distribution manifest over Astrid Runtime 0.9.4.
+- Reproducible macOS and Linux release bundles with checksums, Sigstore bundles,
+  GitHub build-provenance attestations, and explicit runtime/WIT compatibility metadata.
+- An idempotent product installer and updater that preserve runtime state while
+  replacing the coordinated AOS and Astrid executable set.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ members = [
 resolver = "3"
 
 [workspace.dependencies]
-astrid-sdk = { version = "0.7.1", features = ["derive"] }
-astrid-core = "0.9.4"
-astrid-uplink = "0.9.4"
+astrid-sdk = { version = "=0.7.1", features = ["derive"] }
+astrid-core = "=0.9.4"
+astrid-uplink = "=0.9.4"
 axum = "0.8"
 fs2 = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ distros/      Community distribution manifests and release metadata
 docs/         Product and operator documentation
 ```
 
+## Install
+
+The supported installer installs both the `aos` product command and its pinned
+Astrid Runtime under the product-owned `~/.unicity-os` root:
+
+```sh
+curl -fsSL https://aos.unicity.ai/install.sh | sh
+aos init
+```
+
+Re-running the installer performs a coordinated product upgrade without
+rewriting a standalone `~/.astrid` installation. Every release publishes
+checksums, Sigstore bundles, GitHub build-provenance attestations, and
+`runtime-compatibility.toml`, which pins the exact Astrid release and WIT commit.
+
 ## Import an existing runtime
 
 The `aos` CLI can deliberately copy compatible state from a standalone Astrid

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -119,10 +119,13 @@ impl AosHome {
         if fs::read(&path).ok().as_deref() == Some(UNICITY_CE_MANIFEST.as_bytes()) {
             return Ok(path);
         }
+        self.ensure_layout()?;
+        create_private_dir(&self.root.join("distributions"))?;
         let parent = path.parent().expect("manifest path has a parent");
-        fs::create_dir_all(parent)?;
+        create_private_dir(parent)?;
         let temporary = path.with_extension("toml.tmp");
         fs::write(&temporary, UNICITY_CE_MANIFEST)?;
+        set_private_file_permissions(&temporary)?;
         fs::rename(&temporary, &path)?;
         Ok(path)
     }
@@ -138,6 +141,18 @@ impl AosHome {
     /// The installed bundled-runtime executable.
     #[must_use]
     pub fn runtime_binary(&self) -> PathBuf {
+        self.runtime_binary_with(|name| std::env::var_os(name))
+    }
+
+    fn runtime_binary_with<F>(&self, get: F) -> PathBuf
+    where
+        F: Fn(&str) -> Option<OsString>,
+    {
+        if let Some(path) = get("UNICITY_AOS_RUNTIME_BIN").map(PathBuf::from)
+            && path.is_absolute()
+        {
+            return path;
+        }
         self.runtime_home().join("bin").join(runtime_binary_name())
     }
 
@@ -170,7 +185,9 @@ impl AosHome {
     /// # Errors
     /// Returns an error when the directories cannot be created.
     pub fn ensure_layout(&self) -> io::Result<()> {
-        fs::create_dir_all(self.runtime_home())
+        create_private_dir(&self.root)?;
+        create_private_dir(&self.runtime_home())?;
+        create_private_dir(&self.runtime_home().join("bin"))
     }
 
     /// Build a command for the bundled runtime with a process-local home.
@@ -275,6 +292,27 @@ impl AosHome {
     }
 }
 
+fn create_private_dir(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
+fn set_private_file_permissions(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
 #[cfg(windows)]
 fn default_home<F>(get: &F) -> io::Result<OsString>
 where
@@ -361,6 +399,19 @@ mod tests {
     }
 
     #[test]
+    fn packaged_runtime_override_must_be_absolute() {
+        let home = AosHome::from_root("/tmp/unicity-aos-test");
+        assert_eq!(
+            home.runtime_binary_with(|_| Some(OsString::from("runtime/astrid"))),
+            home.runtime_home().join("bin").join(runtime_binary_name())
+        );
+        assert_eq!(
+            home.runtime_binary_with(|_| Some(OsString::from("/opt/aos/runtime/bin/astrid"))),
+            PathBuf::from("/opt/aos/runtime/bin/astrid")
+        );
+    }
+
+    #[test]
     fn runtime_command_scopes_astrid_home_to_the_child() {
         let home = AosHome::from_root("/tmp/unicity-aos-test");
         let command = home.runtime_command();
@@ -438,6 +489,44 @@ mod tests {
             fs::read_to_string(path)
                 .expect("read restored manifest")
                 .contains("id = \"unicity-ce\"")
+        );
+        fs::remove_dir_all(root).expect("remove temporary product home");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn product_layout_and_manifest_are_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = temporary_home();
+        let home = AosHome::from_root(&root);
+        let manifest = home
+            .ensure_unicity_ce_manifest()
+            .expect("write private product manifest");
+
+        for directory in [
+            &root,
+            &home.runtime_home(),
+            &home.runtime_home().join("bin"),
+            &root.join("distributions"),
+            &root.join("distributions/unicity-ce"),
+        ] {
+            assert_eq!(
+                fs::metadata(directory)
+                    .expect("read directory metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+        }
+        assert_eq!(
+            fs::metadata(manifest)
+                .expect("read manifest metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
         );
         fs::remove_dir_all(root).expect("remove temporary product home");
     }

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -5,8 +5,16 @@
 //! bundled runtime, scoped to this installation's private `ASTRID_HOME`.
 
 use std::ffi::{OsStr, OsString};
+#[cfg(unix)]
+use std::fs::OpenOptions;
 use std::io::{self, IsTerminal, Write};
-use std::process::ExitCode;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+#[cfg(unix)]
+use std::path::Path;
+use std::process::{Command, ExitCode};
+#[cfg(unix)]
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use unicity_aos_bootstrap::AosHome;
 
@@ -85,12 +93,7 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
             println!("Unicity AOS {}", env!("CARGO_PKG_VERSION"));
             Some(ExitCode::SUCCESS)
         }
-        Some("self-update" | "self_update") => {
-            eprintln!(
-                "aos: runtime self-update is disabled; update Unicity AOS through its product updater"
-            );
-            Some(ExitCode::FAILURE)
-        }
+        Some("self-update" | "self_update") => Some(handle_self_update(&args[1..])),
         Some("migrate") => Some(handle_migrate_command(&args[1..])),
         Some("serve-health") => Some(handle_health_service()),
         Some("init") if has_distro_override(&args[1..]) => {
@@ -102,6 +105,92 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
             Some(ExitCode::SUCCESS)
         }
         Some(_) => None,
+    }
+}
+
+fn handle_self_update(args: &[OsString]) -> ExitCode {
+    if !args.is_empty() {
+        eprintln!("Usage: aos self-update");
+        return ExitCode::FAILURE;
+    }
+
+    if std::env::var_os("UNICITY_AOS_INSTALL_METHOD").as_deref() == Some(OsStr::new("homebrew")) {
+        return command_exit_code(
+            Command::new("brew")
+                .args(["upgrade", "unicity-aos/tap/aos"])
+                .status(),
+            "run Homebrew upgrade",
+        );
+    }
+
+    #[cfg(unix)]
+    {
+        let installer = std::env::temp_dir().join(format!(
+            "unicity-aos-update-{}-{}.sh",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        let create = create_private_update_file(&installer);
+        if let Err(error) = create {
+            eprintln!("aos: failed to stage product updater: {error}");
+            return ExitCode::FAILURE;
+        }
+
+        let url = "https://aos.unicity.ai/install.sh";
+        let download = Command::new("curl")
+            .args(["--proto", "=https", "--tlsv1.2", "-fsSL", url, "-o"])
+            .arg(&installer)
+            .status();
+        let download_code = command_exit_code(download, "download the product updater");
+        if download_code != ExitCode::SUCCESS {
+            let _ = std::fs::remove_file(&installer);
+            return download_code;
+        }
+
+        let mut update = Command::new("sh");
+        update
+            .arg(&installer)
+            .args(["--yes", "--no-migrate-prompt"])
+            .env_remove("AOS_VERSION");
+        if let Ok(executable) = std::env::current_exe()
+            && let Some(bin_dir) = executable.parent()
+        {
+            update.env("AOS_BIN_DIR", bin_dir);
+        }
+        let status = update.status();
+        let _ = std::fs::remove_file(&installer);
+        command_exit_code(status, "run the product updater")
+    }
+
+    #[cfg(not(unix))]
+    {
+        eprintln!(
+            "aos: automatic product updates are not available on this platform; install the latest AOS package"
+        );
+        ExitCode::FAILURE
+    }
+}
+
+#[cfg(unix)]
+fn create_private_update_file(path: &Path) -> io::Result<std::fs::File> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+}
+
+fn command_exit_code(status: io::Result<std::process::ExitStatus>, operation: &str) -> ExitCode {
+    match status {
+        Ok(status) if status.success() => ExitCode::SUCCESS,
+        Ok(status) => ExitCode::from(status.code().unwrap_or(1).clamp(1, i32::from(u8::MAX)) as u8),
+        Err(error) => {
+            eprintln!("aos: failed to {operation}: {error}");
+            ExitCode::FAILURE
+        }
     }
 }
 
@@ -268,7 +357,7 @@ fn print_legacy_distro_handoff(home: &AosHome) {
 
 fn print_help() {
     println!(
-        "Unicity AOS\n\nUsage:\n  aos init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n  aos migrate runtime --from <absolute-legacy-home>\n  aos serve-health\n  aos <runtime command> [arguments...]\n\n`aos init` installs the Unicity CE manifest bundled with this product release. `aos serve-health` binds only 127.0.0.1:8765 and exposes GET /v1/runtime/health. Unicity delegates runtime and operator commands to its bundled Astrid Runtime. The runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME).\n\n`aos self-update` is intentionally disabled; AOS updates use the product updater."
+        "Unicity AOS\n\nUsage:\n  aos init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n  aos migrate runtime --from <absolute-legacy-home>\n  aos self-update\n  aos serve-health\n  aos <runtime command> [arguments...]\n\n`aos init` installs the Unicity CE manifest bundled with this product release. `aos self-update` updates the coordinated AOS and bundled Astrid executable set. `aos serve-health` binds only 127.0.0.1:8765 and exposes GET /v1/runtime/health. Unicity delegates runtime and operator commands to its bundled Astrid Runtime. The runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME)."
     );
 }
 
@@ -282,8 +371,12 @@ fn print_init_help() {
 mod tests {
     use std::ffi::OsString;
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    #[cfg(unix)]
+    use super::create_private_update_file;
     use super::{has_distro_override, product_runtime_args};
     use unicity_aos_bootstrap::AosHome;
 
@@ -332,5 +425,20 @@ mod tests {
         ]));
         assert!(has_distro_override(&[OsString::from("--distro=other")]));
         assert!(!has_distro_override(&[OsString::from("--yes")]));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn product_updater_is_staged_privately() {
+        let path = temporary_home();
+        let file = create_private_update_file(&path).expect("create private updater");
+        drop(file);
+        let mode = fs::metadata(&path)
+            .expect("read updater metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+        fs::remove_file(path).expect("remove updater");
     }
 }

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -15,7 +15,7 @@ support = "https://github.com/unicity-aos/aos-ce/discussions"
 bug-tracker = "https://github.com/unicity-aos/aos-ce/issues"
 repository = "https://github.com/unicity-aos/aos-ce"
 license = "MIT OR Apache-2.0"
-astrid-version = ">=0.9.1"  # 0.9.0 shipped a broken astrid:process@1.0.0 host ABI (capsules like shell fail to instantiate); fixed in 0.9.1
+astrid-version = "=0.9.4"  # Product releases pin the exact bundled runtime; update this with release/runtime-compatibility.toml.
 
 [distro.requires.astrid]
 llm = "^1.0"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,283 @@
+#!/bin/sh
+set -eu
+
+AOS_RELEASE_REPO="${AOS_RELEASE_REPO:-unicity-aos/aos-ce}"
+AOS_HOME="${UNICITY_AOS_HOME:-$HOME/.unicity-os}"
+AOS_BIN_DIR="${AOS_BIN_DIR:-$AOS_HOME/bin}"
+AOS_VERSION="${AOS_VERSION:-latest}"
+COSIGN_VERSION=v3.1.1
+ASSUME_YES=0
+SKIP_MIGRATION_PROMPT=0
+installation_started=0
+rollback=
+
+usage() {
+  cat <<'EOF'
+Install or upgrade Unicity AOS Community Edition.
+
+Usage: install.sh [--yes] [--version VERSION] [--no-migrate-prompt]
+
+  --yes                do not ask before replacing an existing installation
+  --version VERSION    install a specific calendar-semver release
+  --no-migrate-prompt  do not launch the optional Astrid state-import prompt
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -y|--yes) ASSUME_YES=1 ;;
+    --version)
+      [ "$#" -ge 2 ] || { echo "missing value for --version" >&2; exit 2; }
+      AOS_VERSION=$2
+      shift
+      ;;
+    --no-migrate-prompt) SKIP_MIGRATION_PROMPT=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+case "$AOS_HOME" in
+  /*) ;;
+  *) echo "UNICITY_AOS_HOME must be an absolute path" >&2; exit 1 ;;
+esac
+case "$AOS_BIN_DIR" in
+  /*) ;;
+  *) echo "AOS_BIN_DIR must be an absolute path" >&2; exit 1 ;;
+esac
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "required command not found: $1" >&2; exit 1; }; }
+need curl
+need tar
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "required command not found: sha256sum or shasum" >&2
+    exit 1
+  fi
+}
+
+os=$(uname -s)
+arch=$(uname -m)
+case "$os:$arch" in
+  Darwin:arm64|Darwin:aarch64)
+    target=aarch64-apple-darwin
+    cosign_asset=cosign-darwin-arm64
+    cosign_sha256=94b42a9e697be95675f6160ab031a9a5f1ec1e646d6f648d7b2f5cd59ececbc5
+    ;;
+  Darwin:x86_64)
+    target=x86_64-apple-darwin
+    cosign_asset=cosign-darwin-amd64
+    cosign_sha256=14d2678dfbfde18798151e86fbd91ebdadbb7424b18412a42a155dd8a2df4c7a
+    ;;
+  Linux:aarch64|Linux:arm64)
+    target=aarch64-unknown-linux-gnu
+    cosign_asset=cosign-linux-arm64
+    cosign_sha256=2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11
+    ;;
+  Linux:x86_64|Linux:amd64)
+    target=x86_64-unknown-linux-gnu
+    cosign_asset=cosign-linux-amd64
+    cosign_sha256=ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc
+    ;;
+  *) echo "Unicity AOS does not publish a bundle for $os/$arch yet" >&2; exit 1 ;;
+esac
+
+asset="unicity-aos-${target}.tar.gz"
+if [ "$AOS_VERSION" = latest ]; then
+  base="https://github.com/${AOS_RELEASE_REPO}/releases/latest/download"
+else
+  if ! printf '%s\n' "$AOS_VERSION" | grep -Eq '^20[0-9]{2}\.[0-9]+\.[0-9]+$'; then
+    echo "invalid AOS version: $AOS_VERSION" >&2
+    exit 2
+  fi
+  base="https://github.com/${AOS_RELEASE_REPO}/releases/download/${AOS_VERSION}"
+fi
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/unicity-aos-install.XXXXXX")
+cleanup() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  if [ "$installation_started" -eq 1 ]; then
+    restore || status=1
+  fi
+  rm -rf "$work"
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if command -v cosign >/dev/null 2>&1; then
+  COSIGN_BIN=$(command -v cosign)
+else
+  COSIGN_BIN="$work/cosign"
+  echo "Downloading the pinned Sigstore verifier..."
+  curl --proto '=https' --tlsv1.2 -fsSL \
+    "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/${cosign_asset}" \
+    -o "$COSIGN_BIN"
+  [ ! -L "$COSIGN_BIN" ] || { echo "downloaded Sigstore verifier is a symlink" >&2; exit 1; }
+  [ "$(sha256_file "$COSIGN_BIN")" = "$cosign_sha256" ] || {
+    echo "Sigstore verifier checksum mismatch" >&2
+    exit 1
+  }
+  chmod 700 "$COSIGN_BIN"
+fi
+
+echo "Downloading Unicity AOS for $target..."
+curl --proto '=https' --tlsv1.2 -fsSL "$base/$asset" -o "$work/$asset"
+curl --proto '=https' --tlsv1.2 -fsSL "$base/SHA256SUMS.txt" -o "$work/SHA256SUMS.txt"
+curl --proto '=https' --tlsv1.2 -fsSL "$base/$asset.sigstore.json" -o "$work/$asset.sigstore.json"
+"$COSIGN_BIN" verify-blob \
+  --bundle "$work/$asset.sigstore.json" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/20[0-9]{2}\.[0-9]+\.[0-9]+$' \
+  "$work/$asset" >/dev/null
+
+expected=$(awk -v asset="$asset" '$2 == asset || $2 == "*" asset { print $1; exit }' "$work/SHA256SUMS.txt")
+[ -n "$expected" ] || { echo "release checksum list does not contain $asset" >&2; exit 1; }
+actual=$(sha256_file "$work/$asset")
+[ "$actual" = "$expected" ] || { echo "Unicity AOS archive checksum mismatch" >&2; exit 1; }
+
+mkdir "$work/unpack"
+if tar -tzf "$work/$asset" | awk -v target="$target" -v version="$AOS_VERSION" '
+  {
+    root = $0
+    sub(/\/.*/, "", root)
+    if (first == "") first = root
+    if (root != first) unsafe = 1
+    if (version == "latest") {
+      if (root !~ ("^unicity-aos-20[0-9][0-9]\\.[0-9]+\\.[0-9]+-" target "$")) unsafe = 1
+    } else if (root != "unicity-aos-" version "-" target) {
+      unsafe = 1
+    }
+  }
+  /^\// || /(^|\/)\.\.($|\/)/ { unsafe = 1 }
+  END { exit unsafe ? 0 : 1 }
+'; then
+  echo "release archive contains an unsafe path or unexpected bundle root" >&2
+  exit 1
+fi
+if tar -tvzf "$work/$asset" | awk '
+  substr($1, 1, 1) != "-" && substr($1, 1, 1) != "d" { unsafe = 1 }
+  END { exit unsafe ? 0 : 1 }
+'; then
+  echo "release archive contains a link or special file" >&2
+  exit 1
+fi
+tar -xzf "$work/$asset" -C "$work/unpack"
+bundle_name=$(tar -tzf "$work/$asset" | awk 'NR == 1 { sub(/\/.*/, "", $0); print; exit }')
+[ -n "$bundle_name" ] || { echo "release archive has no Unicity AOS bundle" >&2; exit 1; }
+bundle="$work/unpack/$bundle_name"
+[ -d "$bundle" ] || { echo "release archive has no Unicity AOS bundle" >&2; exit 1; }
+
+for file in bin/aos runtime/bin/astrid runtime/bin/astrid-daemon runtime/bin/astrid-build runtime/bin/astrid-emit release-manifest.json; do
+  [ -f "$bundle/$file" ] || { echo "release archive is missing $file" >&2; exit 1; }
+done
+
+staged_version=$("$bundle/bin/aos" --version | awk '{print $3}')
+if ! printf '%s\n' "$staged_version" | grep -Eq '^20[0-9]{2}\.[0-9]+\.[0-9]+$'; then
+  echo "staged AOS binary reported an invalid product version" >&2
+  exit 1
+fi
+if [ "$AOS_VERSION" != latest ] && [ "$staged_version" != "$AOS_VERSION" ]; then
+  echo "staged AOS version $staged_version does not match requested version $AOS_VERSION" >&2
+  exit 1
+fi
+if [ "$bundle_name" != "unicity-aos-${staged_version}-${target}" ]; then
+  echo "release bundle root does not match its product version and target" >&2
+  exit 1
+fi
+
+if [ -x "$AOS_BIN_DIR/aos" ] && [ "$ASSUME_YES" -ne 1 ] && [ -t 0 ]; then
+  printf 'Replace the existing Unicity AOS installation? [y/N] '
+  read -r answer
+  case "$answer" in y|Y|yes|YES) ;; *) echo "Installation cancelled."; exit 0 ;; esac
+fi
+
+if [ -x "$AOS_BIN_DIR/aos" ]; then
+  "$AOS_BIN_DIR/aos" stop >/dev/null 2>&1 || true
+fi
+
+for managed in "$AOS_HOME" "$AOS_HOME/runtime" "$AOS_HOME/runtime/bin" "$AOS_HOME/releases"; do
+  [ ! -L "$managed" ] || { echo "refusing symlinked managed path: $managed" >&2; exit 1; }
+done
+if [ "$AOS_BIN_DIR" = "$AOS_HOME/bin" ] && [ -L "$AOS_BIN_DIR" ]; then
+  echo "refusing symlinked managed path: $AOS_BIN_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$AOS_BIN_DIR" "$AOS_HOME/runtime/bin" "$AOS_HOME/releases"
+chmod 700 "$AOS_HOME" "$AOS_HOME/runtime" "$AOS_HOME/runtime/bin" "$AOS_HOME/releases"
+if [ "$AOS_BIN_DIR" = "$AOS_HOME/bin" ]; then
+  chmod 700 "$AOS_BIN_DIR"
+fi
+rollback="$work/rollback"
+mkdir "$rollback"
+
+install_one() {
+  source=$1
+  destination=$2
+  name=$3
+  mode=$4
+  temporary="${destination}.new.$$"
+  if [ -e "$destination" ] || [ -L "$destination" ]; then
+    cp -p "$destination" "$rollback/$name" || return 1
+  fi
+  cp "$source" "$temporary" || return 1
+  chmod "$mode" "$temporary" || return 1
+  : > "$rollback/$name.touched" || return 1
+  mv -f "$temporary" "$destination" || return 1
+}
+
+restore() {
+  result=0
+  for name in aos astrid astrid-daemon astrid-build astrid-emit release-manifest; do
+    case "$name" in
+      aos) destination="$AOS_BIN_DIR/aos" ;;
+      release-manifest) destination="$AOS_HOME/releases/${staged_version}.json" ;;
+      *) destination="$AOS_HOME/runtime/bin/$name" ;;
+    esac
+    rm -f "${destination}.new.$$" "${destination}.restore.$$"
+    if [ ! -f "$rollback/$name.touched" ]; then
+      continue
+    elif [ -f "$rollback/$name" ]; then
+      temporary="${destination}.restore.$$"
+      if ! cp -p "$rollback/$name" "$temporary" || ! mv -f "$temporary" "$destination"; then
+        result=1
+      fi
+    else
+      rm -f "$destination" || result=1
+    fi
+  done
+  return "$result"
+}
+
+installation_started=1
+if ! install_one "$bundle/bin/aos" "$AOS_BIN_DIR/aos" aos 755; then exit 1; fi
+for name in astrid astrid-daemon astrid-build astrid-emit; do
+  if ! install_one "$bundle/runtime/bin/$name" "$AOS_HOME/runtime/bin/$name" "$name" 755; then exit 1; fi
+done
+if ! install_one "$bundle/release-manifest.json" "$AOS_HOME/releases/${staged_version}.json" release-manifest 600; then exit 1; fi
+installation_started=0
+
+echo "Installed Unicity AOS $staged_version."
+case ":$PATH:" in
+  *":$AOS_BIN_DIR:"*) init_command="aos init" ;;
+  *)
+    echo "Add $AOS_BIN_DIR to PATH."
+    init_command="$AOS_BIN_DIR/aos init"
+    ;;
+esac
+
+if [ "$SKIP_MIGRATION_PROMPT" -ne 1 ] && [ -t 0 ]; then
+  "$AOS_BIN_DIR/aos" || true
+else
+  echo "Run: $init_command"
+fi

--- a/release/runtime-compatibility.toml
+++ b/release/runtime-compatibility.toml
@@ -1,0 +1,22 @@
+schema-version = 1
+
+[product]
+name = "Unicity AOS Community Edition"
+version = "2026.1.0"
+
+[runtime]
+repository = "astrid-runtime/astrid"
+version = "0.9.4"
+tag = "v0.9.4"
+version-requirement = "=0.9.4"
+# v0.9.4 was signed before the repository moved to the astrid-runtime org.
+# Sigstore identities are immutable provenance and retain the original owner.
+release-workflow-identity = "https://github.com/unicity-astrid/astrid/.github/workflows/release.yml@refs/tags/v0.9.4"
+
+[contracts]
+repository = "astrid-runtime/wit"
+commit = "278dbca3e32f327d0f2358644fc86559779ba0fd"
+sdk-rust-version = "0.7.1"
+# crates.io embeds this source commit in astrid-sdk 0.7.1's
+# .cargo_vcs_info.json; that release does not have a matching Git tag.
+sdk-rust-commit = "bbbc61c8821d6c536fb25d2068b6b646e759ad35"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "usage: $0 <target> <aos-binary> <runtime-archive> <runtime-sha256> <output-dir>" >&2
+  exit 2
+fi
+
+target=$1
+aos_binary=$2
+runtime_archive=$3
+runtime_sha256=$4
+output_dir=$5
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+toml_value() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import pathlib
+import sys
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 and older
+    import tomli as tomllib
+
+path, section, key = sys.argv[1:]
+value = tomllib.loads(pathlib.Path(path).read_text(encoding="utf-8"))[section][key]
+if not isinstance(value, str) or not value:
+    raise SystemExit(f"{path}: [{section}] {key} must be a non-empty string")
+print(value)
+PY
+}
+
+product_version=$(toml_value "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" package version)
+runtime_version=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime version)
+runtime_tag=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime tag)
+runtime_repository=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime repository)
+runtime_identity=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime release-workflow-identity)
+wit_repository=$(toml_value "$repo_root/release/runtime-compatibility.toml" contracts repository)
+wit_commit=$(toml_value "$repo_root/release/runtime-compatibility.toml" contracts commit)
+sdk_rust_version=$(toml_value "$repo_root/release/runtime-compatibility.toml" contracts sdk-rust-version)
+sdk_rust_commit=$(toml_value "$repo_root/release/runtime-compatibility.toml" contracts sdk-rust-commit)
+asset="unicity-aos-${target}.tar.gz"
+root="unicity-aos-${product_version}-${target}"
+
+if [[ -z "$product_version" || -z "$runtime_version" || -z "$runtime_tag" || -z "$runtime_repository" || -z "$runtime_identity" || -z "$wit_repository" || -z "$wit_commit" || -z "$sdk_rust_version" || -z "$sdk_rust_commit" ]]; then
+  echo "release compatibility metadata is incomplete" >&2
+  exit 1
+fi
+if [[ ! -x "$aos_binary" ]]; then
+  echo "AOS binary is missing or not executable: $aos_binary" >&2
+  exit 1
+fi
+if [[ ! -f "$runtime_archive" ]]; then
+  echo "runtime archive is missing: $runtime_archive" >&2
+  exit 1
+fi
+if [[ ! "$runtime_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "runtime SHA-256 is malformed" >&2
+  exit 1
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/runtime-extract" "$work/$root/bin" "$work/$root/runtime/bin" "$output_dir"
+
+if tar -tzf "$runtime_archive" | awk -v root="astrid-${runtime_version}-${target}" '
+  /^\// || /(^|\/)\.\.($|\/)/ { unsafe = 1 }
+  $0 != root && index($0, root "/") != 1 { unsafe = 1 }
+  END { exit unsafe ? 0 : 1 }
+'; then
+  echo "runtime archive contains an unsafe or unexpected path" >&2
+  exit 1
+fi
+if tar -tvzf "$runtime_archive" | awk '
+  substr($1, 1, 1) != "-" && substr($1, 1, 1) != "d" { unsafe = 1 }
+  END { exit unsafe ? 0 : 1 }
+'; then
+  echo "runtime archive contains a link or special file" >&2
+  exit 1
+fi
+tar -xzf "$runtime_archive" -C "$work/runtime-extract"
+
+runtime_root="$work/runtime-extract/astrid-${runtime_version}-${target}"
+if [[ ! -d "$runtime_root" ]]; then
+  echo "runtime archive has no expected root astrid-${runtime_version}-${target}" >&2
+  exit 1
+fi
+
+install -m 0755 "$aos_binary" "$work/$root/bin/aos"
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  if [[ ! -x "$runtime_root/$binary" ]]; then
+    echo "runtime archive is missing $binary" >&2
+    exit 1
+  fi
+  install -m 0755 "$runtime_root/$binary" "$work/$root/runtime/bin/$binary"
+done
+
+install -m 0644 "$repo_root/release/runtime-compatibility.toml" "$work/$root/runtime-compatibility.toml"
+install -m 0644 "$repo_root/distros/community/unicity-ce/Distro.toml" "$work/$root/Distro.toml"
+install -m 0644 "$repo_root/README.md" "$work/$root/README.md"
+
+python3 - "$work/$root/release-manifest.json" "$product_version" "$target" "$runtime_repository" "$runtime_version" "$runtime_tag" "$runtime_sha256" "$runtime_identity" "$wit_repository" "$wit_commit" "$sdk_rust_version" "$sdk_rust_commit" <<'PY'
+import json
+import pathlib
+import sys
+
+path, product, target, runtime_repo, runtime, tag, digest, runtime_identity, wit_repo, wit_commit, sdk_version, sdk_commit = sys.argv[1:]
+manifest = {
+    "schema_version": 1,
+    "product": {"name": "Unicity AOS Community Edition", "version": product},
+    "target": target,
+    "runtime": {
+        "repository": runtime_repo,
+        "version": runtime,
+        "tag": tag,
+        "asset": f"astrid-{runtime}-{target}.tar.gz",
+        "sha256": digest,
+        "release_workflow_identity": runtime_identity,
+    },
+    "contracts": {
+        "repository": wit_repo,
+        "commit": wit_commit,
+        "sdk_rust_version": sdk_version,
+        "sdk_rust_commit": sdk_commit,
+    },
+}
+pathlib.Path(path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+
+tar -czf "$output_dir/$asset" -C "$work" "$root"
+echo "$output_dir/$asset"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+fixture="$work/fixture"
+fake_bin="$work/fake-bin"
+mkdir -p "$fixture" "$fake_bin" "$work/home"
+mkdir -p "$work/home/.astrid"
+printf 'standalone-runtime-state\n' > "$work/home/.astrid/sentinel"
+
+cat > "$work/aos" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = --version ]; then
+  echo 'Unicity AOS 2026.1.0'
+  exit 0
+fi
+exit 0
+EOF
+chmod 755 "$work/aos"
+
+runtime_root="$work/astrid-0.9.4-x86_64-unknown-linux-gnu"
+mkdir -p "$runtime_root"
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  printf '#!/bin/sh\necho %s\n' "$binary" > "$runtime_root/$binary"
+  chmod 755 "$runtime_root/$binary"
+done
+tar -czf "$work/runtime.tar.gz" -C "$work" "$(basename "$runtime_root")"
+"$repo_root/scripts/package-release.sh" \
+  x86_64-unknown-linux-gnu \
+  "$work/aos" \
+  "$work/runtime.tar.gz" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$fixture" >/dev/null
+(
+  cd "$fixture"
+  asset=unicity-aos-x86_64-unknown-linux-gnu.tar.gz
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$asset" > SHA256SUMS.txt
+  else
+    shasum -a 256 "$asset" > SHA256SUMS.txt
+  fi
+)
+: > "$fixture/unicity-aos-x86_64-unknown-linux-gnu.tar.gz.sigstore.json"
+
+cat > "$fake_bin/uname" <<'EOF'
+#!/bin/sh
+case "${1:-}" in
+  -s) echo Linux ;;
+  -m) echo x86_64 ;;
+  *) exit 2 ;;
+esac
+EOF
+
+cat > "$fake_bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+output=
+url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output=$2; shift ;;
+    http*) url=$1 ;;
+  esac
+  shift
+done
+[ -n "$output" ]
+[ -n "$url" ]
+cp "$AOS_TEST_FIXTURE/$(basename "$url")" "$output"
+EOF
+cat > "$fake_bin/cosign" <<'EOF'
+#!/bin/sh
+set -eu
+[ "${1:-}" = verify-blob ]
+: > "$AOS_TEST_FIXTURE/cosign-called"
+EOF
+chmod 755 "$fake_bin/uname" "$fake_bin/curl" "$fake_bin/cosign"
+
+PATH="$fake_bin:$PATH" \
+HOME="$work/home" \
+AOS_TEST_FIXTURE="$fixture" \
+AOS_VERSION=2026.1.0 \
+sh "$repo_root/install.sh" --yes --no-migrate-prompt
+
+test -x "$work/home/.unicity-os/bin/aos"
+test -x "$work/home/.unicity-os/runtime/bin/astrid-daemon"
+test -f "$work/home/.unicity-os/releases/2026.1.0.json"
+test "$("$work/home/.unicity-os/bin/aos" --version)" = 'Unicity AOS 2026.1.0'
+test "$(cat "$work/home/.astrid/sentinel")" = 'standalone-runtime-state'
+test -f "$fixture/cosign-called"
+test "$(stat -c '%a' "$work/home/.unicity-os" 2>/dev/null || stat -f '%Lp' "$work/home/.unicity-os")" = 700
+test "$(stat -c '%a' "$work/home/.unicity-os/releases/2026.1.0.json" 2>/dev/null || stat -f '%Lp' "$work/home/.unicity-os/releases/2026.1.0.json")" = 600
+
+# Exercise the no-preinstalled-cosign path without downloading the 140 MB real
+# verifier. The production digest stays hard-coded; only this fake hash command
+# substitutes that digest for the tiny fixture executable.
+bootstrap_bin="$work/bootstrap-bin"
+mkdir "$bootstrap_bin"
+if command -v sha256sum >/dev/null 2>&1; then
+  real_hash=$(command -v sha256sum)
+  hash_kind=sha256sum
+else
+  real_hash=$(command -v shasum)
+  hash_kind=shasum
+fi
+cat > "$bootstrap_bin/sha256sum" <<'EOF'
+#!/bin/sh
+set -eu
+case "$1" in
+  */cosign)
+    printf '%s  %s\n' ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc "$1"
+    ;;
+  *)
+    if [ "$HASH_KIND" = shasum ]; then
+      exec "$REAL_HASH" -a 256 "$@"
+    fi
+    exec "$REAL_HASH" "$@"
+    ;;
+esac
+EOF
+chmod 755 "$bootstrap_bin/sha256sum"
+mv "$fake_bin/cosign" "$fixture/cosign-linux-amd64"
+rm -f "$fixture/cosign-called"
+PATH="$bootstrap_bin:$fake_bin:/usr/bin:/bin" \
+HOME="$work/bootstrap-home" \
+AOS_TEST_FIXTURE="$fixture" \
+AOS_VERSION=2026.1.0 \
+REAL_HASH="$real_hash" \
+HASH_KIND="$hash_kind" \
+sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
+test -f "$fixture/cosign-called"
+mv "$fixture/cosign-linux-amd64" "$fake_bin/cosign"
+
+cp "$fixture/SHA256SUMS.txt" "$work/good-sums"
+printf '%064d  unicity-aos-x86_64-unknown-linux-gnu.tar.gz\n' 1 > "$fixture/SHA256SUMS.txt"
+if PATH="$fake_bin:$PATH" HOME="$work/other-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a bad checksum" >&2
+  exit 1
+fi
+cp "$work/good-sums" "$fixture/SHA256SUMS.txt"
+
+for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
+  case "$binary" in
+    aos) destination="$work/home/.unicity-os/bin/aos" ;;
+    *) destination="$work/home/.unicity-os/runtime/bin/$binary" ;;
+  esac
+  printf '#!/bin/sh\necho old-%s\n' "$binary" > "$destination"
+  chmod 755 "$destination"
+done
+printf 'old-release-manifest\n' > "$work/home/.unicity-os/releases/2026.1.0.json"
+
+fail_bin="$work/fail-bin"
+mkdir "$fail_bin"
+cat > "$fail_bin/mv" <<'EOF'
+#!/bin/sh
+set -eu
+last=
+for argument in "$@"; do last=$argument; done
+case "$last" in
+  */runtime/bin/astrid-daemon)
+    if [ ! -f "$MV_FAILED" ]; then
+      : > "$MV_FAILED"
+      exit 1
+    fi
+    ;;
+esac
+exec "$REAL_MV" "$@"
+EOF
+chmod 755 "$fail_bin/mv"
+real_mv=$(command -v mv)
+if PATH="$fail_bin:$fake_bin:$PATH" \
+  HOME="$work/home" \
+  AOS_TEST_FIXTURE="$fixture" \
+  AOS_VERSION=2026.1.0 \
+  REAL_MV="$real_mv" \
+  MV_FAILED="$work/mv-failed" \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer ignored a mid-install failure" >&2
+  exit 1
+fi
+for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
+  case "$binary" in
+    aos) destination="$work/home/.unicity-os/bin/aos" ;;
+    *) destination="$work/home/.unicity-os/runtime/bin/$binary" ;;
+  esac
+  test "$("$destination")" = "old-$binary"
+done
+test "$(cat "$work/home/.unicity-os/releases/2026.1.0.json")" = old-release-manifest
+test "$(cat "$work/home/.astrid/sentinel")" = standalone-runtime-state
+
+cat > "$work/aos-mismatch" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = --version ]; then
+  echo 'Unicity AOS 2026.2.0'
+fi
+EOF
+chmod 755 "$work/aos-mismatch"
+"$repo_root/scripts/package-release.sh" \
+  x86_64-unknown-linux-gnu \
+  "$work/aos-mismatch" \
+  "$work/runtime.tar.gz" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$fixture" >/dev/null
+(
+  cd "$fixture"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum unicity-aos-x86_64-unknown-linux-gnu.tar.gz > SHA256SUMS.txt
+  else
+    shasum -a 256 unicity-aos-x86_64-unknown-linux-gnu.tar.gz > SHA256SUMS.txt
+  fi
+)
+if PATH="$fake_bin:$PATH" HOME="$work/mismatch-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a bundle whose binary version did not match the requested release" >&2
+  exit 1
+fi
+test ! -e "$work/mismatch-home/.unicity-os"
+
+unsafe_root="$work/unsafe-bundle/unicity-aos-2026.1.0-x86_64-unknown-linux-gnu"
+mkdir -p "$unsafe_root/bin" "$unsafe_root/runtime/bin"
+ln -s "$work/aos" "$unsafe_root/bin/aos"
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  cp "$runtime_root/$binary" "$unsafe_root/runtime/bin/$binary"
+done
+printf '{}\n' > "$unsafe_root/release-manifest.json"
+tar -czf "$fixture/unicity-aos-x86_64-unknown-linux-gnu.tar.gz" \
+  -C "$work/unsafe-bundle" "$(basename "$unsafe_root")"
+(
+  cd "$fixture"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum unicity-aos-x86_64-unknown-linux-gnu.tar.gz > SHA256SUMS.txt
+  else
+    shasum -a 256 unicity-aos-x86_64-unknown-linux-gnu.tar.gz > SHA256SUMS.txt
+  fi
+)
+if PATH="$fake_bin:$PATH" HOME="$work/unsafe-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a symlink in the release archive" >&2
+  exit 1
+fi
+test ! -e "$work/unsafe-home/.unicity-os"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+python3 "$repo_root/scripts/validate-release-contract.py"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+target=x86_64-unknown-linux-gnu
+runtime_root="$work/astrid-0.9.4-$target"
+mkdir -p "$runtime_root" "$work/output"
+
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  printf '#!/bin/sh\nexit 0\n' > "$runtime_root/$binary"
+  chmod 755 "$runtime_root/$binary"
+done
+tar -czf "$work/runtime.tar.gz" -C "$work" "$(basename "$runtime_root")"
+printf '#!/bin/sh\nexit 0\n' > "$work/aos"
+chmod 755 "$work/aos"
+
+"$repo_root/scripts/package-release.sh" \
+  "$target" \
+  "$work/aos" \
+  "$work/runtime.tar.gz" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$work/output"
+
+archive="$work/output/unicity-aos-$target.tar.gz"
+test -f "$archive"
+tar -tzf "$archive" > "$work/files"
+grep -q '/bin/aos$' "$work/files"
+grep -q '/runtime/bin/astrid-daemon$' "$work/files"
+grep -q '/release-manifest.json$' "$work/files"
+
+tar -xzf "$archive" -C "$work"
+manifest=$(find "$work" -path '*/release-manifest.json' -print -quit)
+python3 - "$manifest" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert manifest["product"]["version"] == "2026.1.0"
+assert manifest["runtime"]["version"] == "0.9.4"
+assert manifest["runtime"]["sha256"] == "0" * 64
+assert manifest["runtime"]["release_workflow_identity"] == "https://github.com/unicity-astrid/astrid/.github/workflows/release.yml@refs/tags/v0.9.4"
+assert manifest["contracts"]["repository"] == "astrid-runtime/wit"
+assert manifest["contracts"]["commit"] == "278dbca3e32f327d0f2358644fc86559779ba0fd"
+assert manifest["contracts"]["sdk_rust_version"] == "0.7.1"
+assert manifest["contracts"]["sdk_rust_commit"] == "bbbc61c8821d6c536fb25d2068b6b646e759ad35"
+PY
+
+unsafe_root="$work/unsafe-runtime"
+mkdir -p "$unsafe_root/astrid-0.9.4-$target"
+ln -s /tmp "$unsafe_root/astrid-0.9.4-$target/astrid"
+for binary in astrid-daemon astrid-build astrid-emit; do
+  printf '#!/bin/sh\nexit 0\n' > "$unsafe_root/astrid-0.9.4-$target/$binary"
+  chmod 755 "$unsafe_root/astrid-0.9.4-$target/$binary"
+done
+tar -czf "$work/unsafe-runtime.tar.gz" -C "$unsafe_root" "astrid-0.9.4-$target"
+if "$repo_root/scripts/package-release.sh" \
+  "$target" \
+  "$work/aos" \
+  "$work/unsafe-runtime.tar.gz" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$work/output" >/dev/null 2>&1; then
+  echo "release composer accepted a symlinked runtime binary" >&2
+  exit 1
+fi

--- a/scripts/validate-release-contract.py
+++ b/scripts/validate-release-contract.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Validate that every independently published AOS compatibility pin agrees."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def strings(path: str) -> dict[tuple[str, str], str]:
+    """Read the string values used by the release contract's TOML files."""
+    values: dict[tuple[str, str], str] = {}
+    section = ""
+    for line in (ROOT / path).read_text(encoding="utf-8").splitlines():
+        section_match = re.match(r"\s*\[([^]]+)]\s*$", line)
+        if section_match:
+            section = section_match.group(1)
+            continue
+        value_match = re.match(r'\s*([A-Za-z0-9_-]+)\s*=\s*"([^"]*)"', line)
+        if value_match:
+            values[(section, value_match.group(1))] = value_match.group(2)
+    return values
+
+
+def workspace_dependency(values: dict[tuple[str, str], str], name: str) -> str:
+    direct = values.get(("workspace.dependencies", name))
+    if direct is not None:
+        return direct
+    text = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    match = re.search(
+        rf'^\s*{re.escape(name)}\s*=\s*\{{[^\n]*\bversion\s*=\s*"([^"]+)"',
+        text,
+        re.MULTILINE,
+    )
+    if match:
+        return match.group(1)
+    raise ValueError(f"{name} must have an exact workspace version")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def main() -> int:
+    workspace = strings("Cargo.toml")
+    product = strings("crates/unicity-aos-bootstrap/Cargo.toml")
+    distro = strings("distros/community/unicity-ce/Distro.toml")
+    compatibility = strings("release/runtime-compatibility.toml")
+
+    product_version = product[("package", "version")]
+    runtime_version = compatibility[("runtime", "version")]
+    sdk_version = compatibility[("contracts", "sdk-rust-version")]
+
+    require(
+        re.fullmatch(r"20[0-9]{2}\.[0-9]+\.[0-9]+", product_version) is not None,
+        "product version must be calendar semver (YYYY.MINOR.PATCH)",
+    )
+    require(
+        compatibility[("product", "version")] == product_version,
+        "runtime-compatibility product version does not match the AOS crate",
+    )
+    require(
+        distro[("distro", "version")] == product_version,
+        "distro version does not match the AOS crate",
+    )
+    require(
+        compatibility[("runtime", "tag")] == f"v{runtime_version}",
+        "runtime tag does not match the pinned runtime version",
+    )
+    require(
+        compatibility[("runtime", "version-requirement")] == f"={runtime_version}",
+        "runtime version requirement must be an exact pin",
+    )
+    require(
+        distro[("distro", "astrid-version")] == f"={runtime_version}",
+        "distro Astrid requirement does not match the bundled runtime",
+    )
+    for dependency in ("astrid-core", "astrid-uplink"):
+        require(
+            workspace_dependency(workspace, dependency) == f"={runtime_version}",
+            f"workspace {dependency} must exactly pin the bundled runtime",
+        )
+    require(
+        workspace_dependency(workspace, "astrid-sdk") == f"={sdk_version}",
+        "workspace astrid-sdk must exactly pin compatibility metadata",
+    )
+    require(
+        re.fullmatch(r"[0-9a-f]{40}", compatibility[("contracts", "commit")])
+        is not None,
+        "WIT compatibility commit must be a full lowercase Git commit",
+    )
+    require(
+        re.fullmatch(
+            r"[0-9a-f]{40}", compatibility[("contracts", "sdk-rust-commit")]
+        )
+        is not None,
+        "SDK compatibility commit must be a full lowercase Git commit",
+    )
+    identity = compatibility[("runtime", "release-workflow-identity")]
+    require(
+        re.fullmatch(
+            rf"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/\.github/workflows/release\.yml@refs/tags/v{re.escape(runtime_version)}",
+            identity,
+        )
+        is not None,
+        "runtime Sigstore identity must be a GitHub release workflow at the pinned tag",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (KeyError, TypeError, ValueError) as error:
+        print(f"release contract: {error}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

- add the coordinated `2026.1.0` AOS release pipeline for macOS and Linux
- package the `aos` product command with the exact signed Astrid Runtime `v0.9.4` executable set
- publish checksums, Sigstore bundles, build-provenance attestations, and machine-readable compatibility metadata
- add the idempotent installer and `aos self-update` path with transactional rollback
- pin runtime, SDK, WIT, distribution, and product compatibility as one validated release contract
- preserve standalone Astrid state and the deliberate product-state import workflow

## Provenance

Astrid `v0.9.4` was signed before the repository moved organizations. Its immutable Sigstore identity is therefore the historical `unicity-astrid/astrid` release workflow; the release contract records and verifies that exact identity.

## Validation

- `python3 scripts/validate-release-contract.py`
- `bash scripts/test-package-release.sh`
- `bash scripts/test-install.sh`
- `shellcheck install.sh scripts/*.sh`
- `actionlint`
- `cargo test --locked -p unicity-aos-bootstrap` (32 library tests, 2 binary tests)
- `cargo fmt --all -- --check`
- `cargo clippy --locked -p unicity-aos-bootstrap --all-targets -- -D warnings`
- `cargo check --locked --workspace`
- native optimized packaging smoke with the real Astrid `v0.9.4` ARM macOS archive

## Release gate

Merging this PR does not publish `2026.1.0`. The signed product tag is created only after the branch is green; the release workflow then exercises all four target builds and produces the release assets consumed by the installer and Homebrew tap.
