### PR TITLE
test: exercise pinned Astrid release provenance

### DIFF
--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -35,6 +35,16 @@ print(
 )
 PY
 )
+if [[ -z "$runtime_version" || -z "$runtime_tag" || -z "$runtime_identity" || \
+      -z "$runtime_source_commit" || -z "$runtime_metadata_asset" || \
+      -z "$runtime_metadata_blake3" ]]; then
+  echo "runtime compatibility fixture provenance is incomplete" >&2
+  exit 1
+fi
+if [[ "$runtime_metadata_available" != true ]]; then
+  echo "installer fixture must exercise available runtime release metadata" >&2
+  exit 1
+fi
 
 cat > "$work/aos" <<'EOF'
 #!/bin/sh

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -9,7 +9,7 @@ fake_bin="$work/fake-bin"
 mkdir -p "$fixture" "$fake_bin" "$work/home" "$work/capsules"
 mkdir -p "$work/home/.astrid"
 printf 'standalone-runtime-state\n' > "$work/home/.astrid/sentinel"
-read -r \
+if ! read -r \
   runtime_version \
   runtime_tag \
   runtime_identity \
@@ -34,7 +34,10 @@ print(
     runtime["release-metadata-blake3"],
 )
 PY
-)
+); then
+  echo "failed to read runtime compatibility fixture provenance" >&2
+  exit 1
+fi
 if [[ -z "$runtime_version" || -z "$runtime_tag" || -z "$runtime_identity" || \
       -z "$runtime_source_commit" || -z "$runtime_metadata_asset" || \
       -z "$runtime_metadata_blake3" ]]; then

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -9,7 +9,14 @@ fake_bin="$work/fake-bin"
 mkdir -p "$fixture" "$fake_bin" "$work/home" "$work/capsules"
 mkdir -p "$work/home/.astrid"
 printf 'standalone-runtime-state\n' > "$work/home/.astrid/sentinel"
-read -r runtime_version runtime_tag runtime_identity < <(
+read -r \
+  runtime_version \
+  runtime_tag \
+  runtime_identity \
+  runtime_metadata_available \
+  runtime_source_commit \
+  runtime_metadata_asset \
+  runtime_metadata_blake3 < <(
   python3 - "$repo_root/release/runtime-compatibility.toml" <<'PY'
 import pathlib
 import sys
@@ -17,7 +24,15 @@ import tomllib
 
 with pathlib.Path(sys.argv[1]).open("rb") as file:
     runtime = tomllib.load(file)["runtime"]
-print(runtime["version"], runtime["tag"], runtime["release-workflow-identity"])
+print(
+    runtime["version"],
+    runtime["tag"],
+    runtime["release-workflow-identity"],
+    str(runtime["release-metadata-available"]).lower(),
+    runtime["source-commit"],
+    runtime["release-metadata-asset"],
+    runtime["release-metadata-blake3"],
+)
 PY
 )
 
@@ -84,10 +99,10 @@ repository = "astrid-runtime/astrid"
 version = "${runtime_version}"
 tag = "${runtime_tag}"
 release-workflow-identity = "${runtime_identity}"
-release-metadata-available = false
-source-commit = ""
-release-metadata-asset = ""
-release-metadata-blake3 = ""
+release-metadata-available = ${runtime_metadata_available}
+source-commit = "${runtime_source_commit}"
+release-metadata-asset = "${runtime_metadata_asset}"
+release-metadata-blake3 = "${runtime_metadata_blake3}"
 
 [contracts]
 repository = "astrid-runtime/wit"

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -203,6 +203,16 @@ print(
 )
 PY
 )
+if [[ -z "$runtime_version" || -z "$runtime_tag" || -z "$runtime_identity" || \
+      -z "$runtime_source_commit" || -z "$runtime_metadata_asset" || \
+      -z "$runtime_metadata_blake3" ]]; then
+  echo "runtime compatibility fixture provenance is incomplete" >&2
+  exit 1
+fi
+if [[ "$runtime_metadata_available" != true ]]; then
+  echo "upgrade/self-heal fixture must exercise available runtime release metadata" >&2
+  exit 1
+fi
 runtime_root=$work/astrid-$runtime_version-$target
 mkdir "$runtime_root"
 for name in astrid astrid-daemon astrid-build astrid-emit; do

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -177,26 +177,32 @@ for spec in source_contract():
 PY
 
 target=x86_64-unknown-linux-gnu
