### PR TITLE
fix(release): install b3sum before identity checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,14 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.12'
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: '1.95.0'
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: aos-release-identity
+      - name: Install pinned BLAKE3 checksum tool
+        run: cargo install b3sum --locked --version "$B3SUM_VERSION"
       - name: Refuse a nightly after its canonical base is tagged
         if: needs.classify.outputs.nightly == 'true'
         env:

--- a/scripts/test-channel-workflow-contract.sh
+++ b/scripts/test-channel-workflow-contract.sh
@@ -91,6 +91,20 @@ if transaction_upload >= history_upload:
     raise SystemExit("channel transaction must be uploaded before history assets")
 PY
 
+python3 - "$release_workflow" <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+start = text.index("  validate-release:\n")
+end = text.index("\n  build:\n", start)
+validate = text[start:end]
+install = validate.index('cargo install b3sum --locked --version "$B3SUM_VERSION"')
+exercise = validate.index("bash scripts/test-install.sh")
+if install >= exercise:
+    raise SystemExit("release identity must install b3sum before exercising the installer")
+PY
+
 if grep -Fq "repos/\$GITHUB_REPOSITORY/commits/\$RELEASE_TAG" "$workflow"; then
   echo "channel promotion resolves an ambiguous branch-or-tag revision" >&2
   exit 1

--- a/scripts/test-channel-workflow-contract.sh
+++ b/scripts/test-channel-workflow-contract.sh
@@ -93,11 +93,19 @@ PY
 
 python3 - "$release_workflow" <<'PY'
 import pathlib
+import re
 import sys
 
 text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
-start = text.index("  validate-release:\n")
-end = text.index("\n  build:\n", start)
+jobs = list(re.finditer(r"(?m)^  ([A-Za-z0-9_-]+):\n", text))
+validate_job = next(
+    (index for index, match in enumerate(jobs) if match.group(1) == "validate-release"),
+    None,
+)
+if validate_job is None:
+    raise SystemExit("release workflow is missing the validate-release job")
+start = jobs[validate_job].start()
+end = jobs[validate_job + 1].start() if validate_job + 1 < len(jobs) else len(text)
 validate = text[start:end]
 install = validate.index('cargo install b3sum --locked --version "$B3SUM_VERSION"')
 exercise = validate.index("bash scripts/test-install.sh")


### PR DESCRIPTION
## Summary

- install the pinned BLAKE3 checksum tool before release identity exercises the installer
- pin the Rust toolchain and cache used for that release preflight
- add a workflow-order regression check so installer validation cannot run before `b3sum` is available

## Verification

- `actionlint .github/workflows/release.yml`
- `shellcheck -S warning scripts/test-channel-workflow-contract.sh`
- `bash scripts/test-channel-workflow-contract.sh`
- `PATH=/opt/homebrew/opt/python@3.12/libexec/bin:$PATH bash scripts/test-install.sh`
- `PATH=/opt/homebrew/opt/python@3.12/libexec/bin:$PATH bash scripts/test-package-release.sh`

The protected release run stopped before publication because `scripts/test-install.sh` could not find `b3sum`. No release record or assets were published.