### PR TITLE
fix(cli): confirm runtime shutdown before success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,7 @@
   Astrid 0.9.4 home shape and a final-candidate runtime boot hook.
 - Present product-facing capsule copy consistently as Unicity AOS while
   preserving stable Astrid Runtime crate, WIT, topic, artifact, and ABI names.
+- Treat the runtime's expected shutdown-response disconnect as a successful
+  `aos stop` only after every coordination marker is gone and the singleton
+  lock is available; all other inherited runtime failures retain their output
+  and exit status.

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -7,9 +7,9 @@
 use std::ffi::{OsStr, OsString};
 use std::io::{self, IsTerminal, Write};
 use std::path::Path;
-#[cfg(any(not(unix), test))]
 use std::process::ExitStatus;
 use std::process::{Command, ExitCode};
+use std::time::Duration;
 
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use unicity_aos_bootstrap::{AOS_WORKSPACE_STATE_DIR, AosHome};
@@ -170,6 +170,9 @@ fn main() -> ExitCode {
     if let Some(exit_code) = handle_product_command(&args) {
         return exit_code;
     }
+    if runtime_stop_requested(&args) {
+        return handle_runtime_stop(&args);
+    }
     if product_init_requested(&args)
         && let Err(code) = prepare_product_init(&args)
     {
@@ -195,6 +198,9 @@ fn main() -> ExitCode {
     if let Some(exit_code) = handle_product_command(&args) {
         return exit_code;
     }
+    if runtime_stop_requested(&args) {
+        return handle_runtime_stop(&args);
+    }
     if product_init_requested(&args)
         && let Err(code) = prepare_product_init(&args)
     {
@@ -214,7 +220,6 @@ fn main() -> ExitCode {
     }
 }
 
-#[cfg(any(not(unix), test))]
 fn child_exit_code(status: ExitStatus) -> ExitCode {
     if status.success() {
         ExitCode::SUCCESS
@@ -365,6 +370,88 @@ fn runtime_args_for_dispatch(mut args: Vec<OsString>) -> Vec<OsString> {
         args.push(OsString::from("--grant-capsules"));
     }
     args
+}
+
+fn runtime_stop_requested(args: &[OsString]) -> bool {
+    leading_runtime_root_index(args)
+        .ok()
+        .flatten()
+        .and_then(|index| args.get(index))
+        .is_some_and(|root| root == "stop")
+}
+
+fn handle_runtime_stop(args: &[OsString]) -> ExitCode {
+    let home = match resolve_home() {
+        Ok(home) => home,
+        Err(code) => return code,
+    };
+    let output = match home
+        .runtime_command_with_args(args)
+        .and_then(|mut command| command.output())
+    {
+        Ok(output) => output,
+        Err(error) => {
+            eprintln!("aos: failed to run bundled runtime stop: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if output.status.success() {
+        return emit_runtime_output(&output)
+            .map_or_else(runtime_output_error, |()| ExitCode::SUCCESS);
+    }
+
+    if expected_shutdown_disconnect(&output) && wait_for_confirmed_stop(&home) {
+        if let Err(error) = std::io::stdout().write_all(&output.stdout) {
+            return runtime_output_error(error);
+        }
+        if output.stdout.is_empty() {
+            println!("Unicity AOS stopped.");
+        }
+        return ExitCode::SUCCESS;
+    }
+
+    match emit_runtime_output(&output) {
+        Ok(()) => child_exit_code(output.status),
+        Err(error) => runtime_output_error(error),
+    }
+}
+
+fn expected_shutdown_disconnect(output: &std::process::Output) -> bool {
+    if output.status.code() != Some(1) {
+        return false;
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    stderr.contains("connection lost waiting on astrid.v1.response.shutdown.")
+        && stderr.contains("connection closed before astrid.v1.response.shutdown.")
+}
+
+fn wait_for_confirmed_stop(home: &AosHome) -> bool {
+    const ATTEMPTS: usize = 100;
+    const INTERVAL: Duration = Duration::from_millis(50);
+
+    for attempt in 0..ATTEMPTS {
+        if unicity_aos_bootstrap::status::confirm_stopped(home)
+            .is_ok_and(|status| status.state == "stopped")
+        {
+            return true;
+        }
+        if attempt + 1 < ATTEMPTS {
+            std::thread::sleep(INTERVAL);
+        }
+    }
+    false
+}
+
+fn emit_runtime_output(output: &std::process::Output) -> io::Result<()> {
+    std::io::stdout().write_all(&output.stdout)?;
+    std::io::stderr().write_all(&output.stderr)?;
+    Ok(())
+}
+
+fn runtime_output_error(error: io::Error) -> ExitCode {
+    eprintln!("aos: failed to write bundled runtime output: {error}");
+    ExitCode::FAILURE
 }
 
 fn is_owned_root(value: &str) -> bool {
@@ -741,7 +828,7 @@ mod tests {
 
     use super::{
         ProductCli, ProductCommand, child_exit_code, handle_product_command, help_targets_product,
-        leading_owned_root, runtime_args_for_dispatch,
+        leading_owned_root, runtime_args_for_dispatch, runtime_stop_requested,
     };
 
     #[test]
@@ -863,6 +950,20 @@ mod tests {
     #[test]
     fn unowned_command_is_left_for_runtime_parser() {
         assert!(handle_product_command(&[OsString::from("doctor")]).is_none());
+    }
+
+    #[test]
+    fn runtime_stop_keeps_the_inherited_argument_surface() {
+        assert!(runtime_stop_requested(&[OsString::from("stop")]));
+        assert!(runtime_stop_requested(&[
+            OsString::from("--principal"),
+            OsString::from("operator"),
+            OsString::from("stop"),
+        ]));
+        assert!(!runtime_stop_requested(&[
+            OsString::from("capsule"),
+            OsString::from("stop"),
+        ]));
     }
 
     #[test]

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -373,11 +373,56 @@ fn runtime_args_for_dispatch(mut args: Vec<OsString>) -> Vec<OsString> {
 }
 
 fn runtime_stop_requested(args: &[OsString]) -> bool {
-    leading_runtime_root_index(args)
-        .ok()
-        .flatten()
-        .and_then(|index| args.get(index))
-        .is_some_and(|root| root == "stop")
+    match leading_runtime_root_index(args) {
+        Ok(Some(index)) => args.get(index).is_some_and(|root| root == "stop"),
+        Ok(None) => false,
+        Err(()) => fallback_runtime_root(args).is_some_and(|root| root == "stop"),
+    }
+}
+
+fn fallback_runtime_root(args: &[OsString]) -> Option<&str> {
+    args.iter().filter_map(|arg| arg.to_str()).find(|arg| {
+        matches!(
+            *arg,
+            "chat"
+                | "run"
+                | "agent"
+                | "group"
+                | "caps"
+                | "quota"
+                | "invite"
+                | "keypair"
+                | "pair-device"
+                | "secret"
+                | "voucher"
+                | "trust"
+                | "audit"
+                | "budget"
+                | "session"
+                | "capsule"
+                | "mcp"
+                | "distro"
+                | "init"
+                | "config"
+                | "gc"
+                | "start"
+                | "status"
+                | "stop"
+                | "restart"
+                | "logs"
+                | "ps"
+                | "top"
+                | "who"
+                | "doctor"
+                | "setup"
+                | "version"
+                | "completions"
+                | "update"
+                | "self-update"
+                | "self_update"
+                | "help"
+        )
+    })
 }
 
 fn handle_runtime_stop(args: &[OsString]) -> ExitCode {
@@ -961,6 +1006,17 @@ mod tests {
             OsString::from("stop"),
         ]));
         assert!(!runtime_stop_requested(&[
+            OsString::from("capsule"),
+            OsString::from("stop"),
+        ]));
+        assert!(runtime_stop_requested(&[
+            OsString::from("--future-runtime-global"),
+            OsString::from("future-value"),
+            OsString::from("stop"),
+        ]));
+        assert!(!runtime_stop_requested(&[
+            OsString::from("--future-runtime-global"),
+            OsString::from("future-value"),
             OsString::from("capsule"),
             OsString::from("stop"),
         ]));

--- a/crates/unicity-aos-bootstrap/src/status.rs
+++ b/crates/unicity-aos-bootstrap/src/status.rs
@@ -78,7 +78,7 @@ pub async fn read(home: &AosHome) -> Result<AosStatus, String> {
     let mut client = match connection {
         Ok(client) => client,
         Err(connection_error) => {
-            return stopped_status(home)
+            return confirm_stopped(home)
                 .map_err(|state_error| format!("{connection_error}; {state_error}"));
         }
     };
@@ -95,7 +95,12 @@ pub async fn read(home: &AosHome) -> Result<AosStatus, String> {
     }
 }
 
-fn stopped_status(home: &AosHome) -> Result<AosStatus, String> {
+/// Confirm that the runtime has released its coordination state and singleton
+/// lock.
+///
+/// This is stricter than a missing socket: a shutdown is complete only after
+/// every transient marker is gone and the runtime lock can be acquired.
+pub fn confirm_stopped(home: &AosHome) -> Result<AosStatus, String> {
     let run_dir = home.runtime_home().join("run");
     for marker in ["system.sock", "system.pid", "system.ready", "system.token"] {
         match fs::symlink_metadata(run_dir.join(marker)) {
@@ -148,7 +153,7 @@ mod tests {
 
     use astrid_core::kernel_api::DaemonStatus;
 
-    use super::{AosStatus, stopped_status};
+    use super::{AosStatus, confirm_stopped};
     use crate::AosHome;
 
     fn temporary_status_home(case: &str) -> PathBuf {
@@ -205,7 +210,7 @@ mod tests {
         fs::create_dir_all(home.runtime_home().join("run")).expect("create runtime run dir");
         fs::write(home.runtime_home().join("run/system.lock"), []).expect("create runtime lock");
 
-        let status = stopped_status(&home).expect("read stopped status");
+        let status = confirm_stopped(&home).expect("read stopped status");
         assert_eq!(status.state, "stopped");
         assert_eq!(status.pid, 0);
         assert_eq!(status.runtime_version, "0.10.0");
@@ -229,7 +234,7 @@ mod tests {
             .expect("open runtime lock");
         lock.try_lock_exclusive().expect("hold runtime lock");
 
-        let error = stopped_status(&home).expect_err("held lock must not report stopped");
+        let error = confirm_stopped(&home).expect_err("held lock must not report stopped");
         assert!(error.contains("runtime lock is still held"));
 
         fs2::FileExt::unlock(&lock).expect("release runtime lock");

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -176,6 +176,60 @@ fn leading_runtime_globals_on_unowned_roots_pass_through_exactly() {
 }
 
 #[test]
+fn inherited_stop_succeeds_only_after_the_runtime_is_confirmed_stopped() {
+    let fixture = Fixture::new("confirmed-stop");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+for arg in "$@"; do
+    echo "<$arg>"
+done > "$AOS_TEST_ARGS"
+echo 'error: connection lost waiting on astrid.v1.response.shutdown.test: connection lost: connection closed before astrid.v1.response.shutdown.test' >&2
+exit 1
+"#,
+    );
+
+    let output = fixture
+        .command()
+        .args(["--principal", "operator", "stop"])
+        .output()
+        .expect("run inherited stop");
+
+    assert!(output.status.success());
+    assert_eq!(
+        fs::read_to_string(&fixture.args).expect("read delegated stop args"),
+        "<--principal>\n<operator>\n<stop>\n"
+    );
+    assert!(output.stderr.is_empty());
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("utf8 stop output"),
+        "Unicity AOS stopped.\n"
+    );
+}
+
+#[test]
+fn inherited_stop_does_not_mask_other_runtime_failures() {
+    let fixture = Fixture::new("failed-stop");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+echo 'invalid stop argument' >&2
+exit 2
+"#,
+    );
+
+    let output = fixture
+        .command()
+        .args(["stop", "--invalid"])
+        .output()
+        .expect("run rejected inherited stop");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(
+        String::from_utf8(output.stderr).expect("utf8 stop error"),
+        "invalid stop argument\n"
+    );
+}
+
+#[test]
 fn product_help_version_and_usage_errors_never_delegate() {
     let fixture = Fixture::new("product-roots");
     fixture.install_runtime(RECORDING_RUNTIME);

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -188,17 +188,29 @@ exit 1
 "#,
     );
 
+    let ready_marker = fixture.home.join("runtime/run/system.ready");
+    fs::create_dir_all(ready_marker.parent().expect("runtime run directory"))
+        .expect("create runtime run directory");
+    fs::write(&ready_marker, []).expect("create runtime ready marker");
+    let marker_to_remove = ready_marker.clone();
+    let shutdown = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(200));
+        fs::remove_file(marker_to_remove).expect("remove runtime ready marker");
+    });
+
     let output = fixture
         .command()
-        .args(["--principal", "operator", "stop"])
+        .args(["--future-runtime-global", "future-value", "stop"])
         .output()
         .expect("run inherited stop");
+    shutdown.join().expect("finish runtime shutdown");
 
     assert!(output.status.success());
     assert_eq!(
         fs::read_to_string(&fixture.args).expect("read delegated stop args"),
-        "<--principal>\n<operator>\n<stop>\n"
+        "<--future-runtime-global>\n<future-value>\n<stop>\n"
     );
+    assert!(!ready_marker.exists());
     assert!(output.stderr.is_empty());
     assert_eq!(
         String::from_utf8(output.stdout).expect("utf8 stop output"),


### PR DESCRIPTION
## Summary

- preserve the inherited Astrid `stop` argument surface while normalizing its known shutdown-response disconnect
- report success only after AOS proves that every runtime coordination marker is gone and the singleton lock is available
- retain the runtime's output and exact exit status for every other stop failure
- add unit, CLI-boundary, changelog, exact runtime boot, and upgrade/self-heal coverage

## Why

Release run `29579077836` passed release identity validation, capsule composition, and three platform builds, then failed closed in the x86_64 Linux clean-home gate. The daemon completed shutdown, but the runtime client lost the shutdown response as the socket closed and exited 1. This makes the inherited `aos stop` surface distinguish a completed shutdown from a real failure without granting AOS any special runtime authority.

No release or artifact was published by the failed run.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p unicity-aos-bootstrap`
- `cargo clippy --locked -p unicity-aos-bootstrap -- -D warnings`
- `PATH=/opt/homebrew/opt/python@3.12/libexec/bin:$PATH bash scripts/test-final-runtime-boot-harness.sh`
- `PATH=/opt/homebrew/opt/python@3.12/libexec/bin:$PATH bash scripts/test-upgrade-self-heal.sh`
- `git diff --check`
