### PR TITLE
feat: inherit the runtime CLI with native AOS overrides

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,7 @@ jobs:
           Install or upgrade:
 
           \`\`\`sh
-          curl -fsSL https://aos.unicity.ai/install.sh | sh
+          curl --proto '=https' --tlsv1.2 -fsSL https://aos.unicity.ai/install.sh | sh
           \`\`\`
           EOF
       - uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The supported installer installs both the `aos` product command and its pinned
 runtime under the product-owned `~/.unicity-os` root:
 
 ```sh
-curl -fsSL https://aos.unicity.ai/install.sh | sh
+curl --proto '=https' --tlsv1.2 -fsSL https://aos.unicity.ai/install.sh | sh
 aos init
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,21 +33,28 @@ checksums, Sigstore bundles, GitHub build-provenance attestations, and
 
 ## Command boundary
 
-The `aos` root accepts only AOS product commands. Unknown commands fail instead
-of falling through to another CLI:
+AOS owns its product roots, including `init`, `status`, migration, updates, and
+health:
 
 ```sh
 aos status
 aos status --json
 ```
 
-Operator and capsule-author commands remain available through the explicit
-runtime escape hatch. Its arguments, exit code, and signals pass directly to
-the bundled Astrid Runtime:
+Every other root inherits the bundled Astrid CLI transparently. Arguments, exit
+codes, and signals pass through unchanged:
 
 ```sh
-aos runtime doctor
-aos runtime capsule build
+aos doctor
+aos capsule build
+```
+
+An AOS-owned root intentionally shadows the runtime root with the same name.
+Use the standalone runtime CLI when the raw command is required:
+
+```sh
+astrid status
+astrid init --help
 ```
 
 ## Import an existing runtime

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ docs/         Product and operator documentation
 ## Install
 
 The supported installer installs both the `aos` product command and its pinned
-Astrid Runtime under the product-owned `~/.unicity-os` root:
+runtime under the product-owned `~/.unicity-os` root:
 
 ```sh
 curl -fsSL https://aos.unicity.ai/install.sh | sh
@@ -27,13 +27,32 @@ aos init
 ```
 
 Re-running the installer performs a coordinated product upgrade without
-rewriting a standalone `~/.astrid` installation. Every release publishes
+rewriting a standalone runtime installation. Every release publishes
 checksums, Sigstore bundles, GitHub build-provenance attestations, and
-`runtime-compatibility.toml`, which pins the exact Astrid release and WIT commit.
+`runtime-compatibility.toml`, which pins the exact runtime release and WIT commit.
+
+## Command boundary
+
+The `aos` root accepts only AOS product commands. Unknown commands fail instead
+of falling through to another CLI:
+
+```sh
+aos status
+aos status --json
+```
+
+Operator and capsule-author commands remain available through the explicit
+runtime escape hatch. Its arguments, exit code, and signals pass directly to
+the bundled Astrid Runtime:
+
+```sh
+aos runtime doctor
+aos runtime capsule build
+```
 
 ## Import an existing runtime
 
-The `aos` CLI can deliberately copy compatible state from a standalone Astrid
-Runtime installation without changing the source. See
+The `aos` CLI can deliberately copy compatible state from a standalone runtime
+installation without changing the source. See
 [Importing standalone runtime state](docs/runtime-migration.md) for the exact
 allowlist, integrity checks, recovery behavior, and command.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ checksums, Sigstore bundles, GitHub build-provenance attestations, and
 
 ## Command boundary
 