-runtime_value() {
-  local key=$1
-  awk -v key="$key" '
-    $0 == "[runtime]" { in_runtime = 1; next }
-    in_runtime && /^\[/ { exit }
-    in_runtime && $1 == key && $2 == "=" {
-      value = $0
-      sub(/^[^=]*=[[:space:]]*"/, "", value)
-      sub(/".*$/, "", value)
-      print value
-      exit
-    }
-  ' "$repo_root/release/runtime-compatibility.toml"
-}
-runtime_version=$(runtime_value version)
-runtime_tag=$(runtime_value tag)
-runtime_identity=$(runtime_value release-workflow-identity)
-test -n "$runtime_version"
-test -n "$runtime_tag"
-test -n "$runtime_identity"
+read -r \
+  runtime_version \
+  runtime_tag \
+  runtime_identity \
+  runtime_metadata_available \
+  runtime_source_commit \
+  runtime_metadata_asset \
+  runtime_metadata_blake3 < <(
+  python3 - "$repo_root/release/runtime-compatibility.toml" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+with pathlib.Path(sys.argv[1]).open("rb") as file:
+    runtime = tomllib.load(file)["runtime"]
+print(
+    runtime["version"],
+    runtime["tag"],
+    runtime["release-workflow-identity"],
+    str(runtime["release-metadata-available"]).lower(),
+    runtime["source-commit"],
+    runtime["release-metadata-asset"],
+    runtime["release-metadata-blake3"],
+)
+PY
+)
 runtime_root=$work/astrid-$runtime_version-$target
 mkdir "$runtime_root"
 for name in astrid astrid-daemon astrid-build astrid-emit; do
@@ -236,10 +242,10 @@ repository = "astrid-runtime/astrid"
 version = "${runtime_version}"
 tag = "${runtime_tag}"
 release-workflow-identity = "${runtime_identity}"
-release-metadata-available = false
-source-commit = ""
-release-metadata-asset = ""
-release-metadata-blake3 = ""
+release-metadata-available = ${runtime_metadata_available}
+source-commit = "${runtime_source_commit}"
+release-metadata-asset = "${runtime_metadata_asset}"
+release-metadata-blake3 = "${runtime_metadata_blake3}"
 
 [contracts]
 repository = "astrid-runtime/wit"

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -177,7 +177,7 @@ for spec in source_contract():
 PY
 
 target=x86_64-unknown-linux-gnu
-read -r \
+if ! read -r \
   runtime_version \
   runtime_tag \
   runtime_identity \
@@ -202,7 +202,10 @@ print(
     runtime["release-metadata-blake3"],
 )
 PY
-)
+); then
+  echo "failed to read runtime compatibility fixture provenance" >&2
+  exit 1
+fi
 if [[ -z "$runtime_version" || -z "$runtime_tag" || -z "$runtime_identity" || \
       -z "$runtime_source_commit" || -z "$runtime_metadata_asset" || \
       -z "$runtime_metadata_blake3" ]]; then


### PR DESCRIPTION
## Summary

- derive the complete Astrid release identity from `release/runtime-compatibility.toml` in installer fixtures
- exercise the strict `release-metadata-available = true` path in install and upgrade/self-heal coverage
- fail fast with explicit diagnostics when required provenance is missing or the strict path is not active

## Verification

- `bash -n scripts/test-install.sh`
- `bash -n scripts/test-upgrade-self-heal.sh`
- `shellcheck scripts/test-install.sh scripts/test-upgrade-self-heal.sh`
- `PATH=/opt/homebrew/opt/python@3.12/libexec/bin:$PATH bash scripts/test-install.sh`
- `PATH=/opt/homebrew/opt/python@3.12/libexec/bin:$PATH bash scripts/test-upgrade-self-heal.sh`