### PR TITLE
chore(release): prepare Unicity AOS 2026.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2026.1.0] - Unreleased
+## [2026.1.1] - Unreleased
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicity-aos-bootstrap"
-version = "2026.1.0"
+version = "2026.1.1"
 dependencies = [
  "astrid-core",
  "astrid-uplink",

--- a/crates/unicity-aos-bootstrap/Cargo.toml
+++ b/crates/unicity-aos-bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicity-aos-bootstrap"
-version = "2026.1.0"
+version = "2026.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Product-owned runtime layout and launcher for Unicity AOS."

--- a/crates/unicity-aos-bootstrap/src/migration.rs
+++ b/crates/unicity-aos-bootstrap/src/migration.rs
@@ -1591,12 +1591,12 @@ mod tests {
         write(
             &source,
             "home/bob/.config/distro.lock",
-            b"[distro]\nid = \"aos-ce\"\nversion = \"2026.1.0\"\n",
+            b"[distro]\nid = \"aos-ce\"\nversion = \"2026.1.1\"\n",
         );
         write(
             &source,
             "home/carol/.config/distro.lock",
-            b"[distro]\nid = \"unicity-ce\"\nversion = \"2026.1.0\"\n",
+            b"[distro]\nid = \"unicity-ce\"\nversion = \"2026.1.1\"\n",
         );
         write(
             &source,
@@ -1989,13 +1989,13 @@ mod tests {
         write(&source, "keys/runtime.key", b"runtime-key");
         install_product_runtime(&product);
         let astralis = b"[distro]\nid = \"astralis\"\nversion = \"0.2.2\"\n";
-        let aos_ce = b"[distro]\nid = \"aos-ce\"\nversion = \"2026.1.0\"\n";
+        let aos_ce = b"[distro]\nid = \"aos-ce\"\nversion = \"2026.1.1\"\n";
         write(&source, "home/alice/.config/distro.lock", astralis);
         write(&source, "home/bob/.config/distro.lock", aos_ce);
         write(
             &source,
             "home/carol/.config/distro.lock",
-            b"[distro]\nid = \"unicity-ce\"\nversion = \"2026.1.0\"\n",
+            b"[distro]\nid = \"unicity-ce\"\nversion = \"2026.1.1\"\n",
         );
         write(&source, "home/dan/.config/distro.lock", b"not toml");
 
@@ -2011,7 +2011,7 @@ mod tests {
                 super::LegacyDistro {
                     principal: "bob".into(),
                     id: "aos-ce".into(),
-                    version: "2026.1.0".into()
+                    version: "2026.1.1".into()
                 },
             ]
         );

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -680,7 +680,7 @@ exit 23
     for args in [
         vec!["update", "--version", "2026.01.0"],
         vec!["update", "--version", "2025.9.0"],
-        vec!["update", "--channel", "dev", "--version", "2026.1.0"],
+        vec!["update", "--channel", "dev", "--version", "2026.1.1"],
     ] {
         assert!(
             !fixture

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -3,8 +3,8 @@ schema-version = 1
 [distro]
 id = "unicity-ce"
 name = "Unicity CE"
-pretty-name = "Unicity CE 2026.1.0 (Genesis)"
-version = "2026.1.0"
+pretty-name = "Unicity CE 2026.1.1 (Genesis)"
+version = "2026.1.1"
 codename = "genesis"
 release-date = "2026-07-17"
 description = "The complete Unicity AOS agent operating system experience"

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -11,8 +11,8 @@ curl --proto '=https' --tlsv1.2 -fsSL https://aos.unicity.ai/install.sh | sh -s 
 An exact release is a separate, mutually exclusive operation:
 
 ```sh
-sh install.sh --version 2026.1.0
-sh install.sh --version 2026.1.0-nightly.20260717.g<40-character-source-commit>
+sh install.sh --version 2026.1.1
+sh install.sh --version 2026.1.1-nightly.20260717.g<40-character-source-commit>
 ```
 
 An exact nightly pin is deliberate and bypasses the moving channel pointer. It

--- a/release/runtime-compatibility.toml
+++ b/release/runtime-compatibility.toml
@@ -2,7 +2,7 @@ schema-version = 1
 
 [product]
 name = "Unicity AOS Community Edition"
-version = "2026.1.0"
+version = "2026.1.1"
 
 [runtime]
 repository = "astrid-runtime/astrid"

--- a/scripts/create-astrid-094-fixture.py
+++ b/scripts/create-astrid-094-fixture.py
@@ -52,8 +52,8 @@ def create(root: Path) -> None:
 
     distro_locks = {
         "alice": ("astralis", "0.2.2"),
-        "bob": ("aos-ce", "2026.1.0"),
-        "carol": ("unicity-ce", "2026.1.0"),
+        "bob": ("aos-ce", "2026.1.1"),
+        "carol": ("unicity-ce", "2026.1.1"),
         "dan": ("other", "1.0.0"),
     }
     for principal, (identifier, version) in distro_locks.items():

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -52,7 +52,7 @@ fi
 cat > "$work/aos" <<'EOF'
 #!/bin/sh
 if [ "${1:-}" = --version ]; then
-  echo 'Unicity AOS 2026.1.0'
+  echo 'Unicity AOS 2026.1.1'
   exit 0
 fi
 exit 0
@@ -85,7 +85,7 @@ bash "$repo_root/scripts/package-release.sh" \
   0000000000000000000000000000000000000000000000000000000000000000 \
   "$work/capsules" \
   "$fixture" >/dev/null
-asset="$fixture/unicity-aos-2026.1.0-x86_64-unknown-linux-gnu.tar.gz"
+asset="$fixture/unicity-aos-2026.1.1-x86_64-unknown-linux-gnu.tar.gz"
 bundle="$asset.sigstore.json"
 signed_asset="$fixture/signed-asset.tar.gz"
 good_bundle="$fixture/valid.sigstore.json"
@@ -96,16 +96,16 @@ cp "$good_bundle" "$bundle"
 asset_sha256=$(shasum -a 256 "$asset" | awk '{print $1}')
 asset_blake3=$(b3sum "$asset" | awk '{print $1}')
 asset_size=$(wc -c < "$asset" | tr -d ' ')
-release_metadata="$fixture/unicity-aos-2026.1.0-release.toml"
+release_metadata="$fixture/unicity-aos-2026.1.1-release.toml"
 cat > "$release_metadata" <<EOF
 schema-version = 1
 kind = "aos-release"
 product = "unicity-aos-ce"
-version = "2026.1.0"
-tag = "2026.1.0"
+version = "2026.1.1"
+tag = "2026.1.1"
 source-commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 published-at = "2026-07-16T10:00:00Z"
-release-workflow-identity = "https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/2026.1.0"
+release-workflow-identity = "https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/2026.1.1"
 
 [runtime]
 repository = "astrid-runtime/astrid"
@@ -128,7 +128,7 @@ release-ready = true
 upgrade-self-heal-ready = true
 EOF
 for metadata_target in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu; do
-  metadata_asset="unicity-aos-2026.1.0-${metadata_target}.tar.gz"
+  metadata_asset="unicity-aos-2026.1.1-${metadata_target}.tar.gz"
   cat >> "$release_metadata" <<EOF
 
 [targets.${metadata_target}]
@@ -233,7 +233,7 @@ chmod 755 "$fake_bin/uname" "$fake_bin/date" "$fake_bin/curl" "$fake_bin/cosign"
   "$fake_bin/sha256sum" "$fixture/cosign-linux-amd64"
 
 if PATH="$fake_bin:$PATH" HOME="$work/impossible-nightly-home" AOS_TEST_FIXTURE="$fixture" \
-  sh "$repo_root/install.sh" --version "2026.1.0-nightly.20260230.g$(printf '%040d' 0)" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  sh "$repo_root/install.sh" --version "2026.1.1-nightly.20260230.g$(printf '%040d' 0)" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer accepted a nightly version with an impossible date" >&2
   exit 1
 fi
@@ -242,12 +242,12 @@ test ! -e "$work/impossible-nightly-home/.aos"
 PATH="$fake_bin:$PATH" \
 HOME="$work/home" \
 AOS_TEST_FIXTURE="$fixture" \
-AOS_VERSION=2026.1.0 \
+AOS_VERSION=2026.1.1 \
 sh "$repo_root/install.sh" --yes --no-migrate-prompt
 
 test -x "$work/home/.aos/bin/aos"
 test -x "$work/home/.aos/runtime/bin/astrid-daemon"
-release_dir="$work/home/.aos/releases/2026.1.0"
+release_dir="$work/home/.aos/releases/2026.1.1"
 test -f "$release_dir/release-manifest.json"
 test -f "$release_dir/Distro.toml"
 test -f "$release_dir/capsule-assets.txt"
@@ -255,7 +255,7 @@ test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | t
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"
-test "$("$work/home/.aos/bin/aos" --version)" = 'Unicity AOS 2026.1.0'
+test "$("$work/home/.aos/bin/aos" --version)" = 'Unicity AOS 2026.1.1'
 test -f "$work/home/.aos/libexec/install.sh"
 test "$(stat -c '%a' "$work/home/.aos/libexec/install.sh" 2>/dev/null || stat -f '%Lp' "$work/home/.aos/libexec/install.sh")" = 600
 test "$(cat "$work/home/.astrid/sentinel")" = 'standalone-runtime-state'
@@ -288,12 +288,12 @@ test -f "$accepted_bundle"
 test "$(awk '$1 == "generation" { print $3 }' "$accepted_channel")" = 2
 grep -Fx 'https://github.com/unicity-aos/aos-ce/.github/workflows/promote-channel.yml@refs/heads/main' \
   "$fixture/cosign-identities" >/dev/null
-grep -Fx 'https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/2026.1.0' \
+grep -Fx 'https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/2026.1.1' \
   "$fixture/cosign-identities" >/dev/null
 
 cp "$fixture/channel-good.toml" "$fixture/channel.toml"
-nightly_version="2026.1.0-nightly.20260717.gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-sed -i.bak "s/version = \"2026.1.0\"/version = \"$nightly_version\"/" "$fixture/channel.toml"
+nightly_version="2026.1.1-nightly.20260717.gaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+sed -i.bak "s/version = \"2026.1.1\"/version = \"$nightly_version\"/" "$fixture/channel.toml"
 rm "$fixture/channel.toml.bak"
 if PATH="$fake_bin:$PATH" HOME="$work/nightly-on-stable-home" AOS_TEST_FIXTURE="$fixture" \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
@@ -350,7 +350,7 @@ cp "$fixture/release-good.toml" "$release_metadata"
 sed -i.bak 's/release-ready = true/release-ready = "true"/' "$release_metadata"
 rm "$release_metadata.bak"
 if PATH="$fake_bin:$PATH" HOME="$work/quoted-gate-home" AOS_TEST_FIXTURE="$fixture" \
-  sh "$repo_root/install.sh" --version 2026.1.0 --yes --no-migrate-prompt >/dev/null 2>&1; then
+  sh "$repo_root/install.sh" --version 2026.1.1 --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer accepted a quoted TOML readiness gate" >&2
   exit 1
 fi
@@ -440,7 +440,7 @@ fi
 test ! -e "$work/unavailable-channel-home/.aos"
 
 if PATH="$fake_bin:$PATH" HOME="$work/mutually-exclusive-home" AOS_TEST_FIXTURE="$fixture" \
-  sh "$repo_root/install.sh" --channel dev --version 2026.1.0 --yes --no-migrate-prompt \
+  sh "$repo_root/install.sh" --channel dev --version 2026.1.1 --yes --no-migrate-prompt \
   >/dev/null 2>&1; then
   echo "installer accepted mutually exclusive channel and version selectors" >&2
   exit 1
@@ -448,7 +448,7 @@ fi
 test ! -e "$work/mutually-exclusive-home/.aos"
 
 printf 'tampered capsule\n' > "$release_dir/capsules/aos-cli.capsule"
-PATH="$fake_bin:$PATH" HOME="$work/home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+PATH="$fake_bin:$PATH" HOME="$work/home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.1 \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
 cmp "$work/capsules/aos-cli.capsule" "$release_dir/capsules/aos-cli.capsule"
 
@@ -462,7 +462,7 @@ echo existing-unicity-aos
 EOF
 chmod 755 "$work/home/.aos/bin/aos"
 cp "$work/home/.aos/bin/aos" "$work/aos-before-unattended-upgrade"
-if PATH="$fake_bin:$PATH" HOME="$work/home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+if PATH="$fake_bin:$PATH" HOME="$work/home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.1 \
   AOS_STOP_MARKER="$work/unattended-stop-called" \
   sh "$repo_root/install.sh" --no-migrate-prompt </dev/null >"$work/unattended-upgrade.log" 2>&1; then
   echo "installer replaced an existing installation without confirmation" >&2
@@ -474,7 +474,7 @@ grep -F 'rerun with --yes to replace it without a prompt' "$work/unattended-upgr
 
 rm -f "$fixture/cosign-called"
 if PATH="$fake_bin:$PATH" HOME="$work/bad-verifier-home" AOS_TEST_FIXTURE="$fixture" \
-  AOS_TEST_BAD_COSIGN_DIGEST=1 AOS_VERSION=2026.1.0 \
+  AOS_TEST_BAD_COSIGN_DIGEST=1 AOS_VERSION=2026.1.1 \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer accepted a Sigstore verifier with the wrong digest" >&2
   exit 1
@@ -483,7 +483,7 @@ test ! -e "$fixture/cosign-called"
 test ! -e "$work/bad-verifier-home/.aos"
 
 printf 'invalid Sigstore fixture\n' > "$bundle"
-if PATH="$fake_bin:$PATH" HOME="$work/bad-bundle-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+if PATH="$fake_bin:$PATH" HOME="$work/bad-bundle-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.1 \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer accepted an invalid Sigstore bundle" >&2
   exit 1
@@ -492,7 +492,7 @@ test ! -e "$work/bad-bundle-home/.aos"
 cp "$good_bundle" "$bundle"
 
 mv "$bundle" "$work/missing-bundle"
-if PATH="$fake_bin:$PATH" HOME="$work/missing-bundle-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+if PATH="$fake_bin:$PATH" HOME="$work/missing-bundle-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.1 \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer accepted a release with no Sigstore bundle" >&2
   exit 1
@@ -501,7 +501,7 @@ test ! -e "$work/missing-bundle-home/.aos"
 mv "$work/missing-bundle" "$bundle"
 
 printf 'modified after signing\n' >> "$asset"
-if PATH="$fake_bin:$PATH" HOME="$work/modified-asset-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+if PATH="$fake_bin:$PATH" HOME="$work/modified-asset-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.1 \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer accepted release bytes that did not match the Sigstore bundle" >&2
   exit 1
@@ -518,7 +518,7 @@ set -eu
 EOF
 chmod 755 "$work/symlink-target"
 ln -s "$work/symlink-target" "$symlink_home/.aos/bin/aos"
-if PATH="$fake_bin:$PATH" HOME="$symlink_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+if PATH="$fake_bin:$PATH" HOME="$symlink_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.1 \
   AOS_SYMLINK_MARKER="$work/symlink-executed" \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer replaced a symlinked destination" >&2
@@ -534,7 +534,7 @@ mkdir -p "$custom_bin_home" "$custom_bin_target"
 cp "$work/symlink-target" "$custom_bin_target/aos"
 ln -s "$custom_bin_target" "$custom_bin_link"
 if PATH="$fake_bin:$PATH" HOME="$custom_bin_home" AOS_BIN_DIR="$custom_bin_link" \
-  AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+  AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.1 \
   AOS_SYMLINK_MARKER="$work/custom-bin-symlink-executed" \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >"$work/custom-bin-symlink.log" 2>&1; then
   echo "installer accepted a symlinked custom binary directory" >&2
@@ -547,7 +547,7 @@ managed_symlink_home="$work/managed-symlink-home"
 mkdir -p "$managed_symlink_home" "$work/managed-symlink-target/bin"
 ln -s "$work/managed-symlink-target" "$managed_symlink_home/.aos"
 ln -s "$work/symlink-target" "$work/managed-symlink-target/bin/aos"
-if PATH="$fake_bin:$PATH" HOME="$managed_symlink_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+if PATH="$fake_bin:$PATH" HOME="$managed_symlink_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.1 \
   AOS_SYMLINK_MARKER="$work/managed-symlink-executed" \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer accepted a symlinked managed installation root" >&2
@@ -557,7 +557,7 @@ test ! -e "$work/managed-symlink-executed"
 
 directory_home="$work/directory-destination-home"
 mkdir -p "$directory_home/.aos/bin/aos"
-if PATH="$fake_bin:$PATH" HOME="$directory_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+if PATH="$fake_bin:$PATH" HOME="$directory_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.1 \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer replaced a directory destination" >&2
   exit 1
@@ -592,7 +592,7 @@ real_mv=$(command -v mv)
 if PATH="$fail_bin:$fake_bin:$PATH" \
   HOME="$work/home" \
   AOS_TEST_FIXTURE="$fixture" \
-  AOS_VERSION=2026.1.0 \
+  AOS_VERSION=2026.1.1 \
   REAL_MV="$real_mv" \
   MV_FAILED="$work/mv-failed" \
   MV_FAIL_DESTINATION="$release_dir" \
@@ -629,24 +629,24 @@ bash "$repo_root/scripts/package-release.sh" \
   "$work/capsules" \
   "$fixture" >/dev/null
 cp "$asset" "$signed_asset"
-if PATH="$fake_bin:$PATH" HOME="$work/mismatch-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+if PATH="$fake_bin:$PATH" HOME="$work/mismatch-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.1 \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer accepted a bundle whose binary version did not match the requested release" >&2
   exit 1
 fi
 test ! -e "$work/mismatch-home/.aos"
 
-unsafe_root="$work/unsafe-bundle/unicity-aos-2026.1.0-x86_64-unknown-linux-gnu"
+unsafe_root="$work/unsafe-bundle/unicity-aos-2026.1.1-x86_64-unknown-linux-gnu"
 mkdir -p "$unsafe_root/bin" "$unsafe_root/runtime/bin"
 ln -s "$work/aos" "$unsafe_root/bin/aos"
 for binary in astrid astrid-daemon astrid-build astrid-emit; do
   cp "$runtime_root/$binary" "$unsafe_root/runtime/bin/$binary"
 done
 printf '{}\n' > "$unsafe_root/release-manifest.json"
-COPYFILE_DISABLE=1 tar -czf "$fixture/unicity-aos-2026.1.0-x86_64-unknown-linux-gnu.tar.gz" \
+COPYFILE_DISABLE=1 tar -czf "$fixture/unicity-aos-2026.1.1-x86_64-unknown-linux-gnu.tar.gz" \
   -C "$work/unsafe-bundle" "$(basename "$unsafe_root")"
 cp "$asset" "$signed_asset"
-if PATH="$fake_bin:$PATH" HOME="$work/unsafe-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.0 \
+if PATH="$fake_bin:$PATH" HOME="$work/unsafe-home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.1.1 \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer accepted a symlink in the release archive" >&2
   exit 1

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -128,7 +128,7 @@ snapshot_imported_directories() {
 snapshot_shipped_assets() {
   local home=$1
   local output=$2
-  local release=$home/releases/2026.1.0
+  local release=$home/releases/2026.1.1
   : > "$output"
   printf '%s|bin/aos\n' "$(b3sum -- "$home/bin/aos" | awk '{print $1}')" >> "$output"
   for name in astrid astrid-daemon astrid-build astrid-emit; do
@@ -137,7 +137,7 @@ snapshot_shipped_assets() {
       "$name" >> "$output"
   done
   while IFS= read -r capsule; do
-    printf '%s|releases/2026.1.0/capsules/%s\n' \
+    printf '%s|releases/2026.1.1/capsules/%s\n' \
       "$(b3sum -- "$release/capsules/$capsule" | awk '{print $1}')" \
       "$capsule" >> "$output"
   done < "$release/capsule-assets.txt"
@@ -162,7 +162,7 @@ python3 "$repo_root/scripts/create-astrid-094-fixture.py" "$legacy"
 
 cargo build --locked -p unicity-aos-bootstrap --bin aos
 product_binary=$repo_root/target/debug/aos
-test "$($product_binary --version)" = 'Unicity AOS 2026.1.0'
+test "$($product_binary --version)" = 'Unicity AOS 2026.1.1'
 
 PYTHONPATH="$repo_root/scripts" python3 - "$capsules" <<'PY'
 import pathlib
@@ -231,7 +231,7 @@ bash "$repo_root/scripts/package-release.sh" \
   "$capsules" \
   "$fixture" >/dev/null
 
-asset=$fixture/unicity-aos-2026.1.0-$target.tar.gz
+asset=$fixture/unicity-aos-2026.1.1-$target.tar.gz
 bundle=$asset.sigstore.json
 cp "$asset" "$fixture/signed-asset.tar.gz"
 printf 'valid Sigstore fixture\n' > "$fixture/valid.sigstore.json"
@@ -239,16 +239,16 @@ cp "$fixture/valid.sigstore.json" "$bundle"
 asset_sha256=$(shasum -a 256 "$asset" | awk '{print $1}')
 asset_blake3=$(b3sum "$asset" | awk '{print $1}')
 asset_size=$(wc -c < "$asset" | tr -d ' ')
-release_metadata=$fixture/unicity-aos-2026.1.0-release.toml
+release_metadata=$fixture/unicity-aos-2026.1.1-release.toml
 cat > "$release_metadata" <<EOF
 schema-version = 1
 kind = "aos-release"
 product = "unicity-aos-ce"
-version = "2026.1.0"
-tag = "2026.1.0"
+version = "2026.1.1"
+tag = "2026.1.1"
 source-commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 published-at = "2026-07-16T10:00:00Z"
-release-workflow-identity = "https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/2026.1.0"
+release-workflow-identity = "https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/2026.1.1"
 
 [runtime]
 repository = "astrid-runtime/astrid"
@@ -271,7 +271,7 @@ release-ready = false
 upgrade-self-heal-ready = false
 EOF
 for metadata_target in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu; do
-  metadata_asset="unicity-aos-2026.1.0-${metadata_target}.tar.gz"
+  metadata_asset="unicity-aos-2026.1.1-${metadata_target}.tar.gz"
   cat >> "$release_metadata" <<EOF
 
 [targets.${metadata_target}]
@@ -342,7 +342,7 @@ install_candidate() {
   PATH="$fake_bin:$PATH" \
   HOME="$home" \
   AOS_TEST_FIXTURE="$fixture" \
-  AOS_VERSION=2026.1.0 \
+  AOS_VERSION=2026.1.1 \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
 }
 
@@ -419,16 +419,16 @@ for name in aos astrid astrid-daemon astrid-build astrid-emit; do
   chmod 755 "$destination"
 done
 while IFS= read -r capsule; do
-  printf 'tampered capsule\n' > "$aos_home/releases/2026.1.0/capsules/$capsule"
-done < "$aos_home/releases/2026.1.0/capsule-assets.txt"
+  printf 'tampered capsule\n' > "$aos_home/releases/2026.1.1/capsules/$capsule"
+done < "$aos_home/releases/2026.1.1/capsule-assets.txt"
 chmod 755 \
   "$aos_home" \
   "$aos_home/bin" \
   "$aos_home/runtime" \
   "$aos_home/runtime/bin" \
   "$aos_home/releases" \
-  "$aos_home/releases/2026.1.0" \
-  "$aos_home/releases/2026.1.0/capsules"
+  "$aos_home/releases/2026.1.1" \
+  "$aos_home/releases/2026.1.1/capsules"
 
 install_candidate
 assert_imported_activation_layout "$aos_home/runtime"
@@ -440,8 +440,8 @@ for directory in \
   "$aos_home/runtime" \
   "$aos_home/runtime/bin" \
   "$aos_home/releases" \
-  "$aos_home/releases/2026.1.0" \
-  "$aos_home/releases/2026.1.0/capsules"; do
+  "$aos_home/releases/2026.1.1" \
+  "$aos_home/releases/2026.1.1/capsules"; do
   test "$(mode_of "$directory")" = 700
 done
 

--- a/scripts/test_nightly_version.py
+++ b/scripts/test_nightly_version.py
@@ -9,9 +9,9 @@ import unittest
 import nightly_version
 
 
-BASE = "2026.1.0"
+BASE = "2026.1.1"
 COMMIT = "0123456789abcdef0123456789abcdef01234567"
-NIGHTLY = f"2026.1.0-nightly.20260717.g{COMMIT}"
+NIGHTLY = f"2026.1.1-nightly.20260717.g{COMMIT}"
 
 
 class NightlyVersionTests(unittest.TestCase):
@@ -23,20 +23,20 @@ class NightlyVersionTests(unittest.TestCase):
         (self.root / "release").mkdir()
         (self.root / "distros/community/unicity-ce").mkdir(parents=True)
         (self.root / "crates/unicity-aos-bootstrap/Cargo.toml").write_text(
-            '[package]\nname = "unicity-aos-bootstrap"\nversion = "2026.1.0"\n',
+            '[package]\nname = "unicity-aos-bootstrap"\nversion = "2026.1.1"\n',
             encoding="utf-8",
         )
         (self.root / "release/runtime-compatibility.toml").write_text(
-            '[product]\nname = "Unicity AOS Community Edition"\nversion = "2026.1.0"\n\n'
+            '[product]\nname = "Unicity AOS Community Edition"\nversion = "2026.1.1"\n\n'
             '[runtime]\nversion = "0.9.4"\nrelease-ready = false\nupgrade-self-heal-ready = false\n',
             encoding="utf-8",
         )
         (self.root / "distros/community/unicity-ce/Distro.toml").write_text(
-            '[distro]\npretty-name = "Unicity CE 2026.1.0 (Genesis)"\nversion = "2026.1.0"\nrelease-date = "2026-07-10"\n',
+            '[distro]\npretty-name = "Unicity CE 2026.1.1 (Genesis)"\nversion = "2026.1.1"\nrelease-date = "2026-07-10"\n',
             encoding="utf-8",
         )
         (self.root / "Cargo.lock").write_text(
-            'version = 4\n\n[[package]]\nname = "unicity-aos-bootstrap"\nversion = "2026.1.0"\n',
+            'version = 4\n\n[[package]]\nname = "unicity-aos-bootstrap"\nversion = "2026.1.1"\n',
             encoding="utf-8",
         )
 
@@ -56,7 +56,7 @@ class NightlyVersionTests(unittest.TestCase):
         compatibility = (self.root / "release/runtime-compatibility.toml").read_text()
         self.assertEqual(
             compatibility,
-            compatibility_before.replace('version = "2026.1.0"', f'version = "{NIGHTLY}"', 1),
+            compatibility_before.replace('version = "2026.1.1"', f'version = "{NIGHTLY}"', 1),
         )
         self.assertIn('release-ready = false', compatibility)
         self.assertIn('upgrade-self-heal-ready = false', compatibility)
@@ -72,13 +72,13 @@ class NightlyVersionTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "source commit"):
             nightly_version.derive(BASE, "20260717", "A" * 40)
         with self.assertRaisesRegex(ValueError, "nightly version"):
-            nightly_version.stage(self.root, "2026.1.0-rc.1")
+            nightly_version.stage(self.root, "2026.1.1-rc.1")
 
     def test_rejects_wrong_base_and_ambiguous_files(self) -> None:
         with self.assertRaisesRegex(ValueError, "derive from"):
             nightly_version.stage(self.root, f"2026.2.0-nightly.20260717.g{COMMIT}")
         path = self.root / "release/runtime-compatibility.toml"
-        path.write_text(path.read_text() + '\n[product]\nversion = "2026.1.0"\n', encoding="utf-8")
+        path.write_text(path.read_text() + '\n[product]\nversion = "2026.1.1"\n', encoding="utf-8")
         with self.assertRaisesRegex(ValueError, "exactly once"):
             nightly_version.stage(self.root, NIGHTLY)
 

--- a/scripts/test_release_metadata.py
+++ b/scripts/test_release_metadata.py
@@ -21,7 +21,7 @@ SPEC.loader.exec_module(METADATA)
 
 
 def release_fixture() -> dict[str, object]:
-    version = "2026.1.0"
+    version = "2026.1.1"
     targets = {}
     for index, target in enumerate(METADATA.TARGETS, 1):
         asset = f"unicity-aos-{version}-{target}.tar.gz"
@@ -42,7 +42,7 @@ def release_fixture() -> dict[str, object]:
         "published-at": "2026-07-16T10:00:00Z",
         "release-workflow-identity": (
             "https://github.com/unicity-aos/aos-ce/.github/workflows/"
-            "release.yml@refs/tags/2026.1.0"
+            "release.yml@refs/tags/2026.1.1"
         ),
         "runtime": {
             "repository": "astrid-runtime/astrid",
@@ -74,7 +74,7 @@ def release_fixture() -> dict[str, object]:
 def nightly_release_fixture() -> dict[str, object]:
     fixture = release_fixture()
     old = fixture["version"]
-    version = f"2026.1.0-nightly.20260717.g{'a' * 40}"
+    version = f"2026.1.1-nightly.20260717.g{'a' * 40}"
     fixture["version"] = version
     fixture["tag"] = version
     fixture["release-workflow-identity"] = (
@@ -118,10 +118,10 @@ def channel_fixture() -> dict[str, object]:
         "expires-at": "2026-08-15T10:00:00Z",
         "release": {
             "repository": "unicity-aos/aos-ce",
-            "version": "2026.1.0",
-            "tag": "2026.1.0",
+            "version": "2026.1.1",
+            "tag": "2026.1.1",
             "source-commit": "a" * 40,
-            "metadata-asset": "unicity-aos-2026.1.0-release.toml",
+            "metadata-asset": "unicity-aos-2026.1.1-release.toml",
             "metadata-sha256": "d" * 64,
             "release-workflow-identity": release["release-workflow-identity"],
         },
@@ -142,7 +142,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         self.assertIsNone(METADATA.VERSION.fullmatch("2026.13.0-rc.1"))
 
     def test_release_accepts_false_staged_gates(self) -> None:
-        self.assertEqual(METADATA.validate_release(release_fixture())["version"], "2026.1.0")
+        self.assertEqual(METADATA.validate_release(release_fixture())["version"], "2026.1.1")
 
     def test_release_accepts_strict_nightly_main_identity(self) -> None:
         result = METADATA.validate_release(nightly_release_fixture())
@@ -198,7 +198,7 @@ class ReleaseMetadataTests(unittest.TestCase):
         fixture["targets"]["aarch64-apple-darwin"]["asset"] = (
             "unicity-aos-aarch64-apple-darwin.tar.gz"
         )
-        with self.assertRaisesRegex(ValueError, "must be unicity-aos-2026.1.0"):
+        with self.assertRaisesRegex(ValueError, "must be unicity-aos-2026.1.1"):
             METADATA.validate_release(fixture)
 
     def test_release_rejects_unapproved_runtime_repository(self) -> None:
@@ -368,8 +368,8 @@ class RenderTests(unittest.TestCase):
             "schema-version = 1",
             'kind = "aos-release"',
             'product = "unicity-aos-ce"',
-            'version = "2026.1.0"',
-            'tag = "2026.1.0"',
+            'version = "2026.1.1"',
+            'tag = "2026.1.1"',
             f'source-commit = "{release["source-commit"]}"',
             'published-at = "2026-07-16T10:00:00Z"',
             f'release-workflow-identity = "{release["release-workflow-identity"]}"',
@@ -424,7 +424,7 @@ class RenderTests(unittest.TestCase):
         import hashlib
 
         for target in METADATA.TARGETS:
-            asset = f"unicity-aos-2026.1.0-{target}.tar.gz"
+            asset = f"unicity-aos-2026.1.1-{target}.tar.gz"
             payload = f"fixture-{target}".encode()
             (artifacts / asset).write_bytes(payload)
             sha_lines.append(f"{hashlib.sha256(payload).hexdigest()}  {asset}")
@@ -438,8 +438,8 @@ class RenderTests(unittest.TestCase):
             "Args",
             (),
             {
-                "version": "2026.1.0",
-                "tag": "2026.1.0",
+                "version": "2026.1.1",
+                "tag": "2026.1.1",
                 "source_commit": "a" * 40,
                 "published_at": "2026-07-16T10:00:00Z",
                 "artifacts": artifacts,

--- a/scripts/test_validate_release_contract.py
+++ b/scripts/test_validate_release_contract.py
@@ -129,11 +129,11 @@ class ReleaseReadinessTests(unittest.TestCase):
             )
 
     def test_nightly_product_version_requires_a_real_date(self) -> None:
-        valid = "2026.1.0-nightly.20260717.g" + "a" * 40
+        valid = "2026.1.1-nightly.20260717.g" + "a" * 40
         VALIDATOR.validate_product_version(valid, allow_nightly=True)
         with self.assertRaisesRegex(ValueError, "invalid date"):
             VALIDATOR.validate_product_version(
-                "2026.1.0-nightly.20260230.g" + "a" * 40,
+                "2026.1.1-nightly.20260230.g" + "a" * 40,
                 allow_nightly=True,
             )
         with self.assertRaisesRegex(ValueError, "allowed calendar"):


### PR DESCRIPTION
## Summary

Move the corrected first public AOS release to `2026.1.1` because GitHub permanently retired `2026.1.0` after the withdrawn immutable release.

## Changes

- update the product, distro, lockfile, compatibility metadata, fixtures, and release examples to `2026.1.1`
- leave the already-merged capsule identity correction and Astrid Runtime 0.10.1 pin unchanged

## Verification

- release contract validation passes
- 81 release-tool tests pass
- 89 bootstrap and CLI-boundary tests pass
- release package and installer harnesses pass for `2026.1.1`
- diff validation passes
