### PR TITLE
Publish signed Community capsule assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
       - run: sh -n install.sh
       - run: python3 scripts/validate-release-contract.py
       - run: bash scripts/test-package-release.sh
       - run: bash scripts/test-install.sh
+      - run: python3 scripts/capsule_release.py
+      - run: python3 scripts/test_capsule_release.py
+      - run: python3 scripts/test_validate_runtime_archive.py
+      - run: bash scripts/test-extract-runtime-tool.sh
 
   community-wasm:
     name: Community WASM
@@ -65,6 +72,18 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo test --locked -p unicity-aos-bootstrap
       - run: cargo clippy --locked -p unicity-aos-bootstrap -- -D warnings
+
+  capsule-tests:
+    name: Capsule host tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: "1.95.0"
+          targets: x86_64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo test --locked --workspace --exclude astrid-capsule-telegram --exclude unicity-aos-bootstrap --target x86_64-unknown-linux-gnu
 
   telegram-wasi:
     name: Telegram WASI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
       - name: Match product, distro, and tag versions
         run: |
           python3 scripts/validate-release-contract.py
@@ -28,6 +31,10 @@ jobs:
           test "$PRODUCT" = "$GITHUB_REF_NAME"
       - run: bash scripts/test-package-release.sh
       - run: bash scripts/test-install.sh
+      - run: python3 scripts/capsule_release.py
+      - run: python3 scripts/test_capsule_release.py
+      - run: python3 scripts/test_validate_runtime_archive.py
+      - run: bash scripts/test-extract-runtime-tool.sh
       - run: sh -n install.sh
 
   build:
