### PR TITLE
test(release): preserve clean-home gate result

### DIFF
--- a/scripts/test-channel-workflow-contract.sh
+++ b/scripts/test-channel-workflow-contract.sh
@@ -7,6 +7,7 @@ release_workflow="$repo_root/.github/workflows/release.yml"
 bootstrap_workflow="$repo_root/.github/workflows/bootstrap-channels.yml"
 nightly_workflow="$repo_root/.github/workflows/nightly.yml"
 nightly_promotion_workflow="$repo_root/.github/workflows/promote-nightly.yml"
+clean_home_gate="$repo_root/scripts/test-clean-home-init.sh"
 
 grep -Fq "if: github.ref == 'refs/heads/main'" "$workflow"
 grep -Fq "repos/\$GITHUB_REPOSITORY/git/ref/tags/\$RELEASE_TAG" "$workflow"
@@ -73,6 +74,8 @@ grep -Fq 'prerelease: ${{ needs.classify.outputs.nightly == '\''true'\'' }}' "$r
 grep -Fq 'workflow_run:' "$nightly_promotion_workflow"
 grep -Fq "github.event.workflow_run.conclusion == 'success'" "$nightly_promotion_workflow"
 grep -Fq 'gh workflow run promote-channel.yml' "$nightly_promotion_workflow"
+grep -Fq 'if ! rm -rf "$work"; then' "$clean_home_gate"
+grep -Fq 'exit "$status"' "$clean_home_gate"
 
 python3 - "$workflow" <<'PY'
 import pathlib

--- a/scripts/test-clean-home-init.sh
+++ b/scripts/test-clean-home-init.sh
@@ -65,7 +65,9 @@ cleanup() {
   status=$?
   trap - EXIT
   run_aos stop >/dev/null 2>&1 || true
-  rm -rf "$work"
+  if ! rm -rf "$work"; then
+    echo "warning: clean-home fixture cleanup left runtime mounts for runner teardown" >&2
+  fi
   exit "$status"
 }
 trap cleanup EXIT


### PR DESCRIPTION
## Summary

- preserve the clean-home gate's real result when best-effort temporary fixture deletion encounters runner-owned FUSE mounts
- keep the cleanup warning visible without turning a completed install, boot, recheck, and stop into a release failure
- pin the behavior in the release workflow contract test

## Why

Release run `29581187270` completed every functional clean-home assertion and printed `clean AOS home initialized, loaded, rechecked, and stopped successfully`. Its EXIT trap then attempted to remove the temporary home, encountered still-mounted FUSE directories owned by the disposable runner, and replaced the successful result with exit 1. No release or artifact was published.

## Validation

- `sh -n scripts/test-clean-home-init.sh scripts/test-channel-workflow-contract.sh`
- `shellcheck scripts/test-clean-home-init.sh`
- `shellcheck -S warning scripts/test-channel-workflow-contract.sh`
- `bash scripts/test-channel-workflow-contract.sh`
- `actionlint .github/workflows/release.yml`
- `git diff --check`