-AOS owns its product roots, including `init`, `status`, migration, updates, and
-health:
+AOS owns its product roots, including `init`, `status`, `migrate`,
+`self-update`, and `serve-health`:
 
 ```sh
 aos status

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -226,7 +226,7 @@ impl AosHome {
         self.spawn_runtime_with_args(std::iter::empty::<&OsStr>())
     }
 
-    /// Spawn the bundled runtime with explicit runtime CLI arguments.
+    /// Spawn the bundled runtime with runtime CLI arguments.
     ///
     /// The runtime home remains scoped to this AOS installation.
     ///
@@ -260,7 +260,7 @@ impl AosHome {
         Err(self.runtime_command_with_args(args).exec())
     }
 
-    /// Run an explicit bundled-runtime command.
+    /// Run a bundled-runtime command.
     ///
     /// The runtime remains the authority for socket authentication and local
     /// credentials. AOS provides only product-owned installation state and

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -18,7 +18,7 @@ pub use migration::{LegacyDistro, MigrationOutcome};
 
 const UNICITY_CE_MANIFEST: &str = include_str!("../../../distros/community/unicity-ce/Distro.toml");
 
-/// Product-owned per-project state directory selected for bundled runtime commands.
+/// Product-owned per-project state directory selected for all AOS runtime access.
 pub const AOS_WORKSPACE_STATE_DIR: &str = ".unicity-os";
 
 /// Product state owned by one Unicity AOS installation.

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -17,6 +17,7 @@ pub mod status;
 pub use migration::{LegacyDistro, MigrationOutcome};
 
 const UNICITY_CE_MANIFEST: &str = include_str!("../../../distros/community/unicity-ce/Distro.toml");
+const AOS_WORKSPACE_STATE_DIR: &str = ".unicity-os";
 
 /// Product state owned by one Unicity AOS installation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -213,7 +214,9 @@ impl AosHome {
         S: AsRef<OsStr>,
     {
         let mut command = Command::new(self.runtime_binary());
-        command.env("ASTRID_HOME", self.runtime_home());
+        command
+            .env("ASTRID_HOME", self.runtime_home())
+            .env("ASTRID_WORKSPACE_STATE_DIR", AOS_WORKSPACE_STATE_DIR);
         command.args(args);
         command
     }
@@ -411,16 +414,19 @@ mod tests {
     }
 
     #[test]
-    fn runtime_command_scopes_astrid_home_to_the_child() {
+    fn runtime_command_scopes_global_and_project_state_to_aos() {
         let home = AosHome::from_root("/tmp/unicity-aos-test");
         let command = home.runtime_command();
-        let runtime_home = command
-            .get_envs()
-            .find_map(|(name, value)| (name == "ASTRID_HOME").then_some(value))
-            .flatten()
-            .expect("runtime command sets ASTRID_HOME");
+        let env_value = |target: &str| {
+            command
+                .get_envs()
+                .find_map(|(name, value)| (name == target).then_some(value))
+                .flatten()
+                .expect("runtime command sets product-scoped environment")
+        };
 
-        assert_eq!(runtime_home, "/tmp/unicity-aos-test/runtime");
+        assert_eq!(env_value("ASTRID_HOME"), "/tmp/unicity-aos-test/runtime");
+        assert_eq!(env_value("ASTRID_WORKSPACE_STATE_DIR"), ".unicity-os");
     }
 
     #[test]

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -17,7 +17,9 @@ pub mod status;
 pub use migration::{LegacyDistro, MigrationOutcome};
 
 const UNICITY_CE_MANIFEST: &str = include_str!("../../../distros/community/unicity-ce/Distro.toml");
-const AOS_WORKSPACE_STATE_DIR: &str = ".unicity-os";
+
+/// Product-owned per-project state directory selected for bundled runtime commands.
+pub const AOS_WORKSPACE_STATE_DIR: &str = ".unicity-os";
 
 /// Product state owned by one Unicity AOS installation.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -13,6 +13,7 @@ use std::process::{Child, Command, ExitStatus};
 
 pub mod health;
 mod migration;
+pub mod status;
 pub use migration::{LegacyDistro, MigrationOutcome};
 
 const UNICITY_CE_MANIFEST: &str = include_str!("../../../distros/community/unicity-ce/Distro.toml");
@@ -225,11 +226,9 @@ impl AosHome {
         self.spawn_runtime_with_args(std::iter::empty::<&OsStr>())
     }
 
-    /// Spawn the bundled runtime with product CLI arguments.
+    /// Spawn the bundled runtime with explicit runtime CLI arguments.
     ///
-    /// Unicity AOS is a trusted distribution built on Astrid Runtime, so this
-    /// path uses the runtime's normal local operator credentials. The runtime
-    /// home remains scoped to this AOS installation.
+    /// The runtime home remains scoped to this AOS installation.
     ///
     /// # Errors
     /// Returns an error when the bundled executable is absent or cannot start.
@@ -261,10 +260,10 @@ impl AosHome {
         Err(self.runtime_command_with_args(args).exec())
     }
 
-    /// Run an Astrid Runtime command as an AOS product command.
+    /// Run an explicit bundled-runtime command.
     ///
     /// The runtime remains the authority for socket authentication and local
-    /// credentials. Unicity provides only product-owned installation state and
+    /// credentials. AOS provides only product-owned installation state and
     /// preserves the runtime's exit status for scripts and service managers.
     ///
     /// # Errors

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -1,7 +1,7 @@
 //! `aos` — the product command surface for Unicity AOS.
 //!
-//! Unicity AOS is a distribution built on Astrid Runtime. Runtime and operator
-//! commands remain available only through the explicit `aos runtime` escape.
+//! Unicity AOS is a distribution built on Astrid Runtime. AOS commands override
+//! the corresponding runtime roots; every other root passes through unchanged.
 
 use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
@@ -43,19 +43,7 @@ fn run() -> ExitCode {
         RootCommand::ServeHealth(args) => handle_health_service(args),
         RootCommand::Status(args) => handle_status(args),
         RootCommand::Init(args) => handle_init(args),
-        RootCommand::Runtime(args) => handle_runtime_escape(args),
-        RootCommand::MissingRuntimeCommand => {
-            eprintln!("Usage: aos runtime <command> [arguments...]");
-            eprintln!(
-                "Runs an operator or capsule-author command with the bundled Astrid Runtime."
-            );
-            ExitCode::FAILURE
-        }
-        RootCommand::Unknown(command) => {
-            eprintln!("aos: unknown command `{}`", command.to_string_lossy());
-            eprintln!("Run `aos --help` for available commands.");
-            ExitCode::FAILURE
-        }
+        RootCommand::Passthrough(args) => handle_runtime_passthrough(args),
     }
 }
 
@@ -69,9 +57,7 @@ enum RootCommand<'a> {
     ServeHealth(&'a [OsString]),
     Status(&'a [OsString]),
     Init(&'a [OsString]),
-    Runtime(&'a [OsString]),
-    MissingRuntimeCommand,
-    Unknown(&'a OsStr),
+    Passthrough(&'a [OsString]),
 }
 
 impl<'a> RootCommand<'a> {
@@ -87,9 +73,7 @@ impl<'a> RootCommand<'a> {
             Some("serve-health") => Self::ServeHealth(&args[1..]),
             Some("status") => Self::Status(&args[1..]),
             Some("init") => Self::Init(&args[1..]),
-            Some("runtime") if args.len() == 1 => Self::MissingRuntimeCommand,
-            Some("runtime") => Self::Runtime(&args[1..]),
-            _ => Self::Unknown(command),
+            _ => Self::Passthrough(args),
         }
     }
 }
@@ -103,7 +87,7 @@ fn resolve_home() -> Result<AosHome, ExitCode> {
 
 fn handle_init(args: &[OsString]) -> ExitCode {
     if has_distro_override(args) {
-        eprintln!("aos init always installs Unicity CE; use `aos runtime init` for another distro");
+        eprintln!("aos init always installs Unicity CE; use `astrid init` for another distro");
         return ExitCode::FAILURE;
     }
     if has_help_flag(args) {
@@ -125,7 +109,7 @@ fn handle_init(args: &[OsString]) -> ExitCode {
     run_runtime(&home, args)
 }
 
-fn handle_runtime_escape(args: &[OsString]) -> ExitCode {
+fn handle_runtime_passthrough(args: &[OsString]) -> ExitCode {
     let home = match AosHome::resolve() {
         Ok(home) => home,
         Err(error) => {
@@ -477,13 +461,13 @@ fn print_legacy_distro_handoff(home: &AosHome) {
 
 fn print_help() {
     println!(
-        "Unicity AOS\n\nUsage:\n  aos init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n  aos status [--json]\n  aos migrate runtime --from <absolute-legacy-home>\n  aos self-update\n  aos serve-health\n  aos runtime <command> [arguments...]\n\n`aos init` installs the Unicity CE manifest bundled with this product release. `aos status` reads the typed local runtime status operation. `aos self-update` updates AOS and its pinned runtime. `aos serve-health` binds only 127.0.0.1:8765 and exposes GET /v1/runtime/health. `aos runtime` is the explicit escape hatch for operator and capsule-author commands provided by the bundled Astrid Runtime. Runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME)."
+        "Unicity AOS\n\nUsage:\n  aos init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n  aos status [--json]\n  aos migrate runtime --from <absolute-legacy-home>\n  aos self-update\n  aos serve-health\n  aos <runtime command> [arguments...]\n\n`aos init` installs the Unicity CE manifest bundled with this product release. `aos status` reads the typed local runtime status operation. `aos self-update` updates AOS and its pinned runtime. `aos serve-health` binds only 127.0.0.1:8765 and exposes GET /v1/runtime/health. Commands not owned by AOS pass through unchanged to the bundled Astrid Runtime. AOS roots intentionally shadow runtime roots; use `astrid <command>` when the raw runtime command is required. Runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME)."
     );
 }
 
 fn print_init_help() {
     println!(
-        "Unicity AOS\n\nUsage:\n  aos init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n\nInstalls Unicity CE from the manifest bundled with this product release. For a different distro, use `aos runtime init`."
+        "Unicity AOS\n\nUsage:\n  aos init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n\nInstalls Unicity CE from the manifest bundled with this product release. For a different distro, use `astrid init`."
     );
 }
 
@@ -545,7 +529,7 @@ mod tests {
     }
 
     #[test]
-    fn parser_recognizes_only_product_roots_and_explicit_runtime_escape() {
+    fn parser_recognizes_product_roots() {
         assert_eq!(RootCommand::parse(&[]), RootCommand::NoArguments);
 
         let help = [OsString::from("--help")];
@@ -575,41 +559,31 @@ mod tests {
         );
         let init = [OsString::from("init"), OsString::from("--yes")];
         assert_eq!(RootCommand::parse(&init), RootCommand::Init(&init[1..]));
-        let runtime = [
-            OsString::from("runtime"),
-            OsString::from("capsule"),
-            OsString::from("build"),
-        ];
-        assert_eq!(
-            RootCommand::parse(&runtime),
-            RootCommand::Runtime(&runtime[1..])
-        );
     }
 
     #[test]
-    fn parser_rejects_missing_runtime_and_unknown_roots() {
-        let runtime = [OsString::from("runtime")];
+    fn parser_passes_every_unowned_root_through_unchanged() {
+        let inherited = [OsString::from("capsule"), OsString::from("build")];
+        assert_eq!(
+            RootCommand::parse(&inherited),
+            RootCommand::Passthrough(&inherited)
+        );
+        let runtime = [OsString::from("runtime"), OsString::from("status")];
         assert_eq!(
             RootCommand::parse(&runtime),
-            RootCommand::MissingRuntimeCommand
-        );
-
-        let unknown = [OsString::from("capsule")];
-        assert_eq!(
-            RootCommand::parse(&unknown),
-            RootCommand::Unknown(unknown[0].as_os_str())
+            RootCommand::Passthrough(&runtime)
         );
     }
 
     #[cfg(unix)]
     #[test]
-    fn parser_rejects_non_utf8_root_commands() {
+    fn parser_preserves_non_utf8_runtime_roots() {
         use std::os::unix::ffi::OsStringExt;
 
-        let unknown = [OsString::from_vec(vec![0xff, b'x'])];
+        let inherited = [OsString::from_vec(vec![0xff, b'x'])];
         assert_eq!(
-            RootCommand::parse(&unknown),
-            RootCommand::Unknown(unknown[0].as_os_str())
+            RootCommand::parse(&inherited),
+            RootCommand::Passthrough(&inherited)
         );
     }
 

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -248,12 +248,9 @@ fn handle_health_service(args: &[OsString]) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    let home = match AosHome::resolve() {
+    let home = match resolve_home() {
         Ok(home) => home,
-        Err(error) => {
-            eprintln!("aos: failed to resolve product home: {error}");
-            return ExitCode::FAILURE;
-        }
+        Err(code) => return code,
     };
 
     set_runtime_environment(&home);

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -110,12 +110,9 @@ fn handle_init(args: &[OsString]) -> ExitCode {
 }
 
 fn handle_runtime_passthrough(args: &[OsString]) -> ExitCode {
-    let home = match AosHome::resolve() {
+    let home = match resolve_home() {
         Ok(home) => home,
-        Err(error) => {
-            eprintln!("aos: failed to resolve product home: {error}");
-            return ExitCode::FAILURE;
-        }
+        Err(code) => return code,
     };
     run_runtime(&home, args.iter())
 }
@@ -334,7 +331,8 @@ fn handle_status(args: &[OsString]) -> ExitCode {
 }
 
 fn set_runtime_environment(home: &AosHome) {
-    // The single-threaded client resolves its local socket from this process-only override.
+    // Safety: this runs before the current-thread client runtime starts and before this
+    // dedicated CLI process creates any other threads.
     unsafe {
         std::env::set_var("ASTRID_HOME", home.runtime_home());
         std::env::set_var("ASTRID_WORKSPACE_STATE_DIR", AOS_WORKSPACE_STATE_DIR);

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -1,8 +1,7 @@
 //! `aos` — the product command surface for Unicity AOS.
 //!
-//! Unicity AOS is a trusted distribution built on Astrid Runtime. The product
-//! binary therefore delegates runtime and operator commands directly to its
-//! bundled runtime, scoped to this installation's private `ASTRID_HOME`.
+//! Unicity AOS is a distribution built on Astrid Runtime. Runtime and operator
+//! commands remain available only through the explicit `aos runtime` escape.
 
 use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
@@ -12,18 +11,121 @@ use std::io::{self, IsTerminal, Write};
 use std::os::unix::fs::OpenOptionsExt;
 #[cfg(unix)]
 use std::path::Path;
+#[cfg(any(not(unix), test))]
+use std::process::ExitStatus;
 use std::process::{Command, ExitCode};
 #[cfg(unix)]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use unicity_aos_bootstrap::AosHome;
 
-#[cfg(unix)]
 fn main() -> ExitCode {
+    run()
+}
+
+fn run() -> ExitCode {
     let args: Vec<OsString> = std::env::args_os().skip(1).collect();
-    if let Some(exit_code) = handle_product_command(&args) {
-        return exit_code;
+    match RootCommand::parse(&args) {
+        RootCommand::NoArguments => offer_first_run_migration().unwrap_or_else(|| {
+            print_help();
+            ExitCode::SUCCESS
+        }),
+        RootCommand::Help => {
+            print_help();
+            ExitCode::SUCCESS
+        }
+        RootCommand::Version => {
+            println!("Unicity AOS {}", env!("CARGO_PKG_VERSION"));
+            ExitCode::SUCCESS
+        }
+        RootCommand::SelfUpdate(args) => handle_self_update(args),
+        RootCommand::Migrate(args) => handle_migrate_command(args),
+        RootCommand::ServeHealth(args) => handle_health_service(args),
+        RootCommand::Status(args) => handle_status(args),
+        RootCommand::Init(args) => handle_init(args),
+        RootCommand::Runtime(args) => handle_runtime_escape(args),
+        RootCommand::MissingRuntimeCommand => {
+            eprintln!("Usage: aos runtime <command> [arguments...]");
+            eprintln!(
+                "Runs an operator or capsule-author command with the bundled Astrid Runtime."
+            );
+            ExitCode::FAILURE
+        }
+        RootCommand::Unknown(command) => {
+            eprintln!("aos: unknown command `{}`", command.to_string_lossy());
+            eprintln!("Run `aos --help` for available commands.");
+            ExitCode::FAILURE
+        }
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RootCommand<'a> {
+    NoArguments,
+    Help,
+    Version,
+    SelfUpdate(&'a [OsString]),
+    Migrate(&'a [OsString]),
+    ServeHealth(&'a [OsString]),
+    Status(&'a [OsString]),
+    Init(&'a [OsString]),
+    Runtime(&'a [OsString]),
+    MissingRuntimeCommand,
+    Unknown(&'a OsStr),
+}
+
+impl<'a> RootCommand<'a> {
+    fn parse(args: &'a [OsString]) -> Self {
+        let Some(command) = args.first() else {
+            return Self::NoArguments;
+        };
+        match command.to_str() {
+            Some("-h" | "--help") => Self::Help,
+            Some("-V" | "--version") => Self::Version,
+            Some("self-update" | "self_update") => Self::SelfUpdate(&args[1..]),
+            Some("migrate") => Self::Migrate(&args[1..]),
+            Some("serve-health") => Self::ServeHealth(&args[1..]),
+            Some("status") => Self::Status(&args[1..]),
+            Some("init") => Self::Init(&args[1..]),
+            Some("runtime") if args.len() == 1 => Self::MissingRuntimeCommand,
+            Some("runtime") => Self::Runtime(&args[1..]),
+            _ => Self::Unknown(command),
+        }
+    }
+}
+
+fn resolve_home() -> Result<AosHome, ExitCode> {
+    AosHome::resolve().map_err(|error| {
+        eprintln!("aos: failed to resolve product home: {error}");
+        ExitCode::FAILURE
+    })
+}
+
+fn handle_init(args: &[OsString]) -> ExitCode {
+    if has_distro_override(args) {
+        eprintln!("aos init always installs Unicity CE; use `aos runtime init` for another distro");
+        return ExitCode::FAILURE;
+    }
+    if has_help_flag(args) {
+        print_init_help();
+        return ExitCode::SUCCESS;
+    }
+
+    let home = match resolve_home() {
+        Ok(home) => home,
+        Err(code) => return code,
+    };
+    let args = match product_init_runtime_args(&home, args) {
+        Ok(args) => args,
+        Err(error) => {
+            eprintln!("aos: failed to prepare Unicity CE: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    run_runtime(&home, args)
+}
+
+fn handle_runtime_escape(args: &[OsString]) -> ExitCode {
     let home = match AosHome::resolve() {
         Ok(home) => home,
         Err(error) => {
@@ -31,14 +133,15 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    let args = match product_runtime_args(&home, args) {
-        Ok(args) => args,
-        Err(error) => {
-            eprintln!("aos: failed to prepare Unicity CE: {error}");
-            return ExitCode::FAILURE;
-        }
-    };
+    run_runtime(&home, args.iter())
+}
 
+#[cfg(unix)]
+fn run_runtime<I, S>(home: &AosHome, args: I) -> ExitCode
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
     match home.exec_runtime_with_args(args) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
@@ -49,29 +152,13 @@ fn main() -> ExitCode {
 }
 
 #[cfg(not(unix))]
-fn main() -> ExitCode {
-    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
-    if let Some(exit_code) = handle_product_command(&args) {
-        return exit_code;
-    }
-    let home = match AosHome::resolve() {
-        Ok(home) => home,
-        Err(error) => {
-            eprintln!("aos: failed to resolve product home: {error}");
-            return ExitCode::FAILURE;
-        }
-    };
-    let args = match product_runtime_args(&home, args) {
-        Ok(args) => args,
-        Err(error) => {
-            eprintln!("aos: failed to prepare Unicity CE: {error}");
-            return ExitCode::FAILURE;
-        }
-    };
-
+fn run_runtime<I, S>(home: &AosHome, args: I) -> ExitCode
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
     match home.run_runtime_with_args(args) {
-        Ok(status) if status.success() => ExitCode::SUCCESS,
-        Ok(status) => ExitCode::from(status.code().unwrap_or(1).clamp(1, i32::from(u8::MAX)) as u8),
+        Ok(status) => child_exit_code(status),
         Err(error) => {
             eprintln!("aos: failed to start bundled runtime: {error}");
             ExitCode::FAILURE
@@ -79,32 +166,12 @@ fn main() -> ExitCode {
     }
 }
 
-fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
-    match args.first().and_then(|arg| arg.to_str()) {
-        None => offer_first_run_migration().or_else(|| {
-            print_help();
-            Some(ExitCode::SUCCESS)
-        }),
-        Some("-h" | "--help") => {
-            print_help();
-            Some(ExitCode::SUCCESS)
-        }
-        Some("-V" | "--version") => {
-            println!("Unicity AOS {}", env!("CARGO_PKG_VERSION"));
-            Some(ExitCode::SUCCESS)
-        }
-        Some("self-update" | "self_update") => Some(handle_self_update(&args[1..])),
-        Some("migrate") => Some(handle_migrate_command(&args[1..])),
-        Some("serve-health") => Some(handle_health_service()),
-        Some("init") if has_distro_override(&args[1..]) => {
-            eprintln!("aos init always installs Unicity CE; use `astrid init` for another distro");
-            Some(ExitCode::FAILURE)
-        }
-        Some("init") if has_help_flag(&args[1..]) => {
-            print_init_help();
-            Some(ExitCode::SUCCESS)
-        }
-        Some(_) => None,
+#[cfg(any(not(unix), test))]
+fn child_exit_code(status: ExitStatus) -> ExitCode {
+    if status.success() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(status.code().unwrap_or(1).clamp(1, i32::from(u8::MAX)) as u8)
     }
 }
 
@@ -194,7 +261,12 @@ fn command_exit_code(status: io::Result<std::process::ExitStatus>, operation: &s
     }
 }
 
-fn handle_health_service() -> ExitCode {
+fn handle_health_service(args: &[OsString]) -> ExitCode {
+    if !args.is_empty() {
+        eprintln!("Usage: aos serve-health");
+        return ExitCode::FAILURE;
+    }
+
     let home = match AosHome::resolve() {
         Ok(home) => home,
         Err(error) => {
@@ -203,12 +275,7 @@ fn handle_health_service() -> ExitCode {
         }
     };
 
-    // Safety: this runs before the Tokio runtime and the health server starts
-    // any threads. The override affects only this dedicated child process, not
-    // the invoking shell or a standalone Astrid Runtime installation.
-    unsafe {
-        std::env::set_var("ASTRID_HOME", home.runtime_home());
-    }
+    set_runtime_home(&home);
 
     let runtime = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -229,18 +296,74 @@ fn handle_health_service() -> ExitCode {
     }
 }
 
-fn product_runtime_args(home: &AosHome, args: Vec<OsString>) -> io::Result<Vec<OsString>> {
-    if args.first().is_some_and(|arg| arg == "init") {
-        let mut runtime_args = vec![
-            OsString::from("init"),
-            OsString::from("--distro"),
-            home.ensure_unicity_ce_manifest()?.into_os_string(),
-        ];
-        runtime_args.extend(args.into_iter().skip(1));
-        Ok(runtime_args)
-    } else {
-        Ok(args)
+fn handle_status(args: &[OsString]) -> ExitCode {
+    if has_help_flag(args) {
+        println!("Unicity AOS\n\nUsage:\n  aos status [--json]");
+        return ExitCode::SUCCESS;
     }
+    if !args.is_empty() && (args.len() != 1 || args[0] != OsStr::new("--json")) {
+        eprintln!("Usage: aos status [--json]");
+        return ExitCode::FAILURE;
+    }
+
+    let home = match resolve_home() {
+        Ok(home) => home,
+        Err(code) => return code,
+    };
+    set_runtime_home(&home);
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("aos: failed to start status client: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let status = match runtime.block_on(unicity_aos_bootstrap::status::read()) {
+        Ok(status) => status,
+        Err(error) => {
+            eprintln!("aos: runtime status unavailable: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if args.first().is_some_and(|arg| arg == "--json") {
+        match serde_json::to_string(&status) {
+            Ok(json) => println!("{json}"),
+            Err(error) => {
+                eprintln!("aos: failed to encode status: {error}");
+                return ExitCode::FAILURE;
+            }
+        }
+    } else {
+        println!("Unicity AOS");
+        println!("State: {}", status.state);
+        println!("PID: {}", status.pid);
+        println!("Uptime: {}s", status.uptime_secs);
+        println!("Runtime version: {}", status.runtime_version);
+        println!("Connected clients: {}", status.connected_clients);
+        println!("Loaded capsules: {}", status.loaded_capsules.len());
+    }
+    ExitCode::SUCCESS
+}
+
+fn set_runtime_home(home: &AosHome) {
+    // The single-threaded client resolves its local socket from this process-only override.
+    unsafe {
+        std::env::set_var("ASTRID_HOME", home.runtime_home());
+    }
+}
+
+fn product_init_runtime_args(home: &AosHome, args: &[OsString]) -> io::Result<Vec<OsString>> {
+    let mut runtime_args = vec![
+        OsString::from("init"),
+        OsString::from("--distro"),
+        home.ensure_unicity_ce_manifest()?.into_os_string(),
+    ];
+    runtime_args.extend(args.iter().cloned());
+    Ok(runtime_args)
 }
 
 fn has_distro_override(args: &[OsString]) -> bool {
@@ -268,10 +391,7 @@ fn offer_first_run_migration() -> Option<ExitCode> {
         return None;
     }
 
-    println!(
-        "Found a standalone Astrid Runtime home at {}.",
-        source.display()
-    );
+    println!("Found a standalone runtime home at {}.", source.display());
     println!(
         "Unicity can copy compatible runtime state into {}. The existing home will stay unchanged.",
         home.runtime_home().display()
@@ -357,13 +477,13 @@ fn print_legacy_distro_handoff(home: &AosHome) {
 
 fn print_help() {
     println!(
-        "Unicity AOS\n\nUsage:\n  aos init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n  aos migrate runtime --from <absolute-legacy-home>\n  aos self-update\n  aos serve-health\n  aos <runtime command> [arguments...]\n\n`aos init` installs the Unicity CE manifest bundled with this product release. `aos self-update` updates the coordinated AOS and bundled Astrid executable set. `aos serve-health` binds only 127.0.0.1:8765 and exposes GET /v1/runtime/health. Unicity delegates runtime and operator commands to its bundled Astrid Runtime. The runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME)."
+        "Unicity AOS\n\nUsage:\n  aos init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n  aos status [--json]\n  aos migrate runtime --from <absolute-legacy-home>\n  aos self-update\n  aos serve-health\n  aos runtime <command> [arguments...]\n\n`aos init` installs the Unicity CE manifest bundled with this product release. `aos status` reads the typed local runtime status operation. `aos self-update` updates AOS and its pinned runtime. `aos serve-health` binds only 127.0.0.1:8765 and exposes GET /v1/runtime/health. `aos runtime` is the explicit escape hatch for operator and capsule-author commands provided by the bundled Astrid Runtime. Runtime state is scoped to ~/.unicity-os/runtime (or UNICITY_AOS_HOME)."
     );
 }
 
 fn print_init_help() {
     println!(
-        "Unicity AOS\n\nUsage:\n  aos init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n\nInstalls Unicity CE from the manifest bundled with this product release. For a different distro, use the Astrid Runtime CLI directly."
+        "Unicity AOS\n\nUsage:\n  aos init [--yes] [--offline] [--allow-unsigned] [--accept-new-key] [--var KEY=VALUE]\n\nInstalls Unicity CE from the manifest bundled with this product release. For a different distro, use `aos runtime init`."
     );
 }
 
@@ -377,7 +497,7 @@ mod tests {
 
     #[cfg(unix)]
     use super::create_private_update_file;
-    use super::{has_distro_override, product_runtime_args};
+    use super::{RootCommand, child_exit_code, has_distro_override, product_init_runtime_args};
     use unicity_aos_bootstrap::AosHome;
 
     fn temporary_home() -> std::path::PathBuf {
@@ -395,16 +515,13 @@ mod tests {
     fn product_init_pins_unicity_ce_and_preserves_flags() {
         let root = temporary_home();
         let home = AosHome::from_root(&root);
-        let args = product_runtime_args(
-            &home,
-            vec![
-                OsString::from("init"),
-                OsString::from("--yes"),
-                OsString::from("--var"),
-                OsString::from("model=gpt-5"),
-            ],
-        )
-        .expect("materialize product manifest");
+        let init_args = vec![
+            OsString::from("--yes"),
+            OsString::from("--var"),
+            OsString::from("model=gpt-5"),
+        ];
+        let args =
+            product_init_runtime_args(&home, &init_args).expect("materialize product manifest");
         assert_eq!(
             [&args[0], &args[1], &args[3], &args[4], &args[5]],
             ["init", "--distro", "--yes", "--var", "model=gpt-5"]
@@ -425,6 +542,97 @@ mod tests {
         ]));
         assert!(has_distro_override(&[OsString::from("--distro=other")]));
         assert!(!has_distro_override(&[OsString::from("--yes")]));
+    }
+
+    #[test]
+    fn parser_recognizes_only_product_roots_and_explicit_runtime_escape() {
+        assert_eq!(RootCommand::parse(&[]), RootCommand::NoArguments);
+
+        let help = [OsString::from("--help")];
+        assert_eq!(RootCommand::parse(&help), RootCommand::Help);
+        let version = [OsString::from("--version")];
+        assert_eq!(RootCommand::parse(&version), RootCommand::Version);
+
+        let self_update = [OsString::from("self_update"), OsString::from("unexpected")];
+        assert_eq!(
+            RootCommand::parse(&self_update),
+            RootCommand::SelfUpdate(&self_update[1..])
+        );
+        let migrate = [OsString::from("migrate"), OsString::from("runtime")];
+        assert_eq!(
+            RootCommand::parse(&migrate),
+            RootCommand::Migrate(&migrate[1..])
+        );
+        let serve_health = [OsString::from("serve-health"), OsString::from("preserved")];
+        assert_eq!(
+            RootCommand::parse(&serve_health),
+            RootCommand::ServeHealth(&serve_health[1..])
+        );
+        let status = [OsString::from("status"), OsString::from("--json")];
+        assert_eq!(
+            RootCommand::parse(&status),
+            RootCommand::Status(&status[1..])
+        );
+        let init = [OsString::from("init"), OsString::from("--yes")];
+        assert_eq!(RootCommand::parse(&init), RootCommand::Init(&init[1..]));
+        let runtime = [
+            OsString::from("runtime"),
+            OsString::from("capsule"),
+            OsString::from("build"),
+        ];
+        assert_eq!(
+            RootCommand::parse(&runtime),
+            RootCommand::Runtime(&runtime[1..])
+        );
+    }
+
+    #[test]
+    fn parser_rejects_missing_runtime_and_unknown_roots() {
+        let runtime = [OsString::from("runtime")];
+        assert_eq!(
+            RootCommand::parse(&runtime),
+            RootCommand::MissingRuntimeCommand
+        );
+
+        let unknown = [OsString::from("capsule")];
+        assert_eq!(
+            RootCommand::parse(&unknown),
+            RootCommand::Unknown(unknown[0].as_os_str())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parser_rejects_non_utf8_root_commands() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let unknown = [OsString::from_vec(vec![0xff, b'x'])];
+        assert_eq!(
+            RootCommand::parse(&unknown),
+            RootCommand::Unknown(unknown[0].as_os_str())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn child_exit_mapping_preserves_codes_and_maps_signals_to_failure() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let success = std::process::Command::new("sh")
+            .args(["-c", "exit 0"])
+            .status()
+            .expect("run successful child");
+        let failure = std::process::Command::new("sh")
+            .args(["-c", "exit 37"])
+            .status()
+            .expect("run failed child");
+
+        assert_eq!(child_exit_code(success), std::process::ExitCode::SUCCESS);
+        assert_eq!(child_exit_code(failure), std::process::ExitCode::from(37));
+        assert_eq!(
+            child_exit_code(std::process::ExitStatus::from_raw(9)),
+            std::process::ExitCode::FAILURE
+        );
     }
 
     #[cfg(unix)]

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -17,7 +17,7 @@ use std::process::{Command, ExitCode};
 #[cfg(unix)]
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use unicity_aos_bootstrap::AosHome;
+use unicity_aos_bootstrap::{AOS_WORKSPACE_STATE_DIR, AosHome};
 
 fn main() -> ExitCode {
     run()
@@ -259,7 +259,7 @@ fn handle_health_service(args: &[OsString]) -> ExitCode {
         }
     };
 
-    set_runtime_home(&home);
+    set_runtime_environment(&home);
 
     let runtime = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -294,7 +294,7 @@ fn handle_status(args: &[OsString]) -> ExitCode {
         Ok(home) => home,
         Err(code) => return code,
     };
-    set_runtime_home(&home);
+    set_runtime_environment(&home);
     let runtime = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -333,10 +333,11 @@ fn handle_status(args: &[OsString]) -> ExitCode {
     ExitCode::SUCCESS
 }
 
-fn set_runtime_home(home: &AosHome) {
+fn set_runtime_environment(home: &AosHome) {
     // The single-threaded client resolves its local socket from this process-only override.
     unsafe {
         std::env::set_var("ASTRID_HOME", home.runtime_home());
+        std::env::set_var("ASTRID_WORKSPACE_STATE_DIR", AOS_WORKSPACE_STATE_DIR);
     }
 }
 

--- a/crates/unicity-aos-bootstrap/src/status.rs
+++ b/crates/unicity-aos-bootstrap/src/status.rs
@@ -1,0 +1,101 @@
+//! Native AOS status over the runtime's typed local control operation.
+
+use std::time::Duration;
+
+use astrid_core::PrincipalId;
+use astrid_core::kernel_api::{DaemonStatus, KernelRequest, KernelResponse};
+use astrid_uplink::KernelClient;
+use serde::Serialize;
+
+const STATUS_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Product status derived from the typed runtime status response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AosStatus {
+    pub state: &'static str,
+    pub pid: u32,
+    pub uptime_secs: u64,
+    pub runtime_version: String,
+    pub ephemeral: bool,
+    pub connected_clients: u32,
+    pub loaded_capsules: Vec<String>,
+}
+
+impl From<DaemonStatus> for AosStatus {
+    fn from(status: DaemonStatus) -> Self {
+        Self {
+            state: "running",
+            pid: status.pid,
+            uptime_secs: status.uptime_secs,
+            runtime_version: status.version,
+            ephemeral: status.ephemeral,
+            connected_clients: status.connected_clients,
+            loaded_capsules: status.loaded_capsules,
+        }
+    }
+}
+
+/// Read status through the typed authenticated local control client.
+pub async fn read() -> Result<AosStatus, String> {
+    let mut client = tokio::time::timeout(
+        STATUS_TIMEOUT,
+        KernelClient::connect(PrincipalId::default()),
+    )
+    .await
+    .map_err(|_| "connection timed out".to_owned())?
+    .map_err(|_| "could not connect to the local runtime".to_owned())?;
+
+    let response = tokio::time::timeout(STATUS_TIMEOUT, client.request(KernelRequest::GetStatus))
+        .await
+        .map_err(|_| "status request timed out".to_owned())?
+        .map_err(|_| "status request failed".to_owned())?;
+
+    match response {
+        KernelResponse::Status(status) => Ok(status.into()),
+        KernelResponse::Error(error) => Err(error),
+        _ => Err("runtime returned an unexpected status response".to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use astrid_core::kernel_api::DaemonStatus;
+
+    use super::AosStatus;
+
+    #[test]
+    fn maps_typed_runtime_status_to_product_status() {
+        let status = AosStatus::from(DaemonStatus {
+            pid: 42,
+            uptime_secs: 90,
+            version: "0.9.4".to_owned(),
+            ephemeral: false,
+            connected_clients: 3,
+            connections_by_principal: Vec::new(),
+            loaded_capsules: vec!["agents".to_owned(), "session".to_owned()],
+        });
+
+        assert_eq!(status.state, "running");
+        assert_eq!(status.pid, 42);
+        assert_eq!(status.runtime_version, "0.9.4");
+        assert_eq!(status.loaded_capsules, ["agents", "session"]);
+    }
+
+    #[test]
+    fn json_has_aos_owned_field_names() {
+        let status = AosStatus {
+            state: "running",
+            pid: 7,
+            uptime_secs: 8,
+            runtime_version: "0.9.4".to_owned(),
+            ephemeral: false,
+            connected_clients: 1,
+            loaded_capsules: vec!["agents".to_owned()],
+        };
+
+        let value = serde_json::to_value(status).expect("serialize status");
+        assert_eq!(value["state"], "running");
+        assert_eq!(value["runtime_version"], "0.9.4");
+        assert!(value.get("astrid").is_none());
+    }
+}

--- a/crates/unicity-aos-bootstrap/src/status.rs
+++ b/crates/unicity-aos-bootstrap/src/status.rs
@@ -43,12 +43,12 @@ pub async fn read() -> Result<AosStatus, String> {
     )
     .await
     .map_err(|_| "connection timed out".to_owned())?
-    .map_err(|_| "could not connect to the local runtime".to_owned())?;
+    .map_err(|error| format!("could not connect to the local runtime: {error}"))?;
 
     let response = tokio::time::timeout(STATUS_TIMEOUT, client.request(KernelRequest::GetStatus))
         .await
         .map_err(|_| "status request timed out".to_owned())?
-        .map_err(|_| "status request failed".to_owned())?;
+        .map_err(|error| format!("status request failed: {error}"))?;
 
     match response {
         KernelResponse::Status(status) => Ok(status.into()),

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -71,30 +71,26 @@ exit "${AOS_TEST_EXIT:-0}"
 "#;
 
 #[test]
-fn unknown_root_fails_without_invoking_the_runtime() {
-    let fixture = Fixture::new("unknown");
+fn unowned_root_passes_through_with_argv_home_and_exit_code() {
+    let fixture = Fixture::new("passthrough");
     fixture.install_runtime(RECORDING_RUNTIME);
 
-    let output = fixture.command().arg("capsule").output().expect("run aos");
+    let output = fixture
+        .command()
+        .env("AOS_TEST_EXIT", "37")
+        .args(["doctor", "--json", "space value", "$(not-a-shell)"])
+        .output()
+        .expect("run aos");
 
-    assert_eq!(output.status.code(), Some(1));
-    assert!(!fixture.args.exists());
-    let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
-    assert!(stderr.contains("aos: unknown command `capsule`"));
-    assert!(stderr.contains("aos --help"));
-}
-
-#[test]
-fn runtime_requires_an_explicit_subcommand() {
-    let fixture = Fixture::new("missing-runtime-command");
-    fixture.install_runtime(RECORDING_RUNTIME);
-
-    let output = fixture.command().arg("runtime").output().expect("run aos");
-
-    assert_eq!(output.status.code(), Some(1));
-    assert!(!fixture.args.exists());
-    let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
-    assert!(stderr.contains("Usage: aos runtime <command>"));
+    assert_eq!(output.status.code(), Some(37));
+    assert_eq!(
+        fs::read_to_string(&fixture.args).expect("read delegated args"),
+        "<doctor>\n<--json>\n<space value>\n<$(not-a-shell)>\n"
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("child-home")).expect("read runtime home"),
+        format!("{}\n", fixture.home.join("runtime").display())
+    );
 }
 
 #[test]
@@ -121,31 +117,20 @@ fn product_help_version_and_usage_errors_never_delegate() {
 }
 
 #[test]
-fn runtime_escape_preserves_arguments_home_and_exit_code() {
-    let fixture = Fixture::new("runtime-delegation");
+fn runtime_is_an_inherited_root_not_a_special_alias() {
+    let fixture = Fixture::new("runtime-root");
     fixture.install_runtime(RECORDING_RUNTIME);
 
     let output = fixture
         .command()
-        .env("AOS_TEST_EXIT", "37")
-        .args([
-            "runtime",
-            "doctor",
-            "--json",
-            "space value",
-            "$(not-a-shell)",
-        ])
+        .args(["runtime", "status", "--json"])
         .output()
         .expect("run aos");
 
-    assert_eq!(output.status.code(), Some(37));
+    assert!(output.status.success());
     assert_eq!(
         fs::read_to_string(&fixture.args).expect("read delegated args"),
-        "<doctor>\n<--json>\n<space value>\n<$(not-a-shell)>\n"
-    );
-    assert_eq!(
-        fs::read_to_string(fixture.root.join("child-home")).expect("read runtime home"),
-        format!("{}\n", fixture.home.join("runtime").display())
+        "<runtime>\n<status>\n<--json>\n"
     );
 }
 
@@ -176,7 +161,7 @@ fn product_init_pins_the_bundled_distro_and_rejects_overrides() {
     assert!(
         String::from_utf8(output.stderr)
             .expect("utf8 stderr")
-            .contains("aos runtime init")
+            .contains("astrid init")
     );
 }
 
@@ -201,7 +186,7 @@ fn native_status_does_not_invoke_the_runtime_cli() {
 }
 
 #[test]
-fn unix_runtime_escape_preserves_signal_termination() {
+fn unix_passthrough_preserves_signal_termination() {
     let fixture = Fixture::new("signal");
     let ready = fixture.root.join("ready");
     fixture.install_runtime(&format!(
@@ -211,9 +196,9 @@ fn unix_runtime_escape_preserves_signal_termination() {
 
     let mut child = fixture
         .command()
-        .args(["runtime", "wait"])
+        .arg("wait")
         .spawn()
-        .expect("spawn aos runtime");
+        .expect("spawn inherited command");
     for _ in 0..200 {
         if ready.exists() {
             break;

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -1,0 +1,232 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::ExitStatusExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+struct Fixture {
+    root: PathBuf,
+    runtime: PathBuf,
+    args: PathBuf,
+    home: PathBuf,
+}
+
+impl Fixture {
+    fn new(name: &str) -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "aos-cli-boundary-{name}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).expect("create fixture");
+        let runtime = root.join("fake-runtime");
+        let args = root.join("args");
+        let home = root.join("runtime-home");
+        Self {
+            root,
+            runtime,
+            args,
+            home,
+        }
+    }
+
+    fn install_runtime(&self, body: &str) {
+        fs::write(&self.runtime, body).expect("write fake runtime");
+        let mut permissions = fs::metadata(&self.runtime)
+            .expect("runtime metadata")
+            .permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&self.runtime, permissions).expect("make runtime executable");
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_aos"));
+        command
+            .env("UNICITY_AOS_HOME", &self.home)
+            .env("UNICITY_AOS_RUNTIME_BIN", &self.runtime)
+            .env("AOS_TEST_ARGS", &self.args)
+            .env("AOS_TEST_HOME", self.root.join("child-home"));
+        command
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+const RECORDING_RUNTIME: &str = r#"#!/bin/sh
+for arg in "$@"; do
+    printf '<%s>\n' "$arg"
+done > "$AOS_TEST_ARGS"
+printf '%s\n' "$ASTRID_HOME" > "$AOS_TEST_HOME"
+exit "${AOS_TEST_EXIT:-0}"
+"#;
+
+#[test]
+fn unknown_root_fails_without_invoking_the_runtime() {
+    let fixture = Fixture::new("unknown");
+    fixture.install_runtime(RECORDING_RUNTIME);
+
+    let output = fixture.command().arg("capsule").output().expect("run aos");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(!fixture.args.exists());
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
+    assert!(stderr.contains("aos: unknown command `capsule`"));
+    assert!(stderr.contains("aos --help"));
+}
+
+#[test]
+fn runtime_requires_an_explicit_subcommand() {
+    let fixture = Fixture::new("missing-runtime-command");
+    fixture.install_runtime(RECORDING_RUNTIME);
+
+    let output = fixture.command().arg("runtime").output().expect("run aos");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(!fixture.args.exists());
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
+    assert!(stderr.contains("Usage: aos runtime <command>"));
+}
+
+#[test]
+fn product_help_version_and_usage_errors_never_delegate() {
+    let fixture = Fixture::new("product-roots");
+    fixture.install_runtime(RECORDING_RUNTIME);
+
+    for (args, expected_success) in [
+        (vec!["--help"], true),
+        (vec!["--version"], true),
+        (vec!["init", "--help"], true),
+        (vec!["migrate"], false),
+        (vec!["self-update", "unexpected"], false),
+        (vec!["serve-health", "unexpected"], false),
+    ] {
+        let status = fixture
+            .command()
+            .args(args)
+            .status()
+            .expect("run product command");
+        assert_eq!(status.success(), expected_success);
+        assert!(!fixture.args.exists());
+    }
+}
+
+#[test]
+fn runtime_escape_preserves_arguments_home_and_exit_code() {
+    let fixture = Fixture::new("runtime-delegation");
+    fixture.install_runtime(RECORDING_RUNTIME);
+
+    let output = fixture
+        .command()
+        .env("AOS_TEST_EXIT", "37")
+        .args([
+            "runtime",
+            "doctor",
+            "--json",
+            "space value",
+            "$(not-a-shell)",
+        ])
+        .output()
+        .expect("run aos");
+
+    assert_eq!(output.status.code(), Some(37));
+    assert_eq!(
+        fs::read_to_string(&fixture.args).expect("read delegated args"),
+        "<doctor>\n<--json>\n<space value>\n<$(not-a-shell)>\n"
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("child-home")).expect("read runtime home"),
+        format!("{}\n", fixture.home.join("runtime").display())
+    );
+}
+
+#[test]
+fn product_init_pins_the_bundled_distro_and_rejects_overrides() {
+    let fixture = Fixture::new("init");
+    fixture.install_runtime(RECORDING_RUNTIME);
+
+    let status = fixture
+        .command()
+        .args(["init", "--yes", "--var", "model=gpt-5"])
+        .status()
+        .expect("run product init");
+    assert!(status.success());
+    let args = fs::read_to_string(&fixture.args).expect("read init args");
+    assert!(args.starts_with("<init>\n<--distro>\n"));
+    assert!(args.contains("<--yes>\n<--var>\n<model=gpt-5>\n"));
+    assert!(args.contains("/distributions/unicity-ce/Distro.toml>"));
+
+    fs::remove_file(&fixture.args).expect("remove first invocation marker");
+    let output = fixture
+        .command()
+        .args(["init", "--distro=other"])
+        .output()
+        .expect("run protected init");
+    assert_eq!(output.status.code(), Some(1));
+    assert!(!fixture.args.exists());
+    assert!(
+        String::from_utf8(output.stderr)
+            .expect("utf8 stderr")
+            .contains("aos runtime init")
+    );
+}
+
+#[test]
+fn native_status_does_not_invoke_the_runtime_cli() {
+    let fixture = Fixture::new("status");
+    fixture.install_runtime(RECORDING_RUNTIME);
+
+    let output = fixture
+        .command()
+        .arg("status")
+        .output()
+        .expect("run aos status");
+
+    assert!(!output.status.success());
+    assert!(!fixture.args.exists());
+    assert!(
+        String::from_utf8(output.stderr)
+            .expect("utf8 stderr")
+            .contains("aos: runtime status unavailable")
+    );
+}
+
+#[test]
+fn unix_runtime_escape_preserves_signal_termination() {
+    let fixture = Fixture::new("signal");
+    let ready = fixture.root.join("ready");
+    fixture.install_runtime(&format!(
+        "#!/bin/sh\nprintf ready > '{}'\nexec sleep 30\n",
+        shell_literal_path(&ready)
+    ));
+
+    let mut child = fixture
+        .command()
+        .args(["runtime", "wait"])
+        .spawn()
+        .expect("spawn aos runtime");
+    for _ in 0..200 {
+        if ready.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(ready.exists(), "runtime must replace the aos process");
+
+    child.kill().expect("terminate delegated runtime");
+    let status = child.wait().expect("wait for delegated runtime");
+    assert_eq!(status.signal(), Some(9));
+}
+
+fn shell_literal_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\'', "'\\''")
+}

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -170,19 +170,21 @@ fn native_status_does_not_invoke_the_runtime_cli() {
     let fixture = Fixture::new("status");
     fixture.install_runtime(RECORDING_RUNTIME);
 
-    let output = fixture
-        .command()
-        .arg("status")
-        .output()
-        .expect("run aos status");
+    for args in [vec!["status"], vec!["status", "--json"]] {
+        let output = fixture
+            .command()
+            .args(args)
+            .output()
+            .expect("run aos status");
 
-    assert!(!output.status.success());
-    assert!(!fixture.args.exists());
-    assert!(
-        String::from_utf8(output.stderr)
-            .expect("utf8 stderr")
-            .contains("aos: runtime status unavailable")
-    );
+        assert!(!output.status.success());
+        assert!(!fixture.args.exists());
+        assert!(
+            String::from_utf8(output.stderr)
+                .expect("utf8 stderr")
+                .contains("aos: runtime status unavailable")
+        );
+    }
 }
 
 #[test]
@@ -190,7 +192,7 @@ fn unix_passthrough_preserves_signal_termination() {
     let fixture = Fixture::new("signal");
     let ready = fixture.root.join("ready");
     fixture.install_runtime(&format!(
-        "#!/bin/sh\nprintf ready > '{}'\nexec sleep 30\n",
+        "#!/bin/sh\nprintf '%s\\n' \"$$\" > '{}'\nexec sleep 30\n",
         shell_literal_path(&ready)
     ));
 
@@ -206,6 +208,15 @@ fn unix_passthrough_preserves_signal_termination() {
         std::thread::sleep(Duration::from_millis(10));
     }
     assert!(ready.exists(), "runtime must replace the aos process");
+    assert_eq!(
+        fs::read_to_string(&ready)
+            .expect("read runtime pid")
+            .trim()
+            .parse::<u32>()
+            .expect("parse runtime pid"),
+        child.id(),
+        "the runtime script must retain the aos process id"
+    );
 
     child.kill().expect("terminate delegated runtime");
     let status = child.wait().expect("wait for delegated runtime");

--- a/install.sh
+++ b/install.sh
@@ -114,21 +114,17 @@ trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-if command -v cosign >/dev/null 2>&1; then
-  COSIGN_BIN=$(command -v cosign)
-else
-  COSIGN_BIN="$work/cosign"
-  echo "Downloading the pinned Sigstore verifier..."
-  curl --proto '=https' --tlsv1.2 -fsSL \
-    "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/${cosign_asset}" \
-    -o "$COSIGN_BIN"
-  [ ! -L "$COSIGN_BIN" ] || { echo "downloaded Sigstore verifier is a symlink" >&2; exit 1; }
-  [ "$(sha256_file "$COSIGN_BIN")" = "$cosign_sha256" ] || {
-    echo "Sigstore verifier checksum mismatch" >&2
-    exit 1
-  }
-  chmod 700 "$COSIGN_BIN"
-fi
+COSIGN_BIN="$work/cosign"
+echo "Downloading the pinned Sigstore verifier..."
+curl --proto '=https' --tlsv1.2 -fsSL \
+  "https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/${cosign_asset}" \
+  -o "$COSIGN_BIN"
+[ ! -L "$COSIGN_BIN" ] || { echo "downloaded Sigstore verifier is a symlink" >&2; exit 1; }
+[ "$(sha256_file "$COSIGN_BIN")" = "$cosign_sha256" ] || {
+  echo "Sigstore verifier checksum mismatch" >&2
+  exit 1
+}
+chmod 700 "$COSIGN_BIN"
 
 echo "Downloading Unicity AOS for $target..."
 curl --proto '=https' --tlsv1.2 -fsSL "$base/$asset" -o "$work/$asset"
@@ -205,6 +201,18 @@ if [ "$bundle_name" != "unicity-aos-${staged_version}-${target}" ]; then
   exit 1
 fi
 
+for managed in "$AOS_HOME" "$AOS_HOME/runtime" "$AOS_HOME/runtime/bin" "$AOS_HOME/releases"; do
+  [ ! -L "$managed" ] || { echo "refusing symlinked managed path: $managed" >&2; exit 1; }
+done
+if [ -L "$AOS_BIN_DIR" ]; then
+  echo "refusing symlinked managed path: $AOS_BIN_DIR" >&2
+  exit 1
+fi
+if [ -L "$AOS_BIN_DIR/aos" ] || { [ -e "$AOS_BIN_DIR/aos" ] && [ ! -f "$AOS_BIN_DIR/aos" ]; }; then
+  echo "refusing non-regular install destination: $AOS_BIN_DIR/aos" >&2
+  exit 1
+fi
+
 if [ -x "$AOS_BIN_DIR/aos" ] && [ "$ASSUME_YES" -ne 1 ] && [ -t 0 ]; then
   printf 'Replace the existing Unicity AOS installation? [y/N] '
   read -r answer
@@ -213,14 +221,6 @@ fi
 
 if [ -x "$AOS_BIN_DIR/aos" ]; then
   "$AOS_BIN_DIR/aos" stop >/dev/null 2>&1 || true
-fi
-
-for managed in "$AOS_HOME" "$AOS_HOME/runtime" "$AOS_HOME/runtime/bin" "$AOS_HOME/releases"; do
-  [ ! -L "$managed" ] || { echo "refusing symlinked managed path: $managed" >&2; exit 1; }
-done
-if [ "$AOS_BIN_DIR" = "$AOS_HOME/bin" ] && [ -L "$AOS_BIN_DIR" ]; then
-  echo "refusing symlinked managed path: $AOS_BIN_DIR" >&2
-  exit 1
 fi
 
 mkdir -p "$AOS_BIN_DIR" "$AOS_HOME/runtime/bin" "$AOS_HOME/releases"

--- a/install.sh
+++ b/install.sh
@@ -227,7 +227,11 @@ install_one() {
   name=$3
   mode=$4
   temporary="${destination}.new.$$"
-  if [ -e "$destination" ] || [ -L "$destination" ]; then
+  if [ -L "$destination" ] || { [ -e "$destination" ] && [ ! -f "$destination" ]; }; then
+    echo "refusing non-regular install destination: $destination" >&2
+    return 1
+  fi
+  if [ -f "$destination" ]; then
     cp -p "$destination" "$rollback/$name" || return 1
   fi
   cp "$source" "$temporary" || return 1

--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,17 @@ curl --proto '=https' --tlsv1.2 -fsSL "$base/$asset.sigstore.json" -o "$work/$as
   --certificate-identity-regexp '^https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/20[0-9]{2}\.[0-9]+\.[0-9]+$' \
   "$work/$asset" >/dev/null
 
-expected=$(awk -v asset="$asset" '$2 == asset || $2 == "*" asset { print $1; exit }' "$work/SHA256SUMS.txt")
+expected=$(awk -v asset="$asset" '
+  {
+    checksum_asset = $2
+    sub(/^\*/, "", checksum_asset)
+    sub(/^\.\//, "", checksum_asset)
+    if (checksum_asset == asset) {
+      print $1
+      exit
+    }
+  }
+' "$work/SHA256SUMS.txt")
 [ -n "$expected" ] || { echo "release checksum list does not contain $asset" >&2; exit 1; }
 actual=$(sha256_file "$work/$asset")
 [ "$actual" = "$expected" ] || { echo "Unicity AOS archive checksum mismatch" >&2; exit 1; }

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,20 @@ need() { command -v "$1" >/dev/null 2>&1 || { echo "required command not found: 
 need curl
 need tar
 
+has_interactive_tty() {
+  { [ -t 1 ] || [ -t 2 ]; } && : 2>/dev/null </dev/tty && : 2>/dev/null >/dev/tty
+}
+
+prompt_from_tty() {
+  prompt=$1
+  if ! printf '%s' "$prompt" 2>/dev/null >/dev/tty; then
+    return 1
+  fi
+  if ! IFS= read -r answer 2>/dev/null </dev/tty; then
+    return 1
+  fi
+}
+
 sha256_file() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | awk '{print $1}'
@@ -205,7 +219,7 @@ for managed in "$AOS_HOME" "$AOS_HOME/runtime" "$AOS_HOME/runtime/bin" "$AOS_HOM
   [ ! -L "$managed" ] || { echo "refusing symlinked managed path: $managed" >&2; exit 1; }
 done
 if [ -L "$AOS_BIN_DIR" ]; then
-  echo "refusing symlinked managed path: $AOS_BIN_DIR" >&2
+  echo "refusing symlinked binary directory: $AOS_BIN_DIR" >&2
   exit 1
 fi
 if [ -L "$AOS_BIN_DIR/aos" ] || { [ -e "$AOS_BIN_DIR/aos" ] && [ ! -f "$AOS_BIN_DIR/aos" ]; }; then
@@ -213,9 +227,12 @@ if [ -L "$AOS_BIN_DIR/aos" ] || { [ -e "$AOS_BIN_DIR/aos" ] && [ ! -f "$AOS_BIN_
   exit 1
 fi
 
-if [ -x "$AOS_BIN_DIR/aos" ] && [ "$ASSUME_YES" -ne 1 ] && [ -t 0 ]; then
-  printf 'Replace the existing Unicity AOS installation? [y/N] '
-  read -r answer
+if [ -x "$AOS_BIN_DIR/aos" ] && [ "$ASSUME_YES" -ne 1 ]; then
+  answer=
+  if ! has_interactive_tty || ! prompt_from_tty 'Replace the existing Unicity AOS installation? [y/N] '; then
+    echo "an existing Unicity AOS installation was found; rerun with --yes to replace it without a prompt" >&2
+    exit 1
+  fi
   case "$answer" in y|Y|yes|YES) ;; *) echo "Installation cancelled."; exit 0 ;; esac
 fi
 
@@ -290,8 +307,8 @@ case ":$PATH:" in
     ;;
 esac
 
-if [ "$SKIP_MIGRATION_PROMPT" -ne 1 ] && [ -t 0 ]; then
-  "$AOS_BIN_DIR/aos" || true
+if [ "$SKIP_MIGRATION_PROMPT" -ne 1 ] && has_interactive_tty; then
+  "$AOS_BIN_DIR/aos" </dev/tty >/dev/tty 2>/dev/tty || true
 else
   echo "Run: $init_command"
 fi

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -141,6 +141,27 @@ if PATH="$fake_bin:$PATH" HOME="$work/other-home" AOS_TEST_FIXTURE="$fixture" AO
 fi
 cp "$work/good-sums" "$fixture/SHA256SUMS.txt"
 
+symlink_home="$work/symlink-destination-home"
+mkdir -p "$symlink_home/.unicity-os/bin"
+printf 'outside-install-root\n' > "$work/symlink-target"
+ln -s "$work/symlink-target" "$symlink_home/.unicity-os/bin/aos"
+if PATH="$fake_bin:$PATH" HOME="$symlink_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer replaced a symlinked destination" >&2
+  exit 1
+fi
+test -L "$symlink_home/.unicity-os/bin/aos"
+test "$(cat "$work/symlink-target")" = outside-install-root
+
+directory_home="$work/directory-destination-home"
+mkdir -p "$directory_home/.unicity-os/bin/aos"
+if PATH="$fake_bin:$PATH" HOME="$directory_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer replaced a directory destination" >&2
+  exit 1
+fi
+test -d "$directory_home/.unicity-os/bin/aos"
+
 for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
   case "$binary" in
     aos) destination="$work/home/.unicity-os/bin/aos" ;;

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -26,7 +26,7 @@ for binary in astrid astrid-daemon astrid-build astrid-emit; do
   printf '#!/bin/sh\necho %s\n' "$binary" > "$runtime_root/$binary"
   chmod 755 "$runtime_root/$binary"
 done
-tar -czf "$work/runtime.tar.gz" -C "$work" "$(basename "$runtime_root")"
+COPYFILE_DISABLE=1 tar -czf "$work/runtime.tar.gz" -C "$work" "$(basename "$runtime_root")"
 "$repo_root/scripts/package-release.sh" \
   x86_64-unknown-linux-gnu \
   "$work/aos" \
@@ -69,13 +69,48 @@ done
 [ -n "$url" ]
 cp "$AOS_TEST_FIXTURE/$(basename "$url")" "$output"
 EOF
-cat > "$fake_bin/cosign" <<'EOF'
+cat > "$fixture/cosign-linux-amd64" <<'EOF'
 #!/bin/sh
 set -eu
 [ "${1:-}" = verify-blob ]
 : > "$AOS_TEST_FIXTURE/cosign-called"
 EOF
-chmod 755 "$fake_bin/uname" "$fake_bin/curl" "$fake_bin/cosign"
+cat > "$fake_bin/cosign" <<'EOF'
+#!/bin/sh
+set -eu
+: > "$AOS_TEST_FIXTURE/path-cosign-called"
+exit 99
+EOF
+
+if command -v sha256sum >/dev/null 2>&1; then
+  REAL_HASH=$(command -v sha256sum)
+  HASH_KIND=sha256sum
+else
+  REAL_HASH=$(command -v shasum)
+  HASH_KIND=shasum
+fi
+export REAL_HASH HASH_KIND
+cat > "$fake_bin/sha256sum" <<'EOF'
+#!/bin/sh
+set -eu
+case "$1" in
+  */cosign)
+    if [ "${AOS_TEST_BAD_COSIGN_DIGEST:-0}" = 1 ]; then
+      printf '%064d  %s\n' 0 "$1"
+    else
+      printf '%s  %s\n' ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc "$1"
+    fi
+    ;;
+  *)
+    if [ "$HASH_KIND" = shasum ]; then
+      exec "$REAL_HASH" -a 256 "$@"
+    fi
+    exec "$REAL_HASH" "$@"
+    ;;
+esac
+EOF
+chmod 755 "$fake_bin/uname" "$fake_bin/curl" "$fake_bin/cosign" \
+  "$fake_bin/sha256sum" "$fixture/cosign-linux-amd64"
 
 PATH="$fake_bin:$PATH" \
 HOME="$work/home" \
@@ -89,48 +124,19 @@ test -f "$work/home/.unicity-os/releases/2026.1.0.json"
 test "$("$work/home/.unicity-os/bin/aos" --version)" = 'Unicity AOS 2026.1.0'
 test "$(cat "$work/home/.astrid/sentinel")" = 'standalone-runtime-state'
 test -f "$fixture/cosign-called"
+test ! -e "$fixture/path-cosign-called"
 test "$(stat -c '%a' "$work/home/.unicity-os" 2>/dev/null || stat -f '%Lp' "$work/home/.unicity-os")" = 700
 test "$(stat -c '%a' "$work/home/.unicity-os/releases/2026.1.0.json" 2>/dev/null || stat -f '%Lp' "$work/home/.unicity-os/releases/2026.1.0.json")" = 600
 
-# Exercise the no-preinstalled-cosign path without downloading the 140 MB real
-# verifier. The production digest stays hard-coded; only this fake hash command
-# substitutes that digest for the tiny fixture executable.
-bootstrap_bin="$work/bootstrap-bin"
-mkdir "$bootstrap_bin"
-if command -v sha256sum >/dev/null 2>&1; then
-  real_hash=$(command -v sha256sum)
-  hash_kind=sha256sum
-else
-  real_hash=$(command -v shasum)
-  hash_kind=shasum
-fi
-cat > "$bootstrap_bin/sha256sum" <<'EOF'
-#!/bin/sh
-set -eu
-case "$1" in
-  */cosign)
-    printf '%s  %s\n' ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc "$1"
-    ;;
-  *)
-    if [ "$HASH_KIND" = shasum ]; then
-      exec "$REAL_HASH" -a 256 "$@"
-    fi
-    exec "$REAL_HASH" "$@"
-    ;;
-esac
-EOF
-chmod 755 "$bootstrap_bin/sha256sum"
-mv "$fake_bin/cosign" "$fixture/cosign-linux-amd64"
 rm -f "$fixture/cosign-called"
-PATH="$bootstrap_bin:$fake_bin:/usr/bin:/bin" \
-HOME="$work/bootstrap-home" \
-AOS_TEST_FIXTURE="$fixture" \
-AOS_VERSION=2026.1.0 \
-REAL_HASH="$real_hash" \
-HASH_KIND="$hash_kind" \
-sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
-test -f "$fixture/cosign-called"
-mv "$fixture/cosign-linux-amd64" "$fake_bin/cosign"
+if PATH="$fake_bin:$PATH" HOME="$work/bad-verifier-home" AOS_TEST_FIXTURE="$fixture" \
+  AOS_TEST_BAD_COSIGN_DIGEST=1 AOS_VERSION=2026.1.0 \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a Sigstore verifier with the wrong digest" >&2
+  exit 1
+fi
+test ! -e "$fixture/cosign-called"
+test ! -e "$work/bad-verifier-home/.unicity-os"
 
 cp "$fixture/SHA256SUMS.txt" "$work/good-sums"
 
@@ -157,15 +163,48 @@ cp "$work/good-sums" "$fixture/SHA256SUMS.txt"
 
 symlink_home="$work/symlink-destination-home"
 mkdir -p "$symlink_home/.unicity-os/bin"
-printf 'outside-install-root\n' > "$work/symlink-target"
+cat > "$work/symlink-target" <<'EOF'
+#!/bin/sh
+set -eu
+: > "$AOS_SYMLINK_MARKER"
+EOF
+chmod 755 "$work/symlink-target"
 ln -s "$work/symlink-target" "$symlink_home/.unicity-os/bin/aos"
 if PATH="$fake_bin:$PATH" HOME="$symlink_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+  AOS_SYMLINK_MARKER="$work/symlink-executed" \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer replaced a symlinked destination" >&2
   exit 1
 fi
 test -L "$symlink_home/.unicity-os/bin/aos"
-test "$(cat "$work/symlink-target")" = outside-install-root
+test ! -e "$work/symlink-executed"
+
+custom_bin_home="$work/custom-bin-home"
+custom_bin_target="$work/custom-bin-target"
+custom_bin_link="$work/custom-bin-link"
+mkdir -p "$custom_bin_home" "$custom_bin_target"
+cp "$work/symlink-target" "$custom_bin_target/aos"
+ln -s "$custom_bin_target" "$custom_bin_link"
+if PATH="$fake_bin:$PATH" HOME="$custom_bin_home" AOS_BIN_DIR="$custom_bin_link" \
+  AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+  AOS_SYMLINK_MARKER="$work/custom-bin-symlink-executed" \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a symlinked custom binary directory" >&2
+  exit 1
+fi
+test ! -e "$work/custom-bin-symlink-executed"
+
+managed_symlink_home="$work/managed-symlink-home"
+mkdir -p "$managed_symlink_home" "$work/managed-symlink-target/bin"
+ln -s "$work/managed-symlink-target" "$managed_symlink_home/.unicity-os"
+ln -s "$work/symlink-target" "$work/managed-symlink-target/bin/aos"
+if PATH="$fake_bin:$PATH" HOME="$managed_symlink_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+  AOS_SYMLINK_MARKER="$work/managed-symlink-executed" \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a symlinked managed installation root" >&2
+  exit 1
+fi
+test ! -e "$work/managed-symlink-executed"
 
 directory_home="$work/directory-destination-home"
 mkdir -p "$directory_home/.unicity-os/bin/aos"
@@ -260,7 +299,7 @@ for binary in astrid astrid-daemon astrid-build astrid-emit; do
   cp "$runtime_root/$binary" "$unsafe_root/runtime/bin/$binary"
 done
 printf '{}\n' > "$unsafe_root/release-manifest.json"
-tar -czf "$fixture/unicity-aos-x86_64-unknown-linux-gnu.tar.gz" \
+COPYFILE_DISABLE=1 tar -czf "$fixture/unicity-aos-x86_64-unknown-linux-gnu.tar.gz" \
   -C "$work/unsafe-bundle" "$(basename "$unsafe_root")"
 (
   cd "$fixture"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -128,6 +128,26 @@ test ! -e "$fixture/path-cosign-called"
 test "$(stat -c '%a' "$work/home/.unicity-os" 2>/dev/null || stat -f '%Lp' "$work/home/.unicity-os")" = 700
 test "$(stat -c '%a' "$work/home/.unicity-os/releases/2026.1.0.json" 2>/dev/null || stat -f '%Lp' "$work/home/.unicity-os/releases/2026.1.0.json")" = 600
 
+cat > "$work/home/.unicity-os/bin/aos" <<'EOF'
+#!/bin/sh
+set -eu
+if [ "${1:-}" = stop ]; then
+  : > "$AOS_STOP_MARKER"
+fi
+echo existing-unicity-aos
+EOF
+chmod 755 "$work/home/.unicity-os/bin/aos"
+cp "$work/home/.unicity-os/bin/aos" "$work/aos-before-unattended-upgrade"
+if PATH="$fake_bin:$PATH" HOME="$work/home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+  AOS_STOP_MARKER="$work/unattended-stop-called" \
+  sh "$repo_root/install.sh" --no-migrate-prompt </dev/null >"$work/unattended-upgrade.log" 2>&1; then
+  echo "installer replaced an existing installation without confirmation" >&2
+  exit 1
+fi
+cmp "$work/aos-before-unattended-upgrade" "$work/home/.unicity-os/bin/aos"
+test ! -e "$work/unattended-stop-called"
+grep -F 'rerun with --yes to replace it without a prompt' "$work/unattended-upgrade.log" >/dev/null
+
 rm -f "$fixture/cosign-called"
 if PATH="$fake_bin:$PATH" HOME="$work/bad-verifier-home" AOS_TEST_FIXTURE="$fixture" \
   AOS_TEST_BAD_COSIGN_DIGEST=1 AOS_VERSION=2026.1.0 \
@@ -188,11 +208,12 @@ ln -s "$custom_bin_target" "$custom_bin_link"
 if PATH="$fake_bin:$PATH" HOME="$custom_bin_home" AOS_BIN_DIR="$custom_bin_link" \
   AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
   AOS_SYMLINK_MARKER="$work/custom-bin-symlink-executed" \
-  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >"$work/custom-bin-symlink.log" 2>&1; then
   echo "installer accepted a symlinked custom binary directory" >&2
   exit 1
 fi
 test ! -e "$work/custom-bin-symlink-executed"
+grep -F "refusing symlinked binary directory: $custom_bin_link" "$work/custom-bin-symlink.log" >/dev/null
 
 managed_symlink_home="$work/managed-symlink-home"
 mkdir -p "$managed_symlink_home" "$work/managed-symlink-target/bin"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -133,6 +133,20 @@ test -f "$fixture/cosign-called"
 mv "$fixture/cosign-linux-amd64" "$fake_bin/cosign"
 
 cp "$fixture/SHA256SUMS.txt" "$work/good-sums"
+
+# Accept checksum entries generated with a relative ./ prefix.
+awk '{
+  checksum_asset = $2
+  sub(/^\*/, "", checksum_asset)
+  print $1 "  ./" checksum_asset
+}' "$work/good-sums" > "$fixture/SHA256SUMS.txt"
+PATH="$fake_bin:$PATH" \
+HOME="$work/relative-checksum-home" \
+AOS_TEST_FIXTURE="$fixture" \
+AOS_VERSION=2026.1.0 \
+sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
+test -x "$work/relative-checksum-home/.unicity-os/bin/aos"
+
 printf '%064d  unicity-aos-x86_64-unknown-linux-gnu.tar.gz\n' 1 > "$fixture/SHA256SUMS.txt"
 if PATH="$fake_bin:$PATH" HOME="$work/other-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then


### PR DESCRIPTION
Closes #26

## Summary

- makes AOS-native roots override their runtime counterparts while every other command inherits the bundled Astrid CLI directly
- preserves the complete argument vector, exit code, and Unix signal behavior through the inherited command path
- injects the product-owned `.unicity-os` workspace state-directory selection into every bundled runtime command without changing standalone Astrid
- adds native `aos status [--json]` over the typed local runtime status request
- keeps `aos init` fixed to the bundled Community Edition distribution
- retains migration, self-update, health, help, and version behavior
- removes the old trusted-distribution wording and documents the boundary
- always downloads the fixed Cosign release asset and verifies its target-specific hardcoded digest before using it, ignoring PATH-provided substitutes
- rejects symlinked managed roots, symlinked binary directories, and non-regular binary destinations before prompting, stopping, backing up, or replacing an existing installation
- preserves replacement and first-run prompts for `curl | sh` by using `/dev/tty`, while unattended replacement fails closed unless `--yes` is explicit
- accepts standard checksum entries named `asset`, `*asset`, `./asset`, or `*./asset`
- adds regressions for relative checksum paths, an incorrect verifier digest, malicious executable symlinks, custom binary-directory symlinks, non-regular destinations, and unattended replacement before confirmation

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p unicity-aos-bootstrap`
- `cargo clippy -p unicity-aos-bootstrap --all-targets -- -D warnings`
- `cargo test -p unicity-aos-bootstrap --no-run`
- `sh -n install.sh`
- `bash -n scripts/test-install.sh`
- `shellcheck install.sh scripts/test-install.sh`
- pinned Cosign digests match Sigstore's official v3.1.1 checksum manifest for all four published targets
- canonical and website installer copies are byte-identical

Full local Rust test execution reaches the macOS pre-harness policy stall already seen in this workspace. The installer harness likewise stalls while spawning nested fixture scripts in this environment; GitHub CI remains the execution gate for both suites.

The workspace-layout input is intentionally dormant with the currently pinned runtime and becomes active when the neutral Astrid layout support is released and the compatibility pin advances.
