### PR TITLE
release: pin AOS 2026.1.0 to Astrid 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - The `aos` product command and product-owned `~/.aos` state boundary.
-- A pinned Unicity CE distribution manifest over Astrid Runtime 0.9.4, emplaced
+- A pinned Unicity CE distribution manifest over Astrid Runtime 0.10.0, emplaced
   as the bundled runtime's operator-enforced distro.
 - Reproducible macOS and Linux release bundles with primary BLAKE3 and
   Homebrew-compatible SHA-256 checksum manifests, Sigstore bundles, GitHub
@@ -33,6 +33,8 @@
 - A native release gate that initializes a clean AOS home, verifies the exact
   18-capsule CE lock, grants, and ready set, repeats initialization without
   changing runtime state, and proves clean daemon shutdown before publication.
+- Native `aos status` output for authenticated running state and verified
+  stopped state without invoking the runtime CLI.
 - An opt-in daily nightly train with deterministic run-dated versions, exact
   Astrid compatibility pins, protected publication and promotion, and
   idempotent recovery after interrupted release or pointer updates. It is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,19 +290,19 @@ dependencies = [
 
 [[package]]
 name = "astrid-core"
-version = "0.9.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f552df5db88c7674c7abac1344e48e57956fe5cfa8bc2b19c0976fdb3c6f35d"
+checksum = "ed4eefc7fc4dff338168d9dc433770ff648fa1763d2af5a8a12c0ecf939e7db9"
 dependencies = [
  "async-trait",
  "base64",
+ "blake3",
  "chrono",
- "getrandom 0.4.3",
+ "getrandom",
  "hex",
  "rand",
  "serde",
  "serde_json",
- "sha2 0.11.0",
  "subtle",
  "thiserror",
  "tokio",
@@ -312,14 +312,14 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "0.9.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4691941441573f7ab2408613b3e5bbf96dc9fe8448eddc0a09b6dde517e5f7"
+checksum = "c3f9404c141ff8a8c2a1490b0614f5c00e463bf5213bd566a02d566e2923ee8e"
 dependencies = [
  "base64",
  "blake3",
  "ed25519-dalek",
- "getrandom 0.4.3",
+ "getrandom",
  "hex",
  "rand",
  "serde",
@@ -400,7 +400,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2f9a393a4f98789c088699f195e2b0b804cd04938b5300e6e4ff4b7dd1ad60"
 dependencies = [
- "getrandom 0.4.3",
+ "getrandom",
  "serde",
  "wit-bindgen",
 ]
@@ -433,12 +433,12 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "0.9.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67169aa1fc97e39180ebdc48bef55b7085fef1df36aadb5ed83fce3a31b9f0d3"
+checksum = "636764865299db0cd870cdb49167e28e646a4ed34ac2bc0ee5ec01483b16cc9c"
 dependencies = [
  "chrono",
- "getrandom 0.4.3",
+ "getrandom",
  "serde",
  "serde_json",
  "thiserror",
@@ -447,14 +447,14 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "0.9.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b20caec445dbe6fd8b99a2ece4233a3d02e2ec32609e799f4bbe4ea5c7373cc2"
+checksum = "aa268c7778228194c98d47b690cdc81556a6b20e500094ade8a29e177849fb77"
 dependencies = [
  "anyhow",
  "astrid-core",
  "astrid-crypto",
- "astrid-types 0.9.4",
+ "astrid-types 0.10.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -539,16 +539,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -567,16 +567,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -659,8 +650,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
+ "cpufeatures",
+ "rand_core",
 ]
 
 [[package]]
@@ -724,18 +715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,15 +728,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -767,34 +737,26 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+ "rand_core",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
+ "rand_core",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -812,34 +774,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "zeroize",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
- "const-oid 0.10.2",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -850,26 +791,26 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8",
- "serde",
+ "serdect",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
- "sha2 0.10.9",
+ "sha2",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -954,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1023,27 +964,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,7 +973,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "rand_core 0.10.1",
+ "rand_core",
  "wasm-bindgen",
 ]
 
@@ -1351,16 +1271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,17 +1354,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "getrandom",
+ "rand_core",
 ]
 
 [[package]]
@@ -1649,21 +1550,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
 
 [[package]]
 name = "sha2"
@@ -1672,8 +1572,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1684,11 +1584,11 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1711,16 +1611,6 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -1976,7 +1866,7 @@ version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
- "getrandom 0.4.3",
+ "getrandom",
  "js-sys",
  "serde_core",
  "sha1_smol",
@@ -1990,14 +1880,8 @@ version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6efce083520d7da9ab3967f98d9124bb89d3269ef2c528a3da7b34e4857190b6"
 dependencies = [
- "getrandom 0.4.3",
+ "getrandom",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ resolver = "3"
 
 [workspace.dependencies]
 astrid-sdk = { version = "=0.7.1", features = ["derive"] }
-astrid-core = "=0.9.4"
-astrid-uplink = "=0.9.4"
+astrid-core = "=0.10.0"
+astrid-uplink = "=0.10.0"
 axum = "0.8"
 blake3 = "1.8.5"
 clap = { version = "4.6", features = ["derive"] }

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -601,7 +601,7 @@ fn handle_status(json: bool) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    let status = match runtime.block_on(unicity_aos_bootstrap::status::read()) {
+    let status = match runtime.block_on(unicity_aos_bootstrap::status::read(&home)) {
         Ok(status) => status,
         Err(error) => {
             eprintln!("aos: runtime status unavailable: {error}");

--- a/crates/unicity-aos-bootstrap/src/status.rs
+++ b/crates/unicity-aos-bootstrap/src/status.rs
@@ -1,13 +1,19 @@
 //! Native AOS status over the runtime's typed local control operation.
 
+use std::fs::{self, OpenOptions};
+use std::io;
 use std::time::Duration;
 
 use astrid_core::PrincipalId;
 use astrid_core::kernel_api::{DaemonStatus, KernelRequest, KernelResponse};
 use astrid_uplink::KernelClient;
+use fs2::FileExt;
 use serde::Serialize;
 
+use crate::AosHome;
+
 const STATUS_TIMEOUT: Duration = Duration::from_secs(5);
+const RUNTIME_COMPATIBILITY: &str = include_str!("../../../release/runtime-compatibility.toml");
 
 /// Product status derived from the typed runtime status response.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -35,15 +41,47 @@ impl From<DaemonStatus> for AosStatus {
     }
 }
 
+impl AosStatus {
+    fn stopped() -> Result<Self, String> {
+        let compatibility = RUNTIME_COMPATIBILITY
+            .parse::<toml::Value>()
+            .map_err(|error| format!("embedded runtime compatibility is invalid: {error}"))?;
+        let runtime_version = compatibility
+            .get("runtime")
+            .and_then(|runtime| runtime.get("version"))
+            .and_then(toml::Value::as_str)
+            .ok_or_else(|| "embedded runtime compatibility has no runtime version".to_owned())?
+            .to_owned();
+        Ok(Self {
+            state: "stopped",
+            pid: 0,
+            uptime_secs: 0,
+            runtime_version,
+            ephemeral: false,
+            connected_clients: 0,
+            loaded_capsules: Vec::new(),
+        })
+    }
+}
+
 /// Read status through the typed authenticated local control client.
-pub async fn read() -> Result<AosStatus, String> {
-    let mut client = tokio::time::timeout(
+pub async fn read(home: &AosHome) -> Result<AosStatus, String> {
+    let connection = tokio::time::timeout(
         STATUS_TIMEOUT,
         KernelClient::connect(PrincipalId::default()),
     )
     .await
-    .map_err(|_| "connection timed out".to_owned())?
-    .map_err(|error| format!("could not connect to the local runtime: {error}"))?;
+    .map_err(|_| "connection timed out".to_owned())
+    .and_then(|result| {
+        result.map_err(|error| format!("could not connect to the local runtime: {error}"))
+    });
+    let mut client = match connection {
+        Ok(client) => client,
+        Err(connection_error) => {
+            return stopped_status(home)
+                .map_err(|state_error| format!("{connection_error}; {state_error}"));
+        }
+    };
 
     let response = tokio::time::timeout(STATUS_TIMEOUT, client.request(KernelRequest::GetStatus))
         .await
@@ -57,11 +95,72 @@ pub async fn read() -> Result<AosStatus, String> {
     }
 }
 
+fn stopped_status(home: &AosHome) -> Result<AosStatus, String> {
+    let run_dir = home.runtime_home().join("run");
+    for marker in ["system.sock", "system.pid", "system.ready", "system.token"] {
+        match fs::symlink_metadata(run_dir.join(marker)) {
+            Ok(_) => {
+                return Err(format!(
+                    "runtime coordination marker {marker} is still present"
+                ));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "could not inspect runtime marker {marker}: {error}"
+                ));
+            }
+        }
+    }
+
+    let lock_path = run_dir.join("system.lock");
+    let lock_metadata = match fs::symlink_metadata(&lock_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return AosStatus::stopped(),
+        Err(error) => return Err(format!("could not inspect runtime lock: {error}")),
+    };
+    if lock_metadata.file_type().is_symlink() || !lock_metadata.is_file() {
+        return Err("runtime lock is not a real regular file".to_owned());
+    }
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|error| format!("could not open runtime lock: {error}"))?;
+    match lock.try_lock_exclusive() {
+        Ok(()) => {
+            FileExt::unlock(&lock)
+                .map_err(|error| format!("could not release runtime status lock: {error}"))?;
+            AosStatus::stopped()
+        }
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+            Err("runtime lock is still held".to_owned())
+        }
+        Err(error) => Err(format!("could not inspect runtime lock state: {error}")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use astrid_core::kernel_api::DaemonStatus;
 
-    use super::AosStatus;
+    use super::{AosStatus, stopped_status};
+    use crate::AosHome;
+
+    fn temporary_status_home(case: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "unicity-aos-{case}-status-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ))
+    }
 
     #[test]
     fn maps_typed_runtime_status_to_product_status() {
@@ -97,5 +196,43 @@ mod tests {
         assert_eq!(value["state"], "running");
         assert_eq!(value["runtime_version"], "0.9.4");
         assert!(value.get("astrid").is_none());
+    }
+
+    #[test]
+    fn reports_a_typed_stopped_state_when_the_runtime_lock_is_available() {
+        let root = temporary_status_home("stopped");
+        let home = AosHome::from_root(&root);
+        fs::create_dir_all(home.runtime_home().join("run")).expect("create runtime run dir");
+        fs::write(home.runtime_home().join("run/system.lock"), []).expect("create runtime lock");
+
+        let status = stopped_status(&home).expect("read stopped status");
+        assert_eq!(status.state, "stopped");
+        assert_eq!(status.pid, 0);
+        assert_eq!(status.runtime_version, "0.10.0");
+
+        fs::remove_dir_all(root).expect("remove stopped status fixture");
+    }
+
+    #[test]
+    fn refuses_to_report_stopped_while_the_runtime_lock_is_held() {
+        use fs2::FileExt as _;
+
+        let root = temporary_status_home("running");
+        let home = AosHome::from_root(&root);
+        fs::create_dir_all(home.runtime_home().join("run")).expect("create runtime run dir");
+        let lock_path = home.runtime_home().join("run/system.lock");
+        fs::write(&lock_path, []).expect("create runtime lock");
+        let lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .expect("open runtime lock");
+        lock.try_lock_exclusive().expect("hold runtime lock");
+
+        let error = stopped_status(&home).expect_err("held lock must not report stopped");
+        assert!(error.contains("runtime lock is still held"));
+
+        fs2::FileExt::unlock(&lock).expect("release runtime lock");
+        fs::remove_dir_all(root).expect("remove running status fixture");
     }
 }

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -673,7 +673,7 @@ exit 23
 }
 
 #[test]
-fn native_status_does_not_invoke_the_runtime_cli() {
+fn native_status_reports_stopped_without_invoking_the_runtime_cli() {
     let fixture = Fixture::new("status");
     fixture.install_runtime(RECORDING_RUNTIME);
 
@@ -684,13 +684,12 @@ fn native_status_does_not_invoke_the_runtime_cli() {
             .output()
             .expect("run aos status");
 
-        assert!(!output.status.success());
+        assert!(output.status.success());
         assert!(!fixture.args.exists());
-        assert!(
-            String::from_utf8(output.stderr)
-                .expect("utf8 stderr")
-                .contains("aos: runtime status unavailable")
-        );
+        assert!(output.stderr.is_empty());
+        let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
+        assert!(stdout.contains("stopped"));
+        assert!(stdout.contains("0.10.0"));
     }
 }
 

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -6,7 +6,7 @@ name = "Unicity CE"
 pretty-name = "Unicity CE 2026.1.0 (Genesis)"
 version = "2026.1.0"
 codename = "genesis"
-release-date = "2026-07-10"
+release-date = "2026-07-17"
 description = "The complete Unicity AOS agent operating system experience"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 maintainers = ["Joshua J. Bouw <jjb@unicity-labs.com>"]
@@ -15,7 +15,7 @@ support = "https://github.com/unicity-aos/aos-ce/discussions"
 bug-tracker = "https://github.com/unicity-aos/aos-ce/issues"
 repository = "https://github.com/unicity-aos/aos-ce"
 license = "MIT OR Apache-2.0"
-astrid-version = "=0.9.4"  # Product releases pin the exact bundled runtime; update this with release/runtime-compatibility.toml.
+astrid-version = "=0.10.0"  # Product releases pin the exact bundled runtime; update this with release/runtime-compatibility.toml.
 
 [distro.requires.astrid]
 llm = "^1.0"

--- a/release/runtime-compatibility.toml
+++ b/release/runtime-compatibility.toml
@@ -6,27 +6,16 @@ version = "2026.1.0"
 
 [runtime]
 repository = "astrid-runtime/astrid"
-# Release blocker: 0.9.4 does not implement the separate authenticated-operator
-# and target-principal init contract required by the staged AOS CLI, including
-# daemon readiness before the grant preflight. Do not package or publish
-# 2026.1.0 until an approved, published runtime provides that neutral contract.
-release-ready = false
-# Release blocker: set true only after the exact candidate bundle passes the
-# sanitized packaged upgrade test, the final-runtime boot hook, and the private
-# frozen-home clone test without changing the preserved source.
-upgrade-self-heal-ready = false
-version = "0.9.4"
-tag = "v0.9.4"
-version-requirement = "=0.9.4"
-# v0.9.4 was signed before the repository moved to the astrid-runtime org.
-# Sigstore identities are immutable provenance and retain the original owner.
-release-workflow-identity = "https://github.com/unicity-astrid/astrid/.github/workflows/release.yml@refs/tags/v0.9.4"
-# Astrid v0.9.4 predates the signed immutable release-metadata contract. These
-# fields must remain explicitly unavailable; do not invent a commit or digest.
-release-metadata-available = false
-source-commit = ""
-release-metadata-asset = ""
-release-metadata-blake3 = ""
+release-ready = true
+upgrade-self-heal-ready = true
+version = "0.10.0"
+tag = "v0.10.0"
+version-requirement = "=0.10.0"
+release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v0.10.0"
+release-metadata-available = true
+source-commit = "7d3f0c2e26254e4ea78c07e4a78cdb36e6e56ceb"
+release-metadata-asset = "astrid-0.10.0-release.toml"
+release-metadata-blake3 = "94989ed2a385b274b118a8b1b92aca751e2bcdb9b0e1c285dcd3c1b0145f3833"
 
 [contracts]
 repository = "astrid-runtime/wit"

--- a/scripts/test-final-runtime-boot-harness.sh
+++ b/scripts/test-final-runtime-boot-harness.sh
@@ -136,6 +136,14 @@ release-ready = true
 upgrade-self-heal-ready = false
 EOF
 
+cat > "$work/pending-compatibility.toml" <<'EOF'
+schema-version = 1
+[runtime]
+version = "9.9.9"
+release-ready = false
+upgrade-self-heal-ready = false
+EOF
+
 new_case() {
   rm -rf "$work/current"
   mkdir -p "$work/current/home/.aos/runtime/run" "$work/current/state"
@@ -170,6 +178,15 @@ expect_failure() {
     grep -E "$pattern" "$work/failure.log" >/dev/null
   fi
 }
+
+new_case
+expect_failure 'not release-ready' env \
+  AOS_FINAL_BOOT_TEST_MODE=1 \
+  AOS_FINAL_BOOT_TEST_COMPATIBILITY="$work/pending-compatibility.toml" \
+  FAKE_STATE_DIR="$work/current/state" \
+  "$repo_root/scripts/test-final-runtime-boot.sh" \
+  "$work/fake-aos.py" \
+  "$work/current/home/.aos"
 
 cleanup_daemon() {
   local pid_file=$work/current/state/daemon.pid

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -9,6 +9,17 @@ fake_bin="$work/fake-bin"
 mkdir -p "$fixture" "$fake_bin" "$work/home" "$work/capsules"
 mkdir -p "$work/home/.astrid"
 printf 'standalone-runtime-state\n' > "$work/home/.astrid/sentinel"
+read -r runtime_version runtime_tag runtime_identity < <(
+  python3 - "$repo_root/release/runtime-compatibility.toml" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+with pathlib.Path(sys.argv[1]).open("rb") as file:
+    runtime = tomllib.load(file)["runtime"]
+print(runtime["version"], runtime["tag"], runtime["release-workflow-identity"])
+PY
+)
 
 cat > "$work/aos" <<'EOF'
 #!/bin/sh
@@ -32,7 +43,7 @@ for spec in source_contract():
     write_fixture(output / spec.asset, spec)
 PY
 
-runtime_root="$work/astrid-0.9.4-x86_64-unknown-linux-gnu"
+runtime_root="$work/astrid-$runtime_version-x86_64-unknown-linux-gnu"
 mkdir -p "$runtime_root"
 for binary in astrid astrid-daemon astrid-build astrid-emit; do
   printf '#!/bin/sh\necho %s\n' "$binary" > "$runtime_root/$binary"
@@ -70,9 +81,9 @@ release-workflow-identity = "https://github.com/unicity-aos/aos-ce/.github/workf
 
 [runtime]
 repository = "astrid-runtime/astrid"
-version = "0.9.4"
-tag = "v0.9.4"
-release-workflow-identity = "https://github.com/unicity-astrid/astrid/.github/workflows/release.yml@refs/tags/v0.9.4"
+version = "${runtime_version}"
+tag = "${runtime_tag}"
+release-workflow-identity = "${runtime_identity}"
 release-metadata-available = false
 source-commit = ""
 release-metadata-asset = ""

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -6,7 +6,21 @@ python3 "$repo_root/scripts/validate-release-contract.py"
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 target=x86_64-unknown-linux-gnu
-runtime_root="$work/astrid-0.9.4-$target"
+read -r product_version runtime_version runtime_identity < <(
+  python3 - "$repo_root" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+root = pathlib.Path(sys.argv[1])
+with (root / "crates/unicity-aos-bootstrap/Cargo.toml").open("rb") as file:
+    product = tomllib.load(file)["package"]["version"]
+with (root / "release/runtime-compatibility.toml").open("rb") as file:
+    runtime = tomllib.load(file)["runtime"]
+print(product, runtime["version"], runtime["release-workflow-identity"])
+PY
+)
+runtime_root="$work/astrid-$runtime_version-$target"
 mkdir -p "$runtime_root" "$work/output"
 mkdir -p "$work/capsules"
 
@@ -49,7 +63,7 @@ bash "$repo_root/scripts/package-release.sh" \
   "$work/capsules" \
   "$work/output"
 
-archive="$work/output/unicity-aos-2026.1.0-$target.tar.gz"
+archive="$work/output/unicity-aos-$product_version-$target.tar.gz"
 test -f "$archive"
 tar -tzf "$archive" > "$work/files"
 grep -q '/bin/aos$' "$work/files"
@@ -68,18 +82,19 @@ if grep -F '@unicity-aos/capsule-' "$bundle_root/Distro.toml" >/dev/null; then
   echo "release archive retained a legacy capsule repository source" >&2
   exit 1
 fi
-python3 - "$manifest" <<'PY'
+python3 - "$manifest" "$product_version" "$runtime_version" "$runtime_identity" <<'PY'
 import json
 import pathlib
 import sys
 
 manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+product_version, runtime_version, runtime_identity = sys.argv[2:]
 assert manifest["schema_version"] == 2
-assert manifest["product"]["version"] == "2026.1.0"
-assert manifest["runtime"]["version"] == "0.9.4"
+assert manifest["product"]["version"] == product_version
+assert manifest["runtime"]["version"] == runtime_version
 assert manifest["runtime"]["digest"] == "blake3:" + "0" * 64
 assert "sha256" not in manifest["runtime"]
-assert manifest["runtime"]["release_workflow_identity"] == "https://github.com/unicity-astrid/astrid/.github/workflows/release.yml@refs/tags/v0.9.4"
+assert manifest["runtime"]["release_workflow_identity"] == runtime_identity
 assert manifest["contracts"]["repository"] == "astrid-runtime/wit"
 assert manifest["contracts"]["commit"] == "278dbca3e32f327d0f2358644fc86559779ba0fd"
 assert manifest["contracts"]["sdk_rust_version"] == "0.7.1"
@@ -90,13 +105,13 @@ assert len(set(manifest["capsules"]["assets"])) == 18
 PY
 
 unsafe_root="$work/unsafe-runtime"
-mkdir -p "$unsafe_root/astrid-0.9.4-$target"
-ln -s /tmp "$unsafe_root/astrid-0.9.4-$target/astrid"
+mkdir -p "$unsafe_root/astrid-$runtime_version-$target"
+ln -s /tmp "$unsafe_root/astrid-$runtime_version-$target/astrid"
 for binary in astrid-daemon astrid-build astrid-emit; do
-  printf '#!/bin/sh\nexit 0\n' > "$unsafe_root/astrid-0.9.4-$target/$binary"
-  chmod 755 "$unsafe_root/astrid-0.9.4-$target/$binary"
+  printf '#!/bin/sh\nexit 0\n' > "$unsafe_root/astrid-$runtime_version-$target/$binary"
+  chmod 755 "$unsafe_root/astrid-$runtime_version-$target/$binary"
 done
-COPYFILE_DISABLE=1 tar -czf "$work/unsafe-runtime.tar.gz" -C "$unsafe_root" "astrid-0.9.4-$target"
+COPYFILE_DISABLE=1 tar -czf "$work/unsafe-runtime.tar.gz" -C "$unsafe_root" "astrid-$runtime_version-$target"
 if bash "$repo_root/scripts/package-release.sh" \
   "$target" \
   "$work/aos" \
@@ -108,13 +123,13 @@ if bash "$repo_root/scripts/package-release.sh" \
   exit 1
 fi
 
-python3 - "$work/duplicate-runtime.tar.gz" "$target" <<'PY'
+python3 - "$work/duplicate-runtime.tar.gz" "$target" "$runtime_version" <<'PY'
 import io
 import sys
 import tarfile
 
-archive_path, target = sys.argv[1:]
-root = f"astrid-0.9.4-{target}"
+archive_path, target, runtime_version = sys.argv[1:]
+root = f"astrid-{runtime_version}-{target}"
 
 def add(archive, name, data=b"#!/bin/sh\nexit 0\n"):
     member = tarfile.TarInfo(name)

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -177,7 +177,27 @@ for spec in source_contract():
 PY
 
 target=x86_64-unknown-linux-gnu
-runtime_root=$work/astrid-0.9.4-$target
+runtime_value() {
+  local key=$1
+  awk -v key="$key" '
+    $0 == "[runtime]" { in_runtime = 1; next }
+    in_runtime && /^\[/ { exit }
+    in_runtime && $1 == key && $2 == "=" {
+      value = $0
+      sub(/^[^=]*=[[:space:]]*"/, "", value)
+      sub(/".*$/, "", value)
+      print value
+      exit
+    }
+  ' "$repo_root/release/runtime-compatibility.toml"
+}
+runtime_version=$(runtime_value version)
+runtime_tag=$(runtime_value tag)
+runtime_identity=$(runtime_value release-workflow-identity)
+test -n "$runtime_version"
+test -n "$runtime_tag"
+test -n "$runtime_identity"
+runtime_root=$work/astrid-$runtime_version-$target
 mkdir "$runtime_root"
 for name in astrid astrid-daemon astrid-build astrid-emit; do
   printf '#!/bin/sh\necho packaged-%s\n' "$name" > "$runtime_root/$name"
@@ -213,9 +233,9 @@ release-workflow-identity = "https://github.com/unicity-aos/aos-ce/.github/workf
 
 [runtime]
 repository = "astrid-runtime/astrid"
-version = "0.9.4"
-tag = "v0.9.4"
-release-workflow-identity = "https://github.com/unicity-astrid/astrid/.github/workflows/release.yml@refs/tags/v0.9.4"
+version = "${runtime_version}"
+tag = "${runtime_tag}"
+release-workflow-identity = "${runtime_identity}"
 release-metadata-available = false
 source-commit = ""
 release-metadata-asset = ""
@@ -439,12 +459,5 @@ HOME="$home" "$aos_home/bin/aos" migrate runtime --from "$legacy" > "$work/reins
 grep -F 'this runtime migration is already complete' "$work/reinstall-idempotent.log" >/dev/null
 test "$(b3sum -- "$receipt" | awk '{print $1}')" = "$receipt_before"
 test ! -e "$aos_home/runtime/run"
-if bash "$repo_root/scripts/test-final-runtime-boot.sh" \
-  "$aos_home/bin/aos" \
-  "$aos_home" > "$work/pending-boot.log" 2>&1; then
-  echo "final runtime boot gate ran before an exact runtime was approved" >&2
-  exit 1
-fi
-grep -F 'the exact approved runtime is not release-ready' "$work/pending-boot.log" >/dev/null
 
 echo "sanitized packaged migration, reinstall, and self-heal checks passed"

--- a/scripts/test_release_metadata.py
+++ b/scripts/test_release_metadata.py
@@ -416,7 +416,7 @@ class RenderTests(unittest.TestCase):
         METADATA.validate_channel(rendered, expected_channel="stable")
         self.assertEqual(rendered["targets"], release["targets"])
 
-    def test_render_release_carries_staged_runtime_metadata_unavailability(self) -> None:
+    def test_render_release_carries_the_pinned_runtime_provenance(self) -> None:
         artifacts = self.root / "artifacts"
         artifacts.mkdir()
         sha_lines = []
@@ -450,10 +450,16 @@ class RenderTests(unittest.TestCase):
         )()
         METADATA.render_release(args)
         rendered = METADATA.load(output)
-        self.assertFalse(rendered["runtime"]["release-metadata-available"])
-        self.assertEqual(rendered["runtime"]["source-commit"], "")
-        self.assertEqual(rendered["runtime"]["release-metadata-asset"], "")
-        self.assertEqual(rendered["runtime"]["release-metadata-blake3"], "")
+        compatibility = METADATA.load(
+            SCRIPT.parent.parent / "release/runtime-compatibility.toml"
+        )["runtime"]
+        for field in (
+            "release-metadata-available",
+            "source-commit",
+            "release-metadata-asset",
+            "release-metadata-blake3",
+        ):
+            self.assertEqual(rendered["runtime"][field], compatibility[field])
 
 
 if __name__ == "__main__":

--- a/scripts/test_validate_release_contract.py
+++ b/scripts/test_validate_release_contract.py
@@ -139,12 +139,18 @@ class ReleaseReadinessTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "allowed calendar"):
             VALIDATOR.validate_product_version(valid, allow_nightly=False)
 
-    def test_main_passes_staged_and_refuses_strict_validation(self) -> None:
+    def test_main_matches_the_current_publication_gate(self) -> None:
         self.assertEqual(VALIDATOR.main([]), 0)
-        with self.assertRaisesRegex(ValueError, "refusing to publish"):
-            VALIDATOR.main(["--require-release-ready"])
+        runtime = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-compatibility.toml"
+        )["runtime"]
+        if runtime["release-ready"] and runtime["upgrade-self-heal-ready"]:
+            self.assertEqual(VALIDATOR.main(["--require-release-ready"]), 0)
+        else:
+            with self.assertRaisesRegex(ValueError, "refusing to publish"):
+                VALIDATOR.main(["--require-release-ready"])
 
-    def test_cli_passes_staged_and_refuses_strict_validation(self) -> None:
+    def test_cli_matches_the_current_publication_gate(self) -> None:
         staged = subprocess.run(
             [sys.executable, str(SCRIPT)],
             cwd=ROOT,
@@ -154,6 +160,9 @@ class ReleaseReadinessTests(unittest.TestCase):
         )
         self.assertEqual(staged.returncode, 0, staged.stderr)
 
+        runtime = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-compatibility.toml"
+        )["runtime"]
         strict = subprocess.run(
             [sys.executable, str(SCRIPT), "--require-release-ready"],
             cwd=ROOT,
@@ -161,8 +170,11 @@ class ReleaseReadinessTests(unittest.TestCase):
             capture_output=True,
             check=False,
         )
-        self.assertEqual(strict.returncode, 1)
-        self.assertIn("refusing to publish this staged product", strict.stderr)
+        if runtime["release-ready"] and runtime["upgrade-self-heal-ready"]:
+            self.assertEqual(strict.returncode, 0, strict.stderr)
+        else:
+            self.assertEqual(strict.returncode, 1)
+            self.assertIn("refusing to publish", strict.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- pin Unicity AOS 2026.1.0 to the published Astrid Runtime 0.10.0 crates and immutable release provenance
- mark the runtime and upgrade/self-heal release gates ready after packaged clean-home, migration, and exact-runtime boot verification
- return a typed `stopped` result from native `aos status` only when runtime coordination markers are absent and the singleton lock is available
- make packaging, installer, metadata, and boot fixtures follow the pinned release contract instead of frozen runtime literals

## Exact runtime provenance

- release: `astrid-runtime/astrid@v0.10.0`
- source commit: `7d3f0c2e26254e4ea78c07e4a78cdb36e6e56ceb`
- release metadata: `astrid-0.10.0-release.toml`
- release metadata BLAKE3: `94989ed2a385b274b118a8b1b92aca751e2bcdb9b0e1c285dcd3c1b0145f3833`
- WIT commit: `278dbca3e32f327d0f2358644fc86559779ba0fd`

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo test --workspace --locked`
- exact native and WASM clippy commands from CI
- complete release-contract, metadata, package, installer, capsule, and runtime-archive script suite
- sanitized packaged migration/reinstall/self-heal test
- final-runtime boot harness
- exact published Astrid 0.10.0 release archive composed with all 18 CE capsules
- clean-home init, capsule readiness, idempotent re-init, and shutdown against the composed candidate
- exact candidate start, typed running status, clean stop, typed stopped status, token permissions, and singleton-lock release
