### PR TITLE
fix(release): use AOS capsule identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - The `aos` product command and product-owned `~/.aos` state boundary.
-- A pinned Unicity CE distribution manifest over Astrid Runtime 0.10.0, emplaced
+- A pinned Unicity CE distribution manifest over Astrid Runtime 0.10.1, emplaced
   as the bundled runtime's operator-enforced distro.
 - Reproducible macOS and Linux release bundles with primary BLAKE3 and
   Homebrew-compatible SHA-256 checksum manifests, Sigstore bundles, GitHub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Runtime import holds the standalone daemon's existing singleton lock without
   changing the source, and interrupted unreceipted cutovers always roll back
   before recopying the current locked source.
-- A signed release path for the 18 installable `astrid-capsule-*` artifacts
+- A signed release path for the 18 installable `aos-*` artifacts
   built from this source tree and selected locally by Community Edition, with
   exact source/manifest identity checks, product-archive inclusion, offline
   provisioning, archive safety validation, BLAKE3 checksums, SHA-256

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,9 +290,9 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "astrid-core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4eefc7fc4dff338168d9dc433770ff648fa1763d2af5a8a12c0ecf939e7db9"
+checksum = "6e11d4d21ef028d130734c376381b316356eed2efc8b8f446e14a66512fd7e6b"
 dependencies = [
  "async-trait",
  "base64",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f9404c141ff8a8c2a1490b0614f5c00e463bf5213bd566a02d566e2923ee8e"
+checksum = "760e3ca8cb194e7a86695ae3a1fb42e566ade25c0b5aa26420204f1b4a2acab5"
 dependencies = [
  "base64",
  "blake3",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636764865299db0cd870cdb49167e28e646a4ed34ac2bc0ee5ec01483b16cc9c"
+checksum = "ed52e6105b784c67e5f44f9cca962890fef29503a7e86a3e31de917847d68c9b"
 dependencies = [
  "chrono",
  "getrandom",
@@ -447,14 +447,14 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa268c7778228194c98d47b690cdc81556a6b20e500094ade8a29e177849fb77"
+checksum = "4fa2826ffebc7b6ef6db5f16d64b63f807fb19ff43f8fe85ccb4529eec9b2e18"
 dependencies = [
  "anyhow",
  "astrid-core",
  "astrid-crypto",
- "astrid-types 0.10.0",
+ "astrid-types 0.10.1",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,19 +77,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
-
-[[package]]
-name = "astrid-capsule-agents"
+name = "aos-agents"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -98,7 +86,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-cli"
+name = "aos-cli"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -107,7 +95,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-context-engine"
+name = "aos-context-engine"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -116,7 +104,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-forge"
+name = "aos-forge"
 version = "0.1.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -126,7 +114,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-fs"
+name = "aos-fs"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -135,7 +123,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-hook-bridge"
+name = "aos-hook-bridge"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -144,7 +132,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-http"
+name = "aos-http"
 version = "0.1.1"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -153,7 +141,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-identity"
+name = "aos-identity"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -163,7 +151,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-memory"
+name = "aos-memory"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -173,7 +161,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-openai"
+name = "aos-openai"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -183,7 +171,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-openai-compat"
+name = "aos-openai-compat"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -193,7 +181,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-prompt-builder"
+name = "aos-prompt-builder"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -202,7 +190,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-react"
+name = "aos-react"
 version = "0.2.2"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -212,7 +200,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-registry"
+name = "aos-registry"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -221,17 +209,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-router"
-version = "0.2.0"
-dependencies = [
- "astrid-sdk 0.7.1",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "astrid-capsule-session"
+name = "aos-router"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -241,7 +219,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-shell"
+name = "aos-session"
+version = "0.2.0"
+dependencies = [
+ "astrid-sdk 0.7.1",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "aos-shell"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -250,7 +238,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-skills"
+name = "aos-skills"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -259,7 +247,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-system"
+name = "aos-system"
 version = "0.2.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -268,7 +256,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-telegram"
+name = "aos-telegram"
 version = "0.1.0"
 dependencies = [
  "astrid-sdk 0.5.3",
@@ -279,7 +267,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "astrid-capsule-users"
+name = "aos-users"
 version = "0.1.0"
 dependencies = [
  "astrid-sdk 0.7.1",
@@ -287,6 +275,18 @@ dependencies = [
  "serde_json",
  "uuid",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "astrid-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ resolver = "3"
 
 [workspace.dependencies]
 astrid-sdk = { version = "=0.7.1", features = ["derive"] }
-astrid-core = "=0.10.0"
-astrid-uplink = "=0.10.0"
+astrid-core = "=0.10.1"
+astrid-uplink = "=0.10.1"
 axum = "0.8"
 blake3 = "1.8.5"
 clap = { version = "4.6", features = ["derive"] }

--- a/capsules/capsule-agents/Capsule.toml
+++ b/capsules/capsule-agents/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-agents"
+name = "aos-agents"
 version = "0.2.0"
 description = "Injects project instructions from AGENTS.md into the system prompt"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "agents"
-file = "astrid_capsule_agents.wasm"
+file = "aos_agents.wasm"
 type = "executable"
 capabilities = { fs_read = ["cwd://"] }
 

--- a/capsules/capsule-agents/Cargo.toml
+++ b/capsules/capsule-agents/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-agents"
+name = "aos-agents"
 version = "0.2.0"
 edition = "2024"
 description = "Injects project instructions from AGENTS.md into the system prompt"

--- a/capsules/capsule-cli/Capsule.toml
+++ b/capsules/capsule-cli/Capsule.toml
@@ -1,11 +1,11 @@
 [package]
-name = "astrid-capsule-cli"
+name = "aos-cli"
 version = "0.2.0"
 description = "Native Unix socket bridge for the Unicity AOS command surface."
 
 [[component]]
 id = "main"
-file = "astrid_capsule_cli.wasm"
+file = "aos_cli.wasm"
 
 [capabilities]
 uplink = true

--- a/capsules/capsule-cli/Cargo.toml
+++ b/capsules/capsule-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-cli"
+name = "aos-cli"
 version = "0.2.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/capsules/capsule-cli/README.md
+++ b/capsules/capsule-cli/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-cli
+# aos-cli
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-context-engine/Capsule.toml
+++ b/capsules/capsule-context-engine/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-context-engine"
+name = "aos-context-engine"
 version = "0.2.0"
 description = "Pluggable context window compaction with interceptor hook support"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "context-engine"
-file = "astrid_capsule_context_engine.wasm"
+file = "aos_context_engine.wasm"
 type = "executable"
 
 [exports]

--- a/capsules/capsule-context-engine/Cargo.toml
+++ b/capsules/capsule-context-engine/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-context-engine"
+name = "aos-context-engine"
 version = "0.2.0"
 edition = "2024"
 description = "Context Engine capsule — pluggable compaction with interceptor hook support"

--- a/capsules/capsule-context-engine/README.md
+++ b/capsules/capsule-context-engine/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-context-engine
+# aos-context-engine
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-forge/Capsule.toml
+++ b/capsules/capsule-forge/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-forge"
+name = "aos-forge"
 version = "0.1.0"
 description = "Capsule-authoring forge for Unicity AOS components"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.7.0"
 
 [[component]]
 id = "forge-tools"
-file = "astrid_capsule_forge.wasm"
+file = "aos_forge.wasm"
 type = "executable"
 
 [capabilities]

--- a/capsules/capsule-forge/Cargo.toml
+++ b/capsules/capsule-forge/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-forge"
+name = "aos-forge"
 version = "0.1.0"
 edition = "2024"
 description = "Capsule-authoring forge for Unicity AOS components"

--- a/capsules/capsule-forge/src/lib.rs
+++ b/capsules/capsule-forge/src/lib.rs
@@ -67,7 +67,7 @@ pub struct EmptyArgs {}
 
 #[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct ScaffoldArgs {
-    /// Capsule name, e.g. `astrid-capsule-weather`. Becomes the crate name.
+    /// Capsule name, e.g. `aos-weather`. Becomes the crate name.
     pub name: String,
     /// Capsule kind. Only `"tool"` is supported in v1 (the default).
     #[serde(default)]
@@ -94,7 +94,7 @@ pub struct ManifestArgs {
 
 #[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct DoctorArgs {
-    /// Installed capsule name, e.g. `astrid-capsule-system`.
+    /// Installed capsule name, e.g. `aos-system`.
     pub name: String,
 }
 
@@ -421,14 +421,14 @@ fn suggest_llm(intent: &str, out: &mut Vec<Value>) {
         out.push(cap(
             "be an LLM provider",
             "[exports]\n\"astrid:llm\" = \"1.0.0\"\n\n[capabilities]\nnet = [\"*\"]\n\n[publish]\n\"llm.v1.stream.<provider>\" = { wit = \"@unicity-astrid/wit/llm/stream-event\" }\n\"llm.v1.response.describe\" = { wit = \"@unicity-astrid/wit/llm/describe-response\" }\n\n[subscribe]\n\"llm.v1.request.describe\" = { wit = \"@unicity-astrid/wit/llm/describe-request\", handler = \"llm_describe\" }\n\"llm.v1.request.generate.<provider>\" = { wit = \"@unicity-astrid/wit/llm/generate-request\", handler = \"handle_llm_request\" }",
-            "Export astrid:llm, subscribe generate.<provider> + request.describe, publish a stream + describe-response. The registry fans out to the unsuffixed describe topic. Mirrors astrid-capsule-openai-compat.",
+            "Export astrid:llm, subscribe generate.<provider> + request.describe, publish a stream + describe-response. The registry fans out to the unsuffixed describe topic. Mirrors aos-openai-compat.",
         ));
     }
     if consumer {
         out.push(cap(
             "call an LLM (consumer)",
             "[imports]\n\"astrid:llm\" = \"^1.0\"\n\n[publish]\n\"llm.v1.request.generate.*\" = { wit = \"@unicity-astrid/wit/llm/generate-request\" }\n\n[subscribe]\n\"llm.v1.stream.*\" = { wit = \"@unicity-astrid/wit/llm/stream-event\", handler = \"handle_llm_stream\" }",
-            "Import astrid:llm, publish a generate request to the active provider's topic, subscribe its stream. Mirrors how astrid-capsule-react drives a provider.",
+            "Import astrid:llm, publish a generate request to the active provider's topic, subscribe its stream. Mirrors how aos-react drives a provider.",
         ));
     }
 }

--- a/capsules/capsule-forge/src/skills/capsule-forge/SKILL.md
+++ b/capsules/capsule-forge/src/skills/capsule-forge/SKILL.md
@@ -455,7 +455,7 @@ it before touching a byte of WASM. Every section below is optional except
 
 ```toml
 [package]
-name = "astrid-capsule-http"   # required; lowercase ASCII alphanumeric + hyphens
+name = "aos-http"   # required; lowercase ASCII alphanumeric + hyphens
 version = "0.1.0"             # required; three-part numeric
 description = "HTTP fetch tool"
 authors = ["Name <e@mail>"]
@@ -474,7 +474,7 @@ One per WASM binary (a capsule usually has exactly one).
 ```toml
 [[component]]
 id = "http-tools"
-file = "astrid_capsule_http.wasm"  # path relative to Capsule.toml; crate name, hyphens->underscores
+file = "aos_http.wasm"  # path relative to Capsule.toml; crate name, hyphens->underscores
 type = "executable"               # "executable" (default) or "library"
 ```
 

--- a/capsules/capsule-fs/Capsule.toml
+++ b/capsules/capsule-fs/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-fs"
+name = "aos-fs"
 version = "0.2.0"
 description = "Core filesystem tools for Unicity AOS"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "fs-tools"
-file = "astrid_capsule_fs.wasm"
+file = "aos_fs.wasm"
 type = "executable"
 # Note: home:// write is intentionally omitted — fs-tools should not write
 # to ~/.astrid/ (which contains keys, audit DBs, etc.). Read is permitted for

--- a/capsules/capsule-fs/Cargo.toml
+++ b/capsules/capsule-fs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-fs"
+name = "aos-fs"
 version = "0.2.0"
 edition = "2024"
 description = "Core filesystem tools for Unicity AOS"

--- a/capsules/capsule-fs/README.md
+++ b/capsules/capsule-fs/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-fs
+# aos-fs
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-hook-bridge/Capsule.toml
+++ b/capsules/capsule-hook-bridge/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-hook-bridge"
+name = "aos-hook-bridge"
 version = "0.2.0"
 description = "Hook bridge capsule — maps lifecycle events to semantic hooks with merge strategies"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "hook-bridge"
-file = "astrid_capsule_hook_bridge.wasm"
+file = "aos_hook_bridge.wasm"
 type = "executable"
 
 [exports]

--- a/capsules/capsule-hook-bridge/Cargo.toml
+++ b/capsules/capsule-hook-bridge/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-hook-bridge"
+name = "aos-hook-bridge"
 version = "0.2.0"
 edition = "2024"
 description = "Hook bridge capsule — maps lifecycle events to semantic hooks with merge strategies"

--- a/capsules/capsule-hook-bridge/README.md
+++ b/capsules/capsule-hook-bridge/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-hook-bridge
+# aos-hook-bridge
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-http/Capsule.toml
+++ b/capsules/capsule-http/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-http"
+name = "aos-http"
 version = "0.1.1"
 description = "HTTP fetch tool for Unicity AOS agents"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "http-tools"
-file = "astrid_capsule_http.wasm"
+file = "aos_http.wasm"
 type = "executable"
 
 [capabilities]

--- a/capsules/capsule-http/Cargo.toml
+++ b/capsules/capsule-http/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-http"
+name = "aos-http"
 version = "0.1.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/capsules/capsule-http/README.md
+++ b/capsules/capsule-http/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-http
+# aos-http
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-identity/Capsule.toml
+++ b/capsules/capsule-identity/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-identity"
+name = "aos-identity"
 version = "0.2.0"
 description = "Agent identity capsule — owns spark config, builds system prompt"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "identity-builder"
-file = "astrid_capsule_identity.wasm"
+file = "aos_identity.wasm"
 type = "executable"
 capabilities = { fs_read = ["home://"], fs_write = ["home://"] }
 

--- a/capsules/capsule-identity/Cargo.toml
+++ b/capsules/capsule-identity/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-identity"
+name = "aos-identity"
 version = "0.2.0"
 edition = "2024"
 description = "Context builder capsule for Unicity AOS"

--- a/capsules/capsule-identity/README.md
+++ b/capsules/capsule-identity/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-identity
+# aos-identity
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-memory/Capsule.toml
+++ b/capsules/capsule-memory/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-memory"
+name = "aos-memory"
 version = "0.2.0"
 description = "Injects cross-session memory into the system prompt via prompt builder hooks"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "memory"
-file = "astrid_capsule_memory.wasm"
+file = "aos_memory.wasm"
 type = "executable"
 capabilities = { fs_read = ["cwd://", "home://"] }
 

--- a/capsules/capsule-memory/Cargo.toml
+++ b/capsules/capsule-memory/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-memory"
+name = "aos-memory"
 version = "0.2.0"
 edition = "2024"
 description = "Cross-session memory capsule for Unicity AOS"

--- a/capsules/capsule-memory/README.md
+++ b/capsules/capsule-memory/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-memory
+# aos-memory
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
@@ -23,7 +23,7 @@ Agent-written content can grow without limit (unlike human-authored `AGENTS.md`)
 
 ## Read-only
 
-This capsule handles the read/inject side only. The agent writes to `.aos/memory.md` using existing filesystem tools (`write_file`, `replace_in_file`) from `astrid-capsule-fs`. No new tools needed.
+This capsule handles the read/inject side only. The agent writes to `.aos/memory.md` using existing filesystem tools (`write_file`, `replace_in_file`) from `aos-fs`. No new tools needed.
 
 ## Development
 

--- a/capsules/capsule-openai-compat/Capsule.toml
+++ b/capsules/capsule-openai-compat/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-openai-compat"
+name = "aos-openai-compat"
 version = "0.2.0"
 description = "OpenAI-compatible LLM Provider"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "openai-compat"
-file = "astrid_capsule_openai_compat.wasm"
+file = "aos_openai_compat.wasm"
 type = "executable"
 capabilities = { net = ["*"] }
 

--- a/capsules/capsule-openai-compat/Cargo.toml
+++ b/capsules/capsule-openai-compat/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-openai-compat"
+name = "aos-openai-compat"
 version = "0.2.0"
 edition = "2024"
 description = "OpenAI-compatible LLM provider capsule for Unicity AOS"

--- a/capsules/capsule-openai-compat/README.md
+++ b/capsules/capsule-openai-compat/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-openai-compat
+# aos-openai-compat
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
@@ -130,7 +130,7 @@ it. The default is no exemptions.
 ```toml
 [security.capsule_local_egress]
 # host:port (or host:*) endpoints this capsule may reach even though they resolve to a local address
-"astrid-capsule-openai-compat" = ["127.0.0.1:1234", "192.168.1.50:11434"]
+"aos-openai-compat" = ["127.0.0.1:1234", "192.168.1.50:11434"]
 ```
 
 The exemption only lifts the airlock for those specific `host:port` pairs. It does not change the

--- a/capsules/capsule-openai/Capsule.toml
+++ b/capsules/capsule-openai/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-openai"
+name = "aos-openai"
 version = "0.2.0"
 description = "Native OpenAI LLM Provider"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.5.0"
 
 [[component]]
 id = "openai"
-file = "astrid_capsule_openai.wasm"
+file = "aos_openai.wasm"
 type = "executable"
 capabilities = { net = ["api.openai.com"] }
 

--- a/capsules/capsule-openai/Cargo.toml
+++ b/capsules/capsule-openai/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-openai"
+name = "aos-openai"
 version = "0.2.0"
 edition = "2024"
 description = "Native OpenAI LLM provider capsule for Unicity AOS"

--- a/capsules/capsule-openai/README.md
+++ b/capsules/capsule-openai/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-openai
+# aos-openai
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
@@ -11,7 +11,7 @@ generic compatible providers do not offer.
 
 For generic OpenAI-compatible providers (Groq, Together, Mistral, DeepSeek, Fireworks, LM Studio,
 vLLM, llama.cpp, etc.), use
-[`astrid-capsule-openai-compat`](https://github.com/unicity-aos/aos-ce/tree/main/capsules/capsule-openai-compat) instead.
+[`aos-openai-compat`](https://github.com/unicity-aos/aos-ce/tree/main/capsules/capsule-openai-compat) instead.
 
 ## OpenAI-specific features
 

--- a/capsules/capsule-openai/src/lib.rs
+++ b/capsules/capsule-openai/src/lib.rs
@@ -17,7 +17,7 @@
 //! - **`max_output_tokens`** at the top level
 //!
 //! For generic OpenAI-compatible providers that still use `/v1/chat/completions`
-//! (Groq, Together, Mistral, etc.), use `astrid-capsule-openai-compat` instead.
+//! (Groq, Together, Mistral, etc.), use `aos-openai-compat` instead.
 
 mod models;
 mod schemas;

--- a/capsules/capsule-prompt-builder/Capsule.toml
+++ b/capsules/capsule-prompt-builder/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-prompt-builder"
+name = "aos-prompt-builder"
 version = "0.2.0"
 description = "Assembles LLM prompts with plugin interceptor hooks for context injection and override"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "prompt-builder"
-file = "astrid_capsule_prompt_builder.wasm"
+file = "aos_prompt_builder.wasm"
 type = "executable"
 
 [publish]

--- a/capsules/capsule-prompt-builder/Cargo.toml
+++ b/capsules/capsule-prompt-builder/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-prompt-builder"
+name = "aos-prompt-builder"
 version = "0.2.0"
 edition = "2024"
 description = "Prompt assembly capsule — fires interceptor hooks and merges plugin contributions into the final LLM prompt"

--- a/capsules/capsule-prompt-builder/README.md
+++ b/capsules/capsule-prompt-builder/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-prompt-builder
+# aos-prompt-builder
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-react/Capsule.toml
+++ b/capsules/capsule-react/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-react"
+name = "aos-react"
 version = "0.2.2"
 description = "ReAct loop: stateless coordinator for LLM reasoning and tool execution"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "react"
-file = "astrid_capsule_react.wasm"
+file = "aos_react.wasm"
 type = "executable"
 
 [imports]

--- a/capsules/capsule-react/Cargo.toml
+++ b/capsules/capsule-react/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-react"
+name = "aos-react"
 version = "0.2.2"
 edition = "2024"
 description = "ReAct loop capsule: stateless coordinator for LLM reasoning and tool execution"

--- a/capsules/capsule-react/README.md
+++ b/capsules/capsule-react/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-react
+# aos-react
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-react/src/lib.rs
+++ b/capsules/capsule-react/src/lib.rs
@@ -553,7 +553,7 @@ impl ReactLoop {
         // drops the subscription on every return path (Drop on
         // `Subscription`). Session publishes `{correlation_id, new_session_id,
         // old_session_id}` at the root of the reply payload (see
-        // `astrid-capsule-session::handle_clear`) — no envelope wrapper.
+        // `aos-session::handle_clear`) — no envelope wrapper.
         let response: serde_json::Value = ipc::request_response(
             "session.v1.request.clear",
             "session.v1.response.clear",
@@ -1767,7 +1767,7 @@ impl ReactLoop {
     /// # IPC envelope format
     ///
     /// Session publishes `{correlation_id, messages}` at the root of the
-    /// reply payload (see `astrid-capsule-session::handle_get_messages`).
+    /// reply payload (see `aos-session::handle_get_messages`).
     /// `ipc::request_response` deserialises the raw JSON without an envelope
     /// wrapper, so `messages` lives at the root of `response`.
     fn fetch_messages_inner(
@@ -1794,7 +1794,7 @@ impl ReactLoop {
 
         // Session publishes `{correlation_id, messages}` at the top
         // level of the response payload (see
-        // `astrid-capsule-session::handle_get_messages`). No envelope
+        // `aos-session::handle_get_messages`). No envelope
         // wrapper — the SDK's `request_response` already deserialised
         // the raw JSON payload; `messages` lives at the root.
         let messages: Vec<Message> = response

--- a/capsules/capsule-registry/Capsule.toml
+++ b/capsules/capsule-registry/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-registry"
+name = "aos-registry"
 version = "0.2.0"
 description = "LLM provider registry — discovers and manages available models"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "registry"
-file = "astrid_capsule_registry.wasm"
+file = "aos_registry.wasm"
 
 [exports]
 "astrid:registry" = "1.0.0"
@@ -37,7 +37,7 @@ file = "astrid_capsule_registry.wasm"
 "cli.v1.command.execute" = { wit = "@unicity-astrid/wit/system/command-execute" }
 # Scriptable `models` verb runs — `aos capsule models ...` dispatches the
 # run body here (see astrid capsule_verb.rs run topic = cli.v1.command.run.<provider_capsule>).
-"cli.v1.command.run.astrid-capsule-registry" = { wit = "opaque" }
+"cli.v1.command.run.aos-registry" = { wit = "opaque" }
 # 4-segment exact (topic_matches requires equal segment count, so registry.v1.* does NOT cover this)
 "registry.v1.selection.callback" = { wit = "@unicity-astrid/wit/registry/selection-callback" }
 "astrid.v1.capsules_loaded" = { wit = "@unicity-astrid/wit/system/capsules-loaded" }

--- a/capsules/capsule-registry/Cargo.toml
+++ b/capsules/capsule-registry/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-registry"
+name = "aos-registry"
 version = "0.2.0"
 edition = "2024"
 description = "LLM provider registry capsule for Unicity AOS"

--- a/capsules/capsule-registry/README.md
+++ b/capsules/capsule-registry/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-registry
+# aos-registry
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
@@ -27,7 +27,7 @@ On capsule reload events, the registry re-discovers providers, reconciles a stal
 | Subscribe | `registry.v1.set_active_model` | Sets active model by ID |
 | Publish | `registry.v1.active_model_changed` | Emitted on model switch |
 | Publish | `registry.v1.response.*` | Per-request responses |
-| Subscribe | `cli.v1.command.run.astrid-capsule-registry` | Scriptable `models` verb runs |
+| Subscribe | `cli.v1.command.run.aos-registry` | Scriptable `models` verb runs |
 | Publish | `cli.v1.command.result.*` | Scriptable verb results, keyed by request id |
 
 ## CLI integration
@@ -36,7 +36,7 @@ TUI slash command (`cli.v1.command.execute`):
 - `/models` - emits a `SelectionRequired` payload for the TUI picker
 - `/models <model_id>` - direct model switch
 
-Scriptable verb (`aos capsule models ...`, over `cli.v1.command.run.astrid-capsule-registry` with the reply on `cli.v1.command.result.<req_id>`):
+Scriptable verb (`aos capsule models ...`, over `cli.v1.command.run.aos-registry` with the reply on `cli.v1.command.result.<req_id>`):
 - `models list [--json]` - list available models (canonical ids, active marked)
 - `models current [--json]` - print the active model id (or `none`)
 - `models set <id>` - switch the active model; accepts a bare model name when unambiguous, persists the canonical `"<capsule>:<model>"` form

--- a/capsules/capsule-registry/src/lib.rs
+++ b/capsules/capsule-registry/src/lib.rs
@@ -58,7 +58,7 @@ const LLM_DESCRIBE_RESPONSE_TOPIC: &str = "llm.v1.response.describe";
 /// CLI run/result protocol topics (the scriptable `models` verb). The run
 /// topic is the providing capsule id; results are keyed by request id. See
 /// `astrid` `crates/astrid-cli/src/commands/capsule_verb.rs`.
-const CLI_RUN_TOPIC: &str = "cli.v1.command.run.astrid-capsule-registry";
+const CLI_RUN_TOPIC: &str = "cli.v1.command.run.aos-registry";
 const CLI_RESULT_TOPIC_PREFIX: &str = "cli.v1.command.result.";
 
 /// Maximum accepted length of an incoming `req_id`. The CLI sends a 32-char

--- a/capsules/capsule-registry/src/lib_tests.rs
+++ b/capsules/capsule-registry/src/lib_tests.rs
@@ -62,7 +62,7 @@ fn req_id_validation_accepts_cli_shape_rejects_topic_injection() {
 fn cli_run_topic_uses_provider_capsule_package_id() {
     // The CLI publishes to cli.v1.command.run.<provider_capsule>, where
     // provider_capsule comes from GetCommands and is the package id.
-    assert_eq!(CLI_RUN_TOPIC, "cli.v1.command.run.astrid-capsule-registry");
+    assert_eq!(CLI_RUN_TOPIC, "cli.v1.command.run.aos-registry");
 
     // Ensure Capsule.toml subscription matches CLI_RUN_TOPIC to prevent drift.
     let capsule_toml = include_str!("../Capsule.toml");

--- a/capsules/capsule-registry/src/selection.rs
+++ b/capsules/capsule-registry/src/selection.rs
@@ -463,8 +463,8 @@ mod tests {
             Some("openai-compat")
         );
         assert_eq!(
-            request_topic_qualifier("llm.v1.request.generate.astrid-capsule-openai-compat"),
-            Some("astrid-capsule-openai-compat")
+            request_topic_qualifier("llm.v1.request.generate.aos-openai-compat"),
+            Some("aos-openai-compat")
         );
         assert_eq!(request_topic_qualifier("llm.v1.request.generate."), None);
         assert_eq!(request_topic_qualifier("llm.v1.request.generate.*"), None);

--- a/capsules/capsule-router/Capsule.toml
+++ b/capsules/capsule-router/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-router"
+name = "aos-router"
 version = "0.2.0"
 description = "Tool execution routing middleware for Unicity AOS"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "router"
-file = "astrid_capsule_router.wasm"
+file = "aos_router.wasm"
 type = "executable"
 
 [exports]

--- a/capsules/capsule-router/Cargo.toml
+++ b/capsules/capsule-router/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-router"
+name = "aos-router"
 version = "0.2.0"
 edition = "2024"
 description = "Tool execution routing middleware for Unicity AOS"

--- a/capsules/capsule-router/README.md
+++ b/capsules/capsule-router/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-router
+# aos-router
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-session/Capsule.toml
+++ b/capsules/capsule-session/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-session"
+name = "aos-session"
 version = "0.2.0"
 description = "Persistent conversation session store"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "session"
-file = "astrid_capsule_session.wasm"
+file = "aos_session.wasm"
 type = "executable"
 
 [exports]

--- a/capsules/capsule-session/Cargo.toml
+++ b/capsules/capsule-session/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-session"
+name = "aos-session"
 version = "0.2.0"
 edition = "2024"
 description = "Persistent conversation session store for Unicity AOS"

--- a/capsules/capsule-session/README.md
+++ b/capsules/capsule-session/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-session
+# aos-session
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-shell/Capsule.toml
+++ b/capsules/capsule-shell/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-shell"
+name = "aos-shell"
 version = "0.2.0"
 description = "Core shell execution tools for Unicity AOS"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "shell-tools"
-file = "astrid_capsule_shell.wasm"
+file = "aos_shell.wasm"
 type = "executable"
 
 [capabilities]

--- a/capsules/capsule-shell/Cargo.toml
+++ b/capsules/capsule-shell/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-shell"
+name = "aos-shell"
 version = "0.2.0"
 edition = "2024"
 description = "Core shell execution tools for Unicity AOS"

--- a/capsules/capsule-shell/README.md
+++ b/capsules/capsule-shell/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-shell
+# aos-shell
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-skills/Capsule.toml
+++ b/capsules/capsule-skills/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-skills"
+name = "aos-skills"
 version = "0.2.0"
 description = "Skills Loader - Reads and loads Agent Skills via VFS"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "skills-loader"
-file = "astrid_capsule_skills.wasm"
+file = "aos_skills.wasm"
 type = "executable"
 # Broad home:// read needed — callers pass arbitrary dir_path (e.g. ".gemini/skills")
 # and the capsule scans both CWD and home trees under that path.

--- a/capsules/capsule-skills/Cargo.toml
+++ b/capsules/capsule-skills/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-skills"
+name = "aos-skills"
 version = "0.2.0"
 edition = "2024"
 description = "Skills loader for Unicity AOS"

--- a/capsules/capsule-skills/README.md
+++ b/capsules/capsule-skills/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-skills
+# aos-skills
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/capsules/capsule-system/Capsule.toml
+++ b/capsules/capsule-system/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-system"
+name = "aos-system"
 version = "0.2.0"
 description = "System management tools — lets the LLM inspect and manage its own runtime"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "system-tools"
-file = "astrid_capsule_system.wasm"
+file = "aos_system.wasm"
 type = "executable"
 
 [capabilities]

--- a/capsules/capsule-system/Cargo.toml
+++ b/capsules/capsule-system/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-system"
+name = "aos-system"
 version = "0.2.0"
 edition = "2024"
 description = "System management tools for Unicity AOS"

--- a/capsules/capsule-system/README.md
+++ b/capsules/capsule-system/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-system
+# aos-system
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
@@ -25,7 +25,7 @@ The LLM uses these tools to understand its own runtime before making changes. A 
 
 1. `list_capsules` -- see what's installed
 2. `read_interface session` -- understand the session interface contract
-3. `inspect_capsule astrid-capsule-session` -- read the current implementation
+3. `inspect_capsule aos-session` -- read the current implementation
 4. Build and install a replacement (via shell or future system tools)
 
 ## Security

--- a/capsules/capsule-system/src/lib.rs
+++ b/capsules/capsule-system/src/lib.rs
@@ -42,7 +42,7 @@ pub struct EmptyArgs {}
 
 #[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct InspectCapsuleArgs {
-    /// Capsule name (e.g. `astrid-capsule-session`).
+    /// Capsule name (e.g. `aos-session`).
     pub name: String,
 }
 

--- a/capsules/capsule-telegram/Capsule.toml
+++ b/capsules/capsule-telegram/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-telegram"
+name = "aos-telegram"
 version = "0.1.0"
 description = "Telegram Bot frontend for Unicity AOS — bridges the Telegram Bot API to the kernel IPC bus."
 authors = ["Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.5.0"
 
 [[component]]
 id = "telegram"
-file = "astrid_capsule_telegram.wasm"
+file = "aos_telegram.wasm"
 type = "executable"
 capabilities = { net = ["*"] }
 

--- a/capsules/capsule-telegram/Cargo.toml
+++ b/capsules/capsule-telegram/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-telegram"
+name = "aos-telegram"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/capsules/capsule-telegram/README.md
+++ b/capsules/capsule-telegram/README.md
@@ -33,7 +33,7 @@ before this capsule can be distributed or installed through AOS.
 If an older development copy is already installed, remove it explicitly with:
 
 ```bash
-aos capsule remove astrid-capsule-telegram --purge
+aos capsule remove aos-telegram --purge
 ```
 
 ## Bot Setup

--- a/capsules/capsule-users/Capsule.toml
+++ b/capsules/capsule-users/Capsule.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-users"
+name = "aos-users"
 version = "0.1.0"
 description = "Within-principal user identity store — platform-to-user-ID mapping over IPC"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
@@ -7,7 +7,7 @@ astrid-version = ">=0.1.0"
 
 [[component]]
 id = "users-store"
-file = "astrid_capsule_users.wasm"
+file = "aos_users.wasm"
 type = "executable"
 # No host capabilities. The capsule's entire surface is IPC pub/sub and
 # the per-capsule KV scope (granted by default).

--- a/capsules/capsule-users/Cargo.toml
+++ b/capsules/capsule-users/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "astrid-capsule-users"
+name = "aos-users"
 version = "0.1.0"
 edition = "2024"
 description = "Within-principal user identity store for Unicity AOS"

--- a/capsules/capsule-users/README.md
+++ b/capsules/capsule-users/README.md
@@ -1,4 +1,4 @@
-# astrid-capsule-users
+# aos-users
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)

--- a/crates/unicity-aos-bootstrap/src/migration.rs
+++ b/crates/unicity-aos-bootstrap/src/migration.rs
@@ -1496,9 +1496,9 @@ mod tests {
         );
         assert!(
             runtime
-                .join("home/default/.local/capsules/astrid-capsule-cli/Capsule.toml")
+                .join("imported/astrid-home-v1/home/default/.local/capsules/astrid-capsule-cli/Capsule.toml")
                 .is_file(),
-            "a canonical capsule selected by Community Edition remains active for default"
+            "a legacy package identity is preserved but cannot masquerade as the renamed AOS capsule"
         );
         assert!(
             runtime

--- a/crates/unicity-aos-bootstrap/src/status.rs
+++ b/crates/unicity-aos-bootstrap/src/status.rs
@@ -213,7 +213,7 @@ mod tests {
         let status = confirm_stopped(&home).expect("read stopped status");
         assert_eq!(status.state, "stopped");
         assert_eq!(status.pid, 0);
-        assert_eq!(status.runtime_version, "0.10.0");
+        assert_eq!(status.runtime_version, "0.10.1");
 
         fs::remove_dir_all(root).expect("remove stopped status fixture");
     }

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -755,7 +755,7 @@ fn native_status_reports_stopped_without_invoking_the_runtime_cli() {
         assert!(output.stderr.is_empty());
         let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
         assert!(stdout.contains("stopped"));
-        assert!(stdout.contains("0.10.0"));
+        assert!(stdout.contains("0.10.1"));
     }
 }
 

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -15,7 +15,7 @@ support = "https://github.com/unicity-aos/aos-ce/discussions"
 bug-tracker = "https://github.com/unicity-aos/aos-ce/issues"
 repository = "https://github.com/unicity-aos/aos-ce"
 license = "MIT OR Apache-2.0"
-astrid-version = "=0.10.0"  # Product releases pin the exact bundled runtime; update this with release/runtime-compatibility.toml.
+astrid-version = "=0.10.1"  # Product releases pin the exact bundled runtime; update this with release/runtime-compatibility.toml.
 
 [distro.requires.astrid]
 llm = "^1.0"

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -35,14 +35,14 @@ openai_max_tokens = { description = "Max output tokens", default = "128000" }
 # ---------------------------------------------------------------------------
 
 [[capsule]]
-name = "astrid-capsule-cli"
-source = "capsules/astrid-capsule-cli.capsule"
+name = "aos-cli"
+source = "capsules/aos-cli.capsule"
 version = "0.2.0"
 role = "uplink"
 
 [[capsule]]
-name = "astrid-capsule-registry"
-source = "capsules/astrid-capsule-registry.capsule"
+name = "aos-registry"
+source = "capsules/aos-registry.capsule"
 version = "0.2.0"
 role = "uplink"
 
@@ -51,8 +51,8 @@ role = "uplink"
 # ---------------------------------------------------------------------------
 
 [[capsule]]
-name = "astrid-capsule-openai-compat"
-source = "capsules/astrid-capsule-openai-compat.capsule"
+name = "aos-openai-compat"
+source = "capsules/aos-openai-compat.capsule"
 version = "0.2.0"
 group = "llm"
 env = { api_key = "{{ openai_api_key }}", base_url = "{{ openai_base_url }}", model = "{{ openai_model }}", temperature = "{{ openai_temperature }}", max_output_tokens = "{{ openai_max_tokens }}" }
@@ -62,43 +62,43 @@ env = { api_key = "{{ openai_api_key }}", base_url = "{{ openai_base_url }}", mo
 # ---------------------------------------------------------------------------
 
 [[capsule]]
-name = "astrid-capsule-react"
-source = "capsules/astrid-capsule-react.capsule"
+name = "aos-react"
+source = "capsules/aos-react.capsule"
 version = "0.2.2"
 
 [[capsule]]
-name = "astrid-capsule-session"
-source = "capsules/astrid-capsule-session.capsule"
+name = "aos-session"
+source = "capsules/aos-session.capsule"
 version = "0.2.0"
 
 [[capsule]]
-name = "astrid-capsule-identity"
-source = "capsules/astrid-capsule-identity.capsule"
+name = "aos-identity"
+source = "capsules/aos-identity.capsule"
 version = "0.2.0"
 
 [[capsule]]
-name = "astrid-capsule-users"
-source = "capsules/astrid-capsule-users.capsule"
+name = "aos-users"
+source = "capsules/aos-users.capsule"
 version = "0.1.0"
 
 [[capsule]]
-name = "astrid-capsule-router"
-source = "capsules/astrid-capsule-router.capsule"
+name = "aos-router"
+source = "capsules/aos-router.capsule"
 version = "0.2.0"
 
 [[capsule]]
-name = "astrid-capsule-prompt-builder"
-source = "capsules/astrid-capsule-prompt-builder.capsule"
+name = "aos-prompt-builder"
+source = "capsules/aos-prompt-builder.capsule"
 version = "0.2.0"
 
 [[capsule]]
-name = "astrid-capsule-context-engine"
-source = "capsules/astrid-capsule-context-engine.capsule"
+name = "aos-context-engine"
+source = "capsules/aos-context-engine.capsule"
 version = "0.2.0"
 
 [[capsule]]
-name = "astrid-capsule-hook-bridge"
-source = "capsules/astrid-capsule-hook-bridge.capsule"
+name = "aos-hook-bridge"
+source = "capsules/aos-hook-bridge.capsule"
 version = "0.2.0"
 
 # ---------------------------------------------------------------------------
@@ -106,23 +106,23 @@ version = "0.2.0"
 # ---------------------------------------------------------------------------
 
 [[capsule]]
-name = "astrid-capsule-shell"
-source = "capsules/astrid-capsule-shell.capsule"
+name = "aos-shell"
+source = "capsules/aos-shell.capsule"
 version = "0.2.0"
 
 [[capsule]]
-name = "astrid-capsule-http"
-source = "capsules/astrid-capsule-http.capsule"
+name = "aos-http"
+source = "capsules/aos-http.capsule"
 version = "0.1.1"
 
 [[capsule]]
-name = "astrid-capsule-fs"
-source = "capsules/astrid-capsule-fs.capsule"
+name = "aos-fs"
+source = "capsules/aos-fs.capsule"
 version = "0.2.0"
 
 [[capsule]]
-name = "astrid-capsule-system"
-source = "capsules/astrid-capsule-system.capsule"
+name = "aos-system"
+source = "capsules/aos-system.capsule"
 version = "0.2.0"
 
 # ---------------------------------------------------------------------------
@@ -130,18 +130,18 @@ version = "0.2.0"
 # ---------------------------------------------------------------------------
 
 [[capsule]]
-name = "astrid-capsule-skills"
-source = "capsules/astrid-capsule-skills.capsule"
+name = "aos-skills"
+source = "capsules/aos-skills.capsule"
 version = "0.2.0"
 
 [[capsule]]
-name = "astrid-capsule-agents"
-source = "capsules/astrid-capsule-agents.capsule"
+name = "aos-agents"
+source = "capsules/aos-agents.capsule"
 version = "0.2.0"
 env = { cwd_dir = ".aos" }
 
 [[capsule]]
-name = "astrid-capsule-memory"
-source = "capsules/astrid-capsule-memory.capsule"
+name = "aos-memory"
+source = "capsules/aos-memory.capsule"
 version = "0.2.0"
 env = { cwd_dir = ".aos" }

--- a/install.sh
+++ b/install.sh
@@ -782,7 +782,7 @@ for file in bin/aos libexec/install.sh runtime/bin/astrid runtime/bin/astrid-dae
 done
 [ -d "$bundle/capsules" ] || { echo "release archive has no capsule directory" >&2; exit 1; }
 if ! awk '
-  !/^astrid-capsule-[a-z0-9-]+\.capsule$/ { invalid = 1 }
+  !/^aos-[a-z0-9-]+\.capsule$/ { invalid = 1 }
   seen[$0]++ { duplicate = 1 }
   END { exit invalid || duplicate || NR == 0 }
 ' "$bundle/capsule-assets.txt"; then

--- a/release/community-capsules.txt
+++ b/release/community-capsules.txt
@@ -1,7 +1,7 @@
 # Community Edition capsule release allowlist.
 #
 # Keep this in distro order. Published artifact identities come from each
-# capsule's Cargo.toml/Capsule.toml and remain astrid-capsule-*.
+# capsule's Cargo.toml/Capsule.toml and remain aos-*.
 capsule-cli
 capsule-registry
 capsule-openai-compat

--- a/release/runtime-compatibility.toml
+++ b/release/runtime-compatibility.toml
@@ -8,14 +8,14 @@ version = "2026.1.0"
 repository = "astrid-runtime/astrid"
 release-ready = true
 upgrade-self-heal-ready = true
-version = "0.10.0"
-tag = "v0.10.0"
-version-requirement = "=0.10.0"
-release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v0.10.0"
+version = "0.10.1"
+tag = "v0.10.1"
+version-requirement = "=0.10.1"
+release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v0.10.1"
 release-metadata-available = true
-source-commit = "7d3f0c2e26254e4ea78c07e4a78cdb36e6e56ceb"
-release-metadata-asset = "astrid-0.10.0-release.toml"
-release-metadata-blake3 = "94989ed2a385b274b118a8b1b92aca751e2bcdb9b0e1c285dcd3c1b0145f3833"
+source-commit = "4771bab3c33d1bce53186e40d01cf014e2dce666"
+release-metadata-asset = "astrid-0.10.1-release.toml"
+release-metadata-blake3 = "58749c2f256e78183b68040fbb8f49e8dea8810f03c19efc6d3aff2d29f6425c"
 
 [contracts]
 repository = "astrid-runtime/wit"

--- a/scripts/capsule_release.py
+++ b/scripts/capsule_release.py
@@ -106,12 +106,12 @@ def source_contract() -> list[CapsuleSpec]:
                 f"{member}: Cargo package {cargo_name} {cargo_version} does not match "
                 f"Capsule package {manifest_name} {manifest_version}"
             )
-        if not cargo_name.startswith("astrid-capsule-"):
-            raise ContractError(f"{member}: published package identity must remain astrid-capsule-*")
-        expected_name = f"astrid-{directory}"
+        if not cargo_name.startswith("aos-"):
+            raise ContractError(f"{member}: published package identity must use aos-*")
+        expected_name = f"aos-{directory.removeprefix('capsule-')}"
         if cargo_name != expected_name:
             raise ContractError(
-                f"{member}: published package identity must remain {expected_name}, got {cargo_name}"
+                f"{member}: published package identity must be {expected_name}, got {cargo_name}"
             )
 
         component_entries = manifest.get("component")

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -95,7 +95,7 @@ done
 
 python3 "$repo_root/scripts/capsule_release.py" --print-assets > "$work/$root/capsule-assets.txt"
 while IFS= read -r capsule; do
-  [[ "$capsule" =~ ^astrid-capsule-[a-z0-9-]+\.capsule$ ]]
+  [[ "$capsule" =~ ^aos-[a-z0-9-]+\.capsule$ ]]
   install -m 0644 "$capsule_artifacts/$capsule" "$work/$root/capsules/$capsule"
 done < "$work/$root/capsule-assets.txt"
 python3 "$repo_root/scripts/capsule_release.py" --artifacts "$work/$root/capsules"

--- a/scripts/test-clean-home-init.sh
+++ b/scripts/test-clean-home-init.sh
@@ -116,7 +116,7 @@ run_aos doctor
 cp "$lock" "$work/distro.lock.before"
 cp "$profile" "$work/default.toml.before"
 pid_file="$aos_home/runtime/run/system.pid"
-cli_meta="$aos_home/runtime/home/default/.local/capsules/astrid-capsule-cli/meta.json"
+cli_meta="$aos_home/runtime/home/default/.local/capsules/aos-cli/meta.json"
 [[ -f "$pid_file" && ! -L "$pid_file" ]]
 [[ -f "$cli_meta" && ! -L "$cli_meta" ]]
 cp "$pid_file" "$work/system.pid.before"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -447,10 +447,10 @@ if PATH="$fake_bin:$PATH" HOME="$work/mutually-exclusive-home" AOS_TEST_FIXTURE=
 fi
 test ! -e "$work/mutually-exclusive-home/.aos"
 
-printf 'tampered capsule\n' > "$release_dir/capsules/astrid-capsule-cli.capsule"
+printf 'tampered capsule\n' > "$release_dir/capsules/aos-cli.capsule"
 PATH="$fake_bin:$PATH" HOME="$work/home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
-cmp "$work/capsules/astrid-capsule-cli.capsule" "$release_dir/capsules/astrid-capsule-cli.capsule"
+cmp "$work/capsules/aos-cli.capsule" "$release_dir/capsules/aos-cli.capsule"
 
 cat > "$work/home/.aos/bin/aos" <<'EOF'
 #!/bin/sh

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -69,7 +69,7 @@ tar -tzf "$archive" > "$work/files"
 grep -q '/bin/aos$' "$work/files"
 grep -q '/libexec/install.sh$' "$work/files"
 grep -q '/runtime/bin/astrid-daemon$' "$work/files"
-test "$(grep -c '/capsules/astrid-capsule-.*\.capsule$' "$work/files")" -eq 18
+test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 18
 grep -q '/capsule-assets.txt$' "$work/files"
 grep -q '/Distro.toml$' "$work/files"
 grep -q '/release-manifest.json$' "$work/files"
@@ -77,7 +77,7 @@ grep -q '/release-manifest.json$' "$work/files"
 tar -xzf "$archive" -C "$work"
 manifest=$(find "$work" -path '*/release-manifest.json' -print -quit)
 bundle_root=$(dirname "$manifest")
-test "$(grep -c '^source = "capsules/astrid-capsule-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 18
+test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 18
 if grep -F '@unicity-aos/capsule-' "$bundle_root/Distro.toml" >/dev/null; then
   echo "release archive retained a legacy capsule repository source" >&2
   exit 1
@@ -158,7 +158,7 @@ if bash "$repo_root/scripts/package-release.sh" \
   exit 1
 fi
 
-rm "$work/capsules/astrid-capsule-cli.capsule"
+rm "$work/capsules/aos-cli.capsule"
 if bash "$repo_root/scripts/package-release.sh" \
   "$target" \
   "$work/aos" \

--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -87,7 +87,7 @@ class CapsuleReleaseTests(unittest.TestCase):
     def test_source_contract_has_exact_community_set(self) -> None:
         self.assertEqual(len(self.specs), 18)
         self.assertEqual(len({spec.asset for spec in self.specs}), 18)
-        self.assertNotIn("astrid-capsule-telegram.capsule", {spec.asset for spec in self.specs})
+        self.assertNotIn("aos-telegram.capsule", {spec.asset for spec in self.specs})
         distro = Path(__file__).resolve().parent.parent / "distros/community/unicity-ce/Distro.toml"
         text = distro.read_text(encoding="utf-8")
         self.assertNotIn("@unicity-aos/", text)


### PR DESCRIPTION
## Summary

Correct the Unicity CE release identity boundary before the first public release.

## Changes

- rename every CE capsule package and component from `astrid-capsule-*` to `aos-*`
- make the distro manifest, installer, bootstrapper, tests, and release tooling use the same identities
- require the release inventory to contain exactly the 18 supported `aos-*` capsules
- retain historical standalone-runtime names only inside explicit migration fixtures
- pin the product to Astrid Runtime 0.10.1 and its authenticated immutable release metadata

## Verification

- all 18 capsule artifacts build with matching `aos-*` package and `aos_*` component identities
- release contract validation and 64 release-tool tests pass
- bootstrap library, binary, and CLI-boundary suites pass
- package/install release tests pass
- fresh `.aos` home installs, grants, loads, reinitializes, and stops all 18 capsules without creating `.astrid`
- authenticated loopback HTTP smoke returns 200 from `aos-session` for the session-list endpoint