@@ -51,6 +58,9 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: '1.95.0'
@@ -115,9 +125,74 @@ jobs:
           name: aos-${{ matrix.target }}
           path: artifacts/*.tar.gz
 
+  capsules:
+    name: Build Community capsules
+    needs: validate-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: '1.95.0'
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: aos-release-capsules
+      - name: Load runtime compatibility pins
+        run: |
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import tomllib
+          with open("release/runtime-compatibility.toml", "rb") as file:
+              metadata = tomllib.load(file)["runtime"]
+          print(f"RUNTIME_VERSION={metadata['version']}")
+          print(f"RUNTIME_TAG={metadata['tag']}")
+          print(f"RUNTIME_REPOSITORY={metadata['repository']}")
+          print(f"RUNTIME_IDENTITY={metadata['release-workflow-identity']}")
+          PY
+      - name: Download pinned runtime builder
+        run: |
+          TARGET=x86_64-unknown-linux-gnu
+          ASSET="astrid-${RUNTIME_VERSION}-${TARGET}.tar.gz"
+          BASE="https://github.com/${RUNTIME_REPOSITORY}/releases/download/${RUNTIME_TAG}"
+          curl --proto '=https' --tlsv1.2 -fsSLO "$BASE/$ASSET"
+          curl --proto '=https' --tlsv1.2 -fsSLO "$BASE/SHA256SUMS.txt"
+          curl --proto '=https' --tlsv1.2 -fsSLo "$ASSET.sigstore.json" "$BASE/$ASSET.sigstore.json"
+          EXPECTED=$(awk -v asset="$ASSET" '$2 == asset { print $1; exit }' SHA256SUMS.txt)
+          test -n "$EXPECTED"
+          echo "$EXPECTED  $ASSET" | sha256sum -c -
+          echo "RUNTIME_ASSET=$ASSET" >> "$GITHUB_ENV"
+          echo "RUNTIME_TARGET=$TARGET" >> "$GITHUB_ENV"
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Verify runtime builder identity
+        run: |
+          cosign verify-blob \
+            --bundle "$RUNTIME_ASSET.sigstore.json" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity "$RUNTIME_IDENTITY" \
+            "$RUNTIME_ASSET"
+      - name: Build installable capsule assets
+        run: |
+          scripts/extract-runtime-tool.sh \
+            "$RUNTIME_ASSET" \
+            "$RUNTIME_VERSION" \
+            "$RUNTIME_TARGET" \
+            astrid-build \
+            "$RUNNER_TEMP/astrid-build"
+          scripts/build-capsule-assets.sh "$RUNNER_TEMP/astrid-build" artifacts
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: aos-community-capsules
+          path: artifacts/*.capsule
+
   github-release:
     name: Publish signed release
-    needs: build
+    needs: [build, capsules]
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -129,6 +204,9 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
       - name: Load runtime compatibility pins
         run: |
           python3 - <<'PY' >> "$GITHUB_ENV"
@@ -140,17 +218,26 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
-          pattern: aos-*
+          pattern: aos-*-*-*
           merge-multiple: true
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: capsule-artifacts
+          name: aos-community-capsules
+      - name: Validate downloaded capsule set
+        run: |
+          python3 scripts/capsule_release.py --artifacts capsule-artifacts
+          cp capsule-artifacts/*.capsule artifacts/
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum -- ./*.tar.gz | sed 's#  \./#  #' > SHA256SUMS.txt
+          sha256sum -- ./*.tar.gz ./*.capsule | sed 's#  \./#  #' > SHA256SUMS.txt
           cp ../release/runtime-compatibility.toml .
       - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: |
             artifacts/*.tar.gz
+            artifacts/*.capsule
             artifacts/SHA256SUMS.txt
             artifacts/runtime-compatibility.toml
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -159,7 +246,7 @@ jobs:
           COSIGN_YES: 'true'
         run: |
           cd artifacts
-          for asset in ./*.tar.gz SHA256SUMS.txt runtime-compatibility.toml; do
+          for asset in ./*.tar.gz ./*.capsule SHA256SUMS.txt runtime-compatibility.toml; do
             cosign sign-blob --yes --bundle "${asset}.sigstore.json" "$asset"
           done
       - name: Write release notes
@@ -168,6 +255,8 @@ jobs:
           Unicity AOS Community Edition ${GITHUB_REF_NAME}.
 
           This product release bundles Astrid Runtime ${RUNTIME_TAG}. The exact runtime release identity, WIT commit, and compatibility pins are published in \`runtime-compatibility.toml\` and in every archive's \`release-manifest.json\`.
+
+          The release also contains the 18 signed, installable capsule artifacts selected by Community Edition. Published \`astrid-capsule-*\` identities remain unchanged.
 
           Install or upgrade:
 
@@ -179,6 +268,7 @@ jobs:
         with:
           files: |
             artifacts/*.tar.gz
+            artifacts/*.capsule
             artifacts/SHA256SUMS.txt
             artifacts/runtime-compatibility.toml
             artifacts/*.sigstore.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+__pycache__/
+*.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2026.1.0] - 2026-07-14
+## [2026.1.0] - Unreleased
 
 ### Added
 
@@ -10,3 +10,7 @@
   GitHub build-provenance attestations, and explicit runtime/WIT compatibility metadata.
 - An idempotent product installer and updater that preserve runtime state while
   replacing the coordinated AOS and Astrid executable set.
+- A signed release path for the 18 installable `astrid-capsule-*` artifacts
+  selected by Community Edition, with exact source/manifest identity checks,
+  archive safety validation, checksums, Sigstore bundles, and provenance.
+- Host-target unit-test coverage for the capsule workspace.

--- a/capsules/capsule-prompt-builder/src/lib.rs
+++ b/capsules/capsule-prompt-builder/src/lib.rs
@@ -25,6 +25,31 @@
 use astrid_sdk::prelude::*;
 use serde::{Deserialize, Serialize};
 
+#[cfg(target_arch = "wasm32")]
+use astrid_sdk::log as runtime_log;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod host_log {
+    pub(super) fn debug(message: impl AsRef<str>) {
+        eprintln!("DEBUG: {}", message.as_ref());
+    }
+
+    pub(super) fn info(message: impl AsRef<str>) {
+        eprintln!("INFO: {}", message.as_ref());
+    }
+
+    pub(super) fn warn(message: impl AsRef<str>) {
+        eprintln!("WARN: {}", message.as_ref());
+    }
+
+    pub(super) fn error(message: impl AsRef<str>) {
+        eprintln!("ERROR: {}", message.as_ref());
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+use host_log as runtime_log;
+
 /// Runtime configuration loaded from capsule config at startup.
 struct Config {
     /// Maximum time (in milliseconds) to wait for plugin hook responses — the
@@ -223,7 +248,7 @@ fn filter_by_permission(
                     || s.response.prepend_system_context.is_some()
                     || s.response.append_system_context.is_some()
                 {
-                    log::warn(format!(
+                    runtime_log::warn(format!(
                         "Stripped prompt-mutating fields from capsule {:?} \
                          (missing allow_prompt_injection capability)",
                         s.source_id
@@ -316,7 +341,7 @@ fn fire_before_prompt_build(request: &AssembleRequest, config: &Config) -> Vec<H
     let sub = match ipc::subscribe(&response_topic) {
         Ok(h) => h,
         Err(e) => {
-            log::error(format!("Failed to subscribe to hook response topic: {e}"));
+            runtime_log::error(format!("Failed to subscribe to hook response topic: {e}"));
             return Vec::new();
         }
     };
@@ -331,7 +356,7 @@ fn fire_before_prompt_build(request: &AssembleRequest, config: &Config) -> Vec<H
     };
 
     if let Err(e) = ipc::publish_json("prompt_builder.v1.hook.before_build", &payload) {
-        log::error(format!(
+        runtime_log::error(format!(
             "Failed to publish prompt_builder.v1.hook.before_build event: {e}"
         ));
         // sub dropped on return — kernel-side resource released automatically.
@@ -391,7 +416,7 @@ fn fire_before_prompt_build(request: &AssembleRequest, config: &Config) -> Vec<H
 
     // sub drops here, releasing the kernel-side subscription.
 
-    log::info(format!(
+    runtime_log::info(format!(
         "Collected {} hook responses for request {}",
         sourced_responses.len(),
         request.request_id
@@ -407,7 +432,7 @@ fn fire_before_prompt_build(request: &AssembleRequest, config: &Config) -> Vec<H
         *cache.entry(uuid.to_owned()).or_insert_with(|| {
             capabilities::check(uuid, "allow_prompt_injection")
                 .inspect_err(|e| {
-                    log::warn(format!("capability check failed for {uuid}: {e}, denying"));
+                    runtime_log::warn(format!("capability check failed for {uuid}: {e}, denying"));
                 })
                 .unwrap_or(false)
         })
@@ -419,7 +444,7 @@ fn parse_hook_message(msg: &ipc::Message) -> Option<Vec<SourcedHookResponse>> {
     let payload: serde_json::Value = match serde_json::from_str(&msg.payload) {
         Ok(v) => v,
         Err(e) => {
-            log::warn(format!("failed to deserialize hook response payload: {e}"));
+            runtime_log::warn(format!("failed to deserialize hook response payload: {e}"));
             return None;
         }
     };
@@ -462,7 +487,7 @@ fn parse_hook_responses(poll_bytes: &[u8]) -> Option<Vec<SourcedHookResponse>> {
     let envelope: serde_json::Value = match serde_json::from_slice(poll_bytes) {
         Ok(v) => v,
         Err(e) => {
-            log::warn(format!("failed to deserialize hook response envelope: {e}"));
+            runtime_log::warn(format!("failed to deserialize hook response envelope: {e}"));
             return None;
         }
     };
@@ -528,7 +553,7 @@ const TOOL_SCHEMA_CACHE_KEY: &str = "__tool_schema_cache";
 /// serving a stale (KV-persisted, restart-surviving) list.
 fn invalidate_tool_cache() {
     let _ = kv::delete(TOOL_SCHEMA_CACHE_KEY);
-    log::info("Tool schema cache invalidated");
+    runtime_log::info("Tool schema cache invalidated");
 }
 
 /// Timeout (ms) for fetching session messages from the session capsule.
@@ -558,7 +583,7 @@ fn collect_tool_schemas() -> Vec<serde_json::Value> {
     if let Ok(cached) = kv::get_json::<Vec<serde_json::Value>>(TOOL_SCHEMA_CACHE_KEY)
         && !cached.is_empty()
     {
-        log::debug(format!("Returning {} cached tool schemas", cached.len()));
+        runtime_log::debug(format!("Returning {} cached tool schemas", cached.len()));
         return cached;
     }
 
@@ -566,7 +591,7 @@ fn collect_tool_schemas() -> Vec<serde_json::Value> {
     let sub = match ipc::subscribe("tool.v1.response.describe.*") {
         Ok(s) => s,
         Err(e) => {
-            log::error(format!(
+            runtime_log::error(format!(
                 "Failed to subscribe to tool.v1.response.describe.*: {e}"
             ));
             return Vec::new();
@@ -576,7 +601,7 @@ fn collect_tool_schemas() -> Vec<serde_json::Value> {
     // Fire the fan-out request. Empty payload — every responder publishes its
     // own tool schema set onto `tool.v1.response.describe.<source_id>`.
     if let Err(e) = ipc::publish("tool.v1.request.describe", "{}") {
-        log::error(format!("Failed to publish tool.v1.request.describe: {e}"));
+        runtime_log::error(format!("Failed to publish tool.v1.request.describe: {e}"));
         return Vec::new();
     }
 
@@ -622,14 +647,14 @@ fn collect_tool_schemas() -> Vec<serde_json::Value> {
         }
     });
 
-    log::info(format!(
+    runtime_log::info(format!(
         "Collected {} tool schemas via tool.v1.request.describe fan-out",
         all_tools.len()
     ));
 
     // Cache the result for subsequent calls.
     if let Err(e) = kv::set_json(TOOL_SCHEMA_CACHE_KEY, &all_tools) {
-        log::warn(format!("Failed to cache tool schemas in KV: {e}"));
+        runtime_log::warn(format!("Failed to cache tool schemas in KV: {e}"));
     }
 
     all_tools
@@ -669,7 +694,7 @@ fn fetch_session_messages(session_id: &str) -> Vec<serde_json::Value> {
     ) {
         Ok(v) => v,
         Err(e) => {
-            log::warn(format!(
+            runtime_log::warn(format!(
                 "session.v1.request.get_messages failed (timeout={SESSION_FETCH_TIMEOUT_MS}ms): {e}"
             ));
             return Vec::new();
@@ -684,16 +709,16 @@ fn fetch_session_messages(session_id: &str) -> Vec<serde_json::Value> {
     let result = match messages_value {
         Some(messages) => serde_json::from_value::<Vec<serde_json::Value>>(messages.clone())
             .unwrap_or_else(|e| {
-                log::warn(format!("Failed to parse session messages array: {e}"));
+                runtime_log::warn(format!("Failed to parse session messages array: {e}"));
                 Vec::new()
             }),
         None => {
-            log::warn("Session response missing `messages` field");
+            runtime_log::warn("Session response missing `messages` field");
             Vec::new()
         }
     };
 
-    log::debug(format!(
+    runtime_log::debug(format!(
         "Fetched {} session messages for session {session_id}",
         result.len()
     ));
@@ -709,7 +734,7 @@ fn assemble(payload: &serde_json::Value, config: &Config) {
     let request: AssembleRequest = match serde_json::from_value(request_value.clone()) {
         Ok(r) => r,
         Err(e) => {
-            log::error(format!("Failed to parse assemble request: {e}"));
+            runtime_log::error(format!("Failed to parse assemble request: {e}"));
             let _ = ipc::publish_json(
                 "prompt_builder.v1.response.assemble",
                 &serde_json::json!({"error": format!("invalid request: {e}")}),

--- a/release/community-capsules.txt
+++ b/release/community-capsules.txt
@@ -1,0 +1,22 @@
+# Community Edition capsule release allowlist.
+#
+# Keep this in distro order. Published artifact identities come from each
+# capsule's Cargo.toml/Capsule.toml and remain astrid-capsule-*.
+capsule-cli
+capsule-registry
+capsule-openai-compat
+capsule-react
+capsule-session
+capsule-identity
+capsule-users
+capsule-router
+capsule-prompt-builder
+capsule-context-engine
+capsule-hook-bridge
+capsule-shell
+capsule-http
+capsule-fs
+capsule-system
+capsule-skills
+capsule-agents
+capsule-memory

--- a/scripts/build-capsule-assets.sh
+++ b/scripts/build-capsule-assets.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <astrid-build> <output-dir>" >&2
+  exit 2
+fi
+
+builder=$1
+output_dir=$2
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+if [[ "$builder" == */* ]]; then
+  if [[ ! -x "$builder" ]]; then
+    echo "astrid-build is missing or not executable: $builder" >&2
+    exit 1
+  fi
+  builder=$(cd "$(dirname "$builder")" && pwd)/$(basename "$builder")
+else
+  builder=$(command -v "$builder" || true)
+  if [[ -z "$builder" ]]; then
+    echo "astrid-build is not on PATH" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$output_dir"
+output_dir=$(cd "$output_dir" && pwd)
+if [[ -n "$(find "$output_dir" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+  echo "capsule output directory must be empty: $output_dir" >&2
+  exit 1
+fi
+
+lock_hash() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$repo_root/Cargo.lock" | awk '{print $1}'
+  else
+    shasum -a 256 "$repo_root/Cargo.lock" | awk '{print $1}'
+  fi
+}
+
+python3 "$repo_root/scripts/capsule_release.py"
+before_lock=$(lock_hash)
+before_source=$(git -C "$repo_root" status --porcelain --untracked-files=all -- \
+  Cargo.lock Cargo.toml capsules distros release)
+plan=$(mktemp)
+trap 'rm -f "$plan"' EXIT
+python3 "$repo_root/scripts/capsule_release.py" --print-build-plan > "$plan"
+
+while IFS=$'\t' read -r directory package; do
+  [[ -n "$directory" && -n "$package" ]]
+  RUSTUP_TOOLCHAIN=1.95.0 "$builder" \
+    "$repo_root/capsules/$directory" \
+    --output "$output_dir"
+  test -f "$output_dir/$package.capsule"
+done < "$plan"
+
+after_lock=$(lock_hash)
+if [[ "$before_lock" != "$after_lock" ]]; then
+  echo "capsule builds changed Cargo.lock; release builds must use the committed lock" >&2
+  exit 1
+fi
+
+after_source=$(git -C "$repo_root" status --porcelain --untracked-files=all -- \
+  Cargo.lock Cargo.toml capsules distros release)
+if [[ "$before_source" != "$after_source" ]]; then
+  echo "capsule builds changed source, manifests, WIT, distro, or release policy" >&2
+  diff -u <(printf '%s\n' "$before_source") <(printf '%s\n' "$after_source") >&2 || true
+  exit 1
+fi
+
+python3 "$repo_root/scripts/capsule_release.py" --artifacts "$output_dir"

--- a/scripts/capsule_release.py
+++ b/scripts/capsule_release.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Validate the Community Edition capsule source and release artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import re
+import stat
+import sys
+import tarfile
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 and older
+    import tomli as tomllib
+
+
+ROOT = Path(__file__).resolve().parent.parent
+POLICY = ROOT / "release" / "community-capsules.txt"
+DISTRO = ROOT / "distros" / "community" / "unicity-ce" / "Distro.toml"
+
+
+class ContractError(RuntimeError):
+    """The capsule release contract is inconsistent or unsafe."""
+
+
+@dataclass(frozen=True)
+class CapsuleSpec:
+    directory: str
+    package: str
+    version: str
+    components: tuple[str, ...]
+    manifest: Path
+
+    @property
+    def asset(self) -> str:
+        return f"{self.package}.capsule"
+
+
+def load_toml(path: Path) -> dict:
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ContractError(f"cannot parse {path}: {error}") from error
+
+
+def release_directories() -> list[str]:
+    try:
+        lines = POLICY.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        raise ContractError(f"cannot read {POLICY}: {error}") from error
+
+    directories = [line.strip() for line in lines if line.strip() and not line.lstrip().startswith("#")]
+    if not directories:
+        raise ContractError("community capsule allowlist is empty")
+    if len(directories) != len(set(directories)):
+        raise ContractError("community capsule allowlist contains duplicates")
+    for directory in directories:
+        if not re.fullmatch(r"capsule-[a-z0-9-]+", directory):
+            raise ContractError(f"invalid capsule directory in allowlist: {directory}")
+    return directories
+
+
+def source_contract() -> list[CapsuleSpec]:
+    workspace = load_toml(ROOT / "Cargo.toml").get("workspace", {})
+    members = set(workspace.get("members", []))
+    distro = load_toml(DISTRO)
+    distro_entries = distro.get("capsule", [])
+    if not isinstance(distro_entries, list):
+        raise ContractError(f"{DISTRO}: [[capsule]] entries are missing")
+
+    distro_by_name: dict[str, dict] = {}
+    for entry in distro_entries:
+        name = entry.get("name") if isinstance(entry, dict) else None
+        if not isinstance(name, str) or not name:
+            raise ContractError(f"{DISTRO}: capsule entry has no name")
+        if name in distro_by_name:
+            raise ContractError(f"{DISTRO}: duplicate capsule {name}")
+        distro_by_name[name] = entry
+
+    specs: list[CapsuleSpec] = []
+    for directory in release_directories():
+        member = f"capsules/{directory}"
+        if member not in members:
+            raise ContractError(f"release capsule is not a workspace member: {member}")
+
+        root = ROOT / member
+        cargo_path = root / "Cargo.toml"
+        manifest_path = root / "Capsule.toml"
+        cargo_package = load_toml(cargo_path).get("package", {})
+        manifest = load_toml(manifest_path)
+        manifest_package = manifest.get("package", {})
+
+        cargo_name = cargo_package.get("name")
+        cargo_version = cargo_package.get("version")
+        manifest_name = manifest_package.get("name")
+        manifest_version = manifest_package.get("version")
+        if not all(isinstance(value, str) and value for value in (cargo_name, cargo_version, manifest_name, manifest_version)):
+            raise ContractError(f"{member}: package name/version is incomplete")
+        if cargo_name != manifest_name or cargo_version != manifest_version:
+            raise ContractError(
+                f"{member}: Cargo package {cargo_name} {cargo_version} does not match "
+                f"Capsule package {manifest_name} {manifest_version}"
+            )
+        if not cargo_name.startswith("astrid-capsule-"):
+            raise ContractError(f"{member}: published package identity must remain astrid-capsule-*")
+        expected_name = f"astrid-{directory}"
+        if cargo_name != expected_name:
+            raise ContractError(
+                f"{member}: published package identity must remain {expected_name}, got {cargo_name}"
+            )
+
+        component_entries = manifest.get("component")
+        if not isinstance(component_entries, list) or not component_entries:
+            raise ContractError(f"{manifest_path}: at least one [[component]] is required")
+        components: list[str] = []
+        for component in component_entries:
+            filename = component.get("file") if isinstance(component, dict) else None
+            if (
+                not isinstance(filename, str)
+                or not filename.endswith(".wasm")
+                or PurePosixPath(filename).name != filename
+            ):
+                raise ContractError(f"{manifest_path}: unsafe component filename {filename!r}")
+            components.append(filename)
+        if len(components) != len(set(components)):
+            raise ContractError(f"{manifest_path}: duplicate component filename")
+
+        distro_entry = distro_by_name.get(cargo_name)
+        if distro_entry is None:
+            raise ContractError(f"{member}: {cargo_name} is not selected by Unicity CE")
+        if distro_entry.get("version") != cargo_version:
+            raise ContractError(
+                f"{DISTRO}: {cargo_name} version {distro_entry.get('version')!r} "
+                f"does not match source {cargo_version}"
+            )
+        expected_source = f"@unicity-aos/{directory}"
+        if distro_entry.get("source") != expected_source:
+            raise ContractError(
+                f"{DISTRO}: {cargo_name} source must remain {expected_source!r} until source migration"
+            )
+
+        specs.append(
+            CapsuleSpec(
+                directory=directory,
+                package=cargo_name,
+                version=cargo_version,
+                components=tuple(components),
+                manifest=manifest_path,
+            )
+        )
+
+    expected_names = {spec.package for spec in specs}
+    if set(distro_by_name) != expected_names:
+        missing = sorted(set(distro_by_name) - expected_names)
+        extra = sorted(expected_names - set(distro_by_name))
+        raise ContractError(
+            f"community capsule allowlist and distro differ; unlisted={missing}, not-in-distro={extra}"
+        )
+    return specs
+
+
+def _canonical_member_name(member: tarfile.TarInfo, asset: Path) -> str:
+    """Return the extraction path, rejecting aliases and unsafe names."""
+    name = member.name
+    raw = name[:-1] if member.isdir() and name.endswith("/") else name
+    parts = raw.split("/")
+    path = PurePosixPath(raw)
+    if (
+        not raw
+        or path.is_absolute()
+        or any(part in ("", ".", "..") for part in parts)
+        or path.as_posix() != raw
+    ):
+        raise ContractError(f"{asset}: unsafe or non-canonical archive path {name!r}")
+    return raw
+
+
+def _read_embedded_manifest(archive: tarfile.TarFile, member: tarfile.TarInfo, asset: Path) -> dict:
+    stream = archive.extractfile(member)
+    if stream is None:
+        raise ContractError(f"{asset}: Capsule.toml is not a regular file")
+    try:
+        return tomllib.loads(stream.read().decode("utf-8"))
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+        raise ContractError(f"{asset}: embedded Capsule.toml is invalid: {error}") from error
+
+
+def validate_archive(asset: Path, spec: CapsuleSpec) -> None:
+    try:
+        archive = tarfile.open(asset, mode="r:gz")
+    except (OSError, tarfile.TarError) as error:
+        raise ContractError(f"{asset}: invalid capsule archive: {error}") from error
+
+    with archive:
+        members = archive.getmembers()
+        names: dict[str, tarfile.TarInfo] = {}
+        portability_names: dict[str, str] = {}
+        for member in members:
+            if not (member.isfile() or member.isdir()):
+                raise ContractError(f"{asset}: links and special files are forbidden ({member.name})")
+            canonical_name = _canonical_member_name(member, asset)
+            if canonical_name in names:
+                raise ContractError(f"{asset}: duplicate archive path {canonical_name!r}")
+            portability_name = unicodedata.normalize("NFC", canonical_name).casefold()
+            if portability_name in portability_names:
+                raise ContractError(
+                    f"{asset}: archive paths collide on portable filesystems: "
+                    f"{portability_names[portability_name]!r} and {canonical_name!r}"
+                )
+            names[canonical_name] = member
+            portability_names[portability_name] = canonical_name
+
+        manifest_member = names.get("Capsule.toml")
+        if manifest_member is None or not manifest_member.isfile():
+            raise ContractError(f"{asset}: Capsule.toml is missing")
+        embedded = _read_embedded_manifest(archive, manifest_member, asset)
+        source_manifest = load_toml(spec.manifest)
+        if embedded != source_manifest:
+            raise ContractError(f"{asset}: embedded Capsule.toml does not match source manifest")
+        package = embedded.get("package", {})
+        if package.get("name") != spec.package or package.get("version") != spec.version:
+            raise ContractError(
+                f"{asset}: embedded package identity does not match {spec.package} {spec.version}"
+            )
+
+        embedded_components = embedded.get("component")
+        if not isinstance(embedded_components, list):
+            raise ContractError(f"{asset}: embedded [[component]] entries are missing")
+        component_files = tuple(
+            component.get("file") for component in embedded_components if isinstance(component, dict)
+        )
+        if component_files != spec.components:
+            raise ContractError(f"{asset}: embedded component list does not match source manifest")
+        for component in spec.components:
+            member = names.get(component)
+            if member is None or not member.isfile():
+                raise ContractError(f"{asset}: component {component} is missing")
+
+
+def validate_artifacts(directory: Path, specs: list[CapsuleSpec]) -> None:
+    if directory.is_symlink() or not directory.is_dir():
+        raise ContractError(f"capsule artifact directory does not exist: {directory}")
+    expected = {spec.asset for spec in specs}
+    entries = list(directory.iterdir())
+    invalid = sorted(
+        path.name
+        for path in entries
+        if path.is_symlink() or not stat.S_ISREG(path.lstat().st_mode)
+    )
+    if invalid:
+        raise ContractError(f"capsule artifact directory contains non-regular entries: {invalid}")
+    actual = {path.name for path in entries}
+    if actual != expected:
+        raise ContractError(
+            f"capsule artifact set differs; missing={sorted(expected - actual)}, "
+            f"unexpected={sorted(actual - expected)}"
+        )
+    for spec in specs:
+        validate_archive(directory / spec.asset, spec)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifacts", type=Path, help="validate the exact built .capsule set")
+    parser.add_argument("--print-build-plan", action="store_true", help="print directory and package TSV")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    try:
+        specs = source_contract()
+        args = parse_args(argv)
+        if args.artifacts is not None:
+            validate_artifacts(args.artifacts, specs)
+        if args.print_build_plan:
+            for spec in specs:
+                print(f"{spec.directory}\t{spec.package}")
+    except ContractError as error:
+        print(f"capsule release contract error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/extract-runtime-tool.sh
+++ b/scripts/extract-runtime-tool.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "usage: $0 <runtime-archive> <runtime-version> <target> <tool> <output>" >&2
+  exit 2
+fi
+
+archive=$1
+version=$2
+target=$3
+tool=$4
+output=$5
+root="astrid-${version}-${target}"
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+if [[ ! -f "$archive" ]]; then
+  echo "runtime archive is missing: $archive" >&2
+  exit 1
+fi
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "invalid runtime version: $version" >&2
+  exit 1
+fi
+if [[ ! "$target" =~ ^[A-Za-z0-9_-]+$ || ! "$tool" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  echo "invalid runtime target or tool name" >&2
+  exit 1
+fi
+
+python3 "$repo_root/scripts/validate-runtime-archive.py" "$archive" "$root" "$tool"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+tar -xzf "$archive" -C "$work"
+source="$work/$root/$tool"
+if [[ ! -f "$source" || ! -x "$source" ]]; then
+  echo "runtime archive has no executable $root/$tool" >&2
+  exit 1
+fi
+mkdir -p "$(dirname "$output")"
+install -m 0755 "$source" "$output"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -63,21 +63,10 @@ work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 mkdir -p "$work/runtime-extract" "$work/$root/bin" "$work/$root/runtime/bin" "$output_dir"
 
-if tar -tzf "$runtime_archive" | awk -v root="astrid-${runtime_version}-${target}" '
-  /^\// || /(^|\/)\.\.($|\/)/ { unsafe = 1 }
-  $0 != root && index($0, root "/") != 1 { unsafe = 1 }
-  END { exit unsafe ? 0 : 1 }
-'; then
-  echo "runtime archive contains an unsafe or unexpected path" >&2
-  exit 1
-fi
-if tar -tvzf "$runtime_archive" | awk '
-  substr($1, 1, 1) != "-" && substr($1, 1, 1) != "d" { unsafe = 1 }
-  END { exit unsafe ? 0 : 1 }
-'; then
-  echo "runtime archive contains a link or special file" >&2
-  exit 1
-fi
+python3 "$repo_root/scripts/validate-runtime-archive.py" \
+  "$runtime_archive" \
+  "astrid-${runtime_version}-${target}" \
+  astrid astrid-daemon astrid-build astrid-emit
 tar -xzf "$runtime_archive" -C "$work/runtime-extract"
 
 runtime_root="$work/runtime-extract/astrid-${runtime_version}-${target}"

--- a/scripts/test-extract-runtime-tool.sh
+++ b/scripts/test-extract-runtime-tool.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+version=0.9.4
+target=x86_64-unknown-linux-gnu
+root="astrid-${version}-${target}"
+
+mkdir -p "$work/good/$root"
+printf '#!/bin/sh\nexit 0\n' > "$work/good/$root/astrid-build"
+chmod 755 "$work/good/$root/astrid-build"
+COPYFILE_DISABLE=1 tar -czf "$work/good.tar.gz" -C "$work/good" "$root"
+
+"$repo_root/scripts/extract-runtime-tool.sh" \
+  "$work/good.tar.gz" "$version" "$target" astrid-build "$work/bin/astrid-build"
+test -x "$work/bin/astrid-build"
+
+mkdir -p "$work/unsafe/$root"
+ln -s /tmp "$work/unsafe/$root/astrid-build"
+COPYFILE_DISABLE=1 tar -czf "$work/unsafe.tar.gz" -C "$work/unsafe" "$root"
+if "$repo_root/scripts/extract-runtime-tool.sh" \
+  "$work/unsafe.tar.gz" "$version" "$target" astrid-build "$work/bin/unsafe" \
+  > /dev/null 2>&1; then
+  echo "runtime tool extractor accepted a symlink" >&2
+  exit 1
+fi

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -13,7 +13,7 @@ for binary in astrid astrid-daemon astrid-build astrid-emit; do
   printf '#!/bin/sh\nexit 0\n' > "$runtime_root/$binary"
   chmod 755 "$runtime_root/$binary"
 done
-tar -czf "$work/runtime.tar.gz" -C "$work" "$(basename "$runtime_root")"
+COPYFILE_DISABLE=1 tar -czf "$work/runtime.tar.gz" -C "$work" "$(basename "$runtime_root")"
 printf '#!/bin/sh\nexit 0\n' > "$work/aos"
 chmod 755 "$work/aos"
 
@@ -56,7 +56,7 @@ for binary in astrid-daemon astrid-build astrid-emit; do
   printf '#!/bin/sh\nexit 0\n' > "$unsafe_root/astrid-0.9.4-$target/$binary"
   chmod 755 "$unsafe_root/astrid-0.9.4-$target/$binary"
 done
-tar -czf "$work/unsafe-runtime.tar.gz" -C "$unsafe_root" "astrid-0.9.4-$target"
+COPYFILE_DISABLE=1 tar -czf "$work/unsafe-runtime.tar.gz" -C "$unsafe_root" "astrid-0.9.4-$target"
 if "$repo_root/scripts/package-release.sh" \
   "$target" \
   "$work/aos" \
@@ -64,5 +64,39 @@ if "$repo_root/scripts/package-release.sh" \
   0000000000000000000000000000000000000000000000000000000000000000 \
   "$work/output" >/dev/null 2>&1; then
   echo "release composer accepted a symlinked runtime binary" >&2
+  exit 1
+fi
+
+python3 - "$work/duplicate-runtime.tar.gz" "$target" <<'PY'
+import io
+import sys
+import tarfile
+
+archive_path, target = sys.argv[1:]
+root = f"astrid-0.9.4-{target}"
+
+def add(archive, name, data=b"#!/bin/sh\nexit 0\n"):
+    member = tarfile.TarInfo(name)
+    member.mode = 0o755
+    member.size = len(data)
+    archive.addfile(member, io.BytesIO(data))
+
+with tarfile.open(archive_path, "w:gz") as archive:
+    directory = tarfile.TarInfo(root)
+    directory.type = tarfile.DIRTYPE
+    directory.mode = 0o755
+    archive.addfile(directory)
+    for binary in ("astrid", "astrid-daemon", "astrid-build", "astrid-emit"):
+        add(archive, f"{root}/{binary}")
+    add(archive, f"{root}/astrid", b"#!/bin/sh\nexit 99\n")
+PY
+
+if "$repo_root/scripts/package-release.sh" \
+  "$target" \
+  "$work/aos" \
+  "$work/duplicate-runtime.tar.gz" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$work/output" >/dev/null 2>&1; then
+  echo "release composer accepted a duplicate runtime binary" >&2
   exit 1
 fi

--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import io
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from capsule_release import ContractError, CapsuleSpec, source_contract, validate_artifacts
+
+
+def add_bytes(
+    archive: tarfile.TarFile,
+    name: str,
+    data: bytes,
+    *,
+    kind: Optional[bytes] = None,
+) -> None:
+    member = tarfile.TarInfo(name)
+    member.size = len(data)
+    member.mtime = 0
+    member.uid = 0
+    member.gid = 0
+    if kind is not None:
+        member.type = kind
+        member.size = 0
+    archive.addfile(member, io.BytesIO(data) if member.isfile() else None)
+
+
+def write_fixture(path: Path, spec: CapsuleSpec, *, mutation: Optional[str] = None) -> None:
+    manifest = spec.manifest.read_bytes()
+    with tarfile.open(path, mode="w:gz") as archive:
+        if mutation == "traversal":
+            add_bytes(archive, "../escape", b"bad")
+        if mutation == "duplicate-manifest":
+            add_bytes(archive, "Capsule.toml", manifest)
+        if mutation == "dot-alias":
+            add_bytes(archive, "./Capsule.toml", b'[package]\nname = "wrong-package"\nversion = "0.0.0"\n')
+        if mutation == "case-alias":
+            add_bytes(archive, "capsule.toml", b"bad")
+        if mutation == "symlink":
+            link = tarfile.TarInfo("outside")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "/tmp"
+            archive.addfile(link)
+        if mutation == "hardlink":
+            link = tarfile.TarInfo("outside")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "Capsule.toml"
+            archive.addfile(link)
+        if mutation == "device":
+            device = tarfile.TarInfo("device")
+            device.type = tarfile.CHRTYPE
+            archive.addfile(device)
+        if mutation == "wrong-manifest":
+            manifest = manifest.replace(
+                f'name = "{spec.package}"'.encode(),
+                b'name = "wrong-package"',
+                1,
+            )
+        if mutation == "changed-capability":
+            manifest = manifest.replace(b"uplink = true", b"uplink = false", 1)
+        add_bytes(archive, "Capsule.toml", manifest)
+        for component in spec.components:
+            if mutation == "missing-component" and component == spec.components[0]:
+                continue
+            add_bytes(archive, component, b"\x00asm")
+
+
+class CapsuleReleaseTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.specs = source_contract()
+
+    def fixture_set(self, directory: Path) -> None:
+        for spec in self.specs:
+            write_fixture(directory / spec.asset, spec)
+
+    def test_source_contract_has_exact_community_set(self) -> None:
+        self.assertEqual(len(self.specs), 18)
+        self.assertEqual(len({spec.asset for spec in self.specs}), 18)
+        self.assertNotIn("astrid-capsule-telegram.capsule", {spec.asset for spec in self.specs})
+
+    def test_accepts_exact_safe_artifact_set(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            self.fixture_set(directory)
+            validate_artifacts(directory, self.specs)
+
+    def assert_mutation_rejected(self, mutation: str) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            self.fixture_set(directory)
+            write_fixture(directory / self.specs[0].asset, self.specs[0], mutation=mutation)
+            with self.assertRaises(ContractError):
+                validate_artifacts(directory, self.specs)
+
+    def test_rejects_traversal(self) -> None:
+        self.assert_mutation_rejected("traversal")
+
+    def test_rejects_exact_duplicate(self) -> None:
+        self.assert_mutation_rejected("duplicate-manifest")
+
+    def test_rejects_dot_alias(self) -> None:
+        self.assert_mutation_rejected("dot-alias")
+
+    def test_rejects_case_alias(self) -> None:
+        self.assert_mutation_rejected("case-alias")
+
+    def test_rejects_symlink(self) -> None:
+        self.assert_mutation_rejected("symlink")
+
+    def test_rejects_hardlink(self) -> None:
+        self.assert_mutation_rejected("hardlink")
+
+    def test_rejects_device(self) -> None:
+        self.assert_mutation_rejected("device")
+
+    def test_rejects_wrong_embedded_identity(self) -> None:
+        self.assert_mutation_rejected("wrong-manifest")
+
+    def test_rejects_changed_capabilities(self) -> None:
+        self.assert_mutation_rejected("changed-capability")
+
+    def test_rejects_missing_component(self) -> None:
+        self.assert_mutation_rejected("missing-component")
+
+    def test_rejects_unexpected_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            self.fixture_set(directory)
+            (directory / "unexpected.capsule").write_bytes(b"no")
+            with self.assertRaises(ContractError):
+                validate_artifacts(directory, self.specs)
+
+    def test_rejects_unexpected_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            self.fixture_set(directory)
+            (directory / "unexpected").mkdir()
+            with self.assertRaises(ContractError):
+                validate_artifacts(directory, self.specs)
+
+    def test_rejects_symlink_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            self.fixture_set(directory)
+            target = directory / self.specs[0].asset
+            target.unlink()
+            target.symlink_to(directory / self.specs[1].asset)
+            with self.assertRaises(ContractError):
+                validate_artifacts(directory, self.specs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_runtime_archive.py
+++ b/scripts/test_validate_runtime_archive.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional
+
+
+SCRIPT = Path(__file__).resolve().parent / "validate-runtime-archive.py"
+SPEC = importlib.util.spec_from_file_location("validate_runtime_archive", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+ArchiveError = MODULE.ArchiveError
+validate = MODULE.validate
+
+
+def add_member(
+    archive: tarfile.TarFile,
+    name: str,
+    *,
+    mode: int = 0o755,
+    kind: Optional[bytes] = None,
+    data: bytes = b"tool",
+) -> None:
+    member = tarfile.TarInfo(name)
+    member.mode = mode
+    member.size = len(data)
+    if kind is not None:
+        member.type = kind
+        member.size = 0
+    archive.addfile(member, io.BytesIO(data) if member.isfile() else None)
+
+
+class RuntimeArchiveTests(unittest.TestCase):
+    root = "astrid-0.9.4-x86_64-unknown-linux-gnu"
+    tool = "astrid-build"
+
+    def fixture(self, directory: Path, mutation: Optional[str] = None) -> Path:
+        path = directory / "runtime.tar.gz"
+        with tarfile.open(path, mode="w:gz") as archive:
+            add_member(archive, self.root, kind=tarfile.DIRTYPE)
+            add_member(archive, f"{self.root}/{self.tool}")
+            if mutation == "duplicate":
+                add_member(archive, f"{self.root}/{self.tool}", data=b"later")
+            if mutation == "dot-alias":
+                add_member(archive, f"{self.root}/./{self.tool}", data=b"later")
+            if mutation == "case-alias":
+                add_member(archive, f"{self.root}/Astrid-Build", data=b"later")
+            if mutation == "traversal":
+                add_member(archive, f"{self.root}/../escape")
+            if mutation == "outside-root":
+                add_member(archive, "other/file")
+            if mutation == "symlink":
+                add_member(archive, f"{self.root}/link", kind=tarfile.SYMTYPE)
+            if mutation == "hardlink":
+                add_member(archive, f"{self.root}/hard", kind=tarfile.LNKTYPE)
+            if mutation == "device":
+                add_member(archive, f"{self.root}/device", kind=tarfile.CHRTYPE)
+        return path
+
+    def test_accepts_canonical_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            validate(self.fixture(Path(temp)), self.root, [self.tool])
+
+    def test_rejects_non_executable_tool(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "runtime.tar.gz"
+            with tarfile.open(path, mode="w:gz") as archive:
+                add_member(archive, self.root, kind=tarfile.DIRTYPE)
+                add_member(archive, f"{self.root}/{self.tool}", mode=0o644)
+            with self.assertRaises(ArchiveError):
+                validate(path, self.root, [self.tool])
+
+    def assert_rejected(self, mutation: str) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            with self.assertRaises(ArchiveError):
+                validate(self.fixture(Path(temp), mutation), self.root, [self.tool])
+
+    def test_rejects_duplicate(self) -> None:
+        self.assert_rejected("duplicate")
+
+    def test_rejects_dot_alias(self) -> None:
+        self.assert_rejected("dot-alias")
+
+    def test_rejects_case_alias(self) -> None:
+        self.assert_rejected("case-alias")
+
+    def test_rejects_traversal(self) -> None:
+        self.assert_rejected("traversal")
+
+    def test_rejects_outside_root(self) -> None:
+        self.assert_rejected("outside-root")
+
+    def test_rejects_symlink(self) -> None:
+        self.assert_rejected("symlink")
+
+    def test_rejects_hardlink(self) -> None:
+        self.assert_rejected("hardlink")
+
+    def test_rejects_device(self) -> None:
+        self.assert_rejected("device")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-runtime-archive.py
+++ b/scripts/validate-runtime-archive.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Validate a pinned Astrid runtime archive before extracting required tools."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tarfile
+import unicodedata
+from pathlib import Path, PurePosixPath
+
+
+class ArchiveError(RuntimeError):
+    """The runtime archive is ambiguous or unsafe to extract."""
+
+
+def canonical_name(member: tarfile.TarInfo, archive: Path) -> str:
+    name = member.name
+    raw = name[:-1] if member.isdir() and name.endswith("/") else name
+    parts = raw.split("/")
+    path = PurePosixPath(raw)
+    if (
+        not raw
+        or path.is_absolute()
+        or any(part in ("", ".", "..") for part in parts)
+        or path.as_posix() != raw
+    ):
+        raise ArchiveError(f"{archive}: unsafe or non-canonical path {name!r}")
+    return raw
+
+
+def validate(archive_path: Path, root: str, tools: list[str]) -> None:
+    if not archive_path.is_file() or archive_path.is_symlink():
+        raise ArchiveError(f"runtime archive is missing or not a regular file: {archive_path}")
+    if not root or "/" in root or root in (".", ".."):
+        raise ArchiveError(f"invalid runtime archive root: {root!r}")
+    if not tools:
+        raise ArchiveError("at least one runtime tool is required")
+    for tool in tools:
+        if not tool or "/" in tool or tool in (".", ".."):
+            raise ArchiveError(f"invalid runtime tool: {tool!r}")
+
+    try:
+        archive = tarfile.open(archive_path, mode="r:gz")
+    except (OSError, tarfile.TarError) as error:
+        raise ArchiveError(f"cannot read runtime archive: {error}") from error
+
+    names: dict[str, tarfile.TarInfo] = {}
+    portable_names: dict[str, str] = {}
+    with archive:
+        for member in archive.getmembers():
+            if not (member.isfile() or member.isdir()):
+                raise ArchiveError(f"runtime archive contains a link or special file: {member.name}")
+            name = canonical_name(member, archive_path)
+            if name != root and not name.startswith(f"{root}/"):
+                raise ArchiveError(f"runtime archive path is outside {root}: {name}")
+            if name in names:
+                raise ArchiveError(f"runtime archive contains duplicate path: {name}")
+            portable = unicodedata.normalize("NFC", name).casefold()
+            if portable in portable_names:
+                raise ArchiveError(
+                    "runtime archive paths collide on portable filesystems: "
+                    f"{portable_names[portable]!r} and {name!r}"
+                )
+            names[name] = member
+            portable_names[portable] = name
+
+    for tool in tools:
+        expected = f"{root}/{tool}"
+        tool_member = names.get(expected)
+        if tool_member is None or not tool_member.isfile() or tool_member.mode & 0o111 == 0:
+            raise ArchiveError(f"runtime archive has no executable {expected}")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("archive", type=Path)
+    parser.add_argument("root")
+    parser.add_argument("tool", nargs="+")
+    args = parser.parse_args(argv)
+    try:
+        validate(args.archive, args.root, args.tool)
+    except ArchiveError as error:
+        print(f"runtime archive validation error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## What changed

- defines the exact 18-capsule Community Edition release set and preserves every existing `astrid-capsule-*` identity
- builds installable `.capsule` assets with the pinned, checksum- and Sigstore-verified Astrid builder
- binds each artifact to its complete source `Capsule.toml`, package version, components, distro entry, and standalone source alias
- rejects ambiguous or unsafe capsule/runtime archives, including traversal, duplicate and portable-path aliases, links, devices, and non-regular artifact entries
- revalidates the exact capsule set after Actions artifact transport before checksumming, attesting, signing, or uploading
- runs capsule host tests in CI; the prompt-builder keeps Astrid logging on wasm and uses a host-only logger for native tests
- hardens product runtime composition with the same structured archive validation
- retains the Homebrew tap notification after release publication

## Release boundary

This augments the first `2026.1.0` release; it does not create `2026.1.1`. The changelog continues to mark `2026.1.0` unreleased. Merging this PR does not create, move, or publish a tag or release. The existing staging release is a draft, and the GitHub `release` environment requires explicit reviewer approval before publication.

The distro sources remain on their existing standalone repositories. Rebinding them to the monorepo requires the separate resolved-source update work so calendar-versioned product releases do not appear as perpetual capsule upgrades.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked --workspace --exclude astrid-capsule-telegram --exclude unicity-aos-bootstrap --target aarch64-apple-darwin`
- all 18 installable capsules built with Astrid Runtime 0.9.4 and passed full artifact validation
- `python3 scripts/validate-release-contract.py`
- `python3 scripts/capsule_release.py`
- 15 capsule release contract/mutation tests
- 10 runtime archive mutation tests
- package release and installer fixture tests
- `actionlint`
- `shellcheck scripts/*.sh install.sh`
- `git diff --check`

Three independent read-only reviews were completed; all code findings were addressed before publication of this branch.
