### PR TITLE
feat: establish the AOS meta harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,8 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo metadata --locked --format-version 1 --no-deps
-      - run: cargo check --locked --workspace --exclude astrid-capsule-telegram --exclude unicity-aos-bootstrap --target wasm32-unknown-unknown
-      - run: cargo clippy --locked --workspace --exclude astrid-capsule-telegram --exclude unicity-aos-bootstrap --target wasm32-unknown-unknown -- -D warnings
+      - run: cargo check --locked --workspace --exclude aos-telegram --exclude unicity-aos-bootstrap --target wasm32-unknown-unknown
+      - run: cargo clippy --locked --workspace --exclude aos-telegram --exclude unicity-aos-bootstrap --target wasm32-unknown-unknown -- -D warnings
 
   product-native:
     name: Product native
@@ -100,7 +100,7 @@ jobs:
           toolchain: "1.95.0"
           targets: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - run: cargo test --locked --workspace --exclude astrid-capsule-telegram --exclude unicity-aos-bootstrap --target x86_64-unknown-linux-gnu
+      - run: cargo test --locked --workspace --exclude aos-telegram --exclude unicity-aos-bootstrap --target x86_64-unknown-linux-gnu
 
   telegram-wasi:
     name: Telegram WASI
@@ -112,4 +112,4 @@ jobs:
           toolchain: "1.95.0"
           targets: wasm32-wasip1
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - run: cargo check --locked -p astrid-capsule-telegram --target wasm32-wasip1
+      - run: cargo check --locked -p aos-telegram --target wasm32-wasip1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -470,7 +470,7 @@ jobs:
 
           This product release bundles Astrid Runtime ${RUNTIME_TAG}. The exact runtime release identity, WIT commit, and compatibility pins are published in \`runtime-compatibility.toml\` and in every archive's \`release-manifest.json\`.
 
-          The release also contains the 18 signed, installable capsule artifacts selected by Community Edition. Published \`astrid-capsule-*\` identities remain unchanged.
+          The release also contains the 19 signed, installable capsule artifacts selected by Community Edition. Published \`astrid-capsule-*\` identities remain unchanged.
 
           Install this exact release:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,23 @@
 - Runtime import holds the standalone daemon's existing singleton lock without
   changing the source, and interrupted unreceipted cutovers always roll back
   before recopying the current locked source.
-- A signed release path for the 18 installable `aos-*` artifacts
+- A signed release path for the 19 installable `aos-*` artifacts
   built from this source tree and selected locally by Community Edition, with
   exact source/manifest identity checks, product-archive inclusion, offline
   provisioning, archive safety validation, BLAKE3 checksums, SHA-256
   compatibility checksums, Sigstore bundles, and provenance.
 - Host-target unit-test coverage for the capsule workspace.
+- Forge in the default Community Edition distribution, including a discoverable
+  meta-harness bootstrap and skill that teach fresh agents to supervise
+  platform-scoped workers, resolve capability gaps, and quarantine generated
+  capabilities until independent verification and approval.
 - Homebrew formula updates initiated by the tap's authenticated stable-release
   poll, eliminating the cross-repository dispatch credential.
 - Strict, signed stable/dev/nightly channel and immutable release metadata
   contracts with exact workflow identities, expiry, replay-resistant generation
   state, and fail-closed direct installer resolution.
 - A native release gate that initializes a clean AOS home, verifies the exact
-  18-capsule CE lock, grants, and ready set, repeats initialization without
+  19-capsule CE lock, grants, and ready set, repeats initialization without
   changing runtime state, and proves clean daemon shutdown before publication.
 - Native `aos status` output for authenticated running state and verified
   stopped state without invoking the runtime CLI.
@@ -42,6 +46,8 @@
 
 ### Changed
 
+- Target the Telegram capsule's actual `aos-telegram` package name in CI so the
+  WASI job and target-specific workspace exclusions run as intended.
 - Parse AOS-owned commands with Clap-generated validation and help while
   preserving byte-for-byte delegation of inherited runtime commands and their
   help surfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@
 - Host-target unit-test coverage for the capsule workspace.
 - Forge in the default Community Edition distribution, including a discoverable
   bootstrap and skill that teach fresh agents to build a user-space
-  meta-harness on AOS, supervise platform-scoped workers, resolve capability
-  gaps, and quarantine generated capabilities until independent verification
-  and approval.
+  meta-harness on AOS by seeing instructions, memory, skills, harness code,
+  tools, capsules, traces, and evaluations as an improvable world. Agents reach
+  for Forge proactively when real work reveals a useful new capability, while
+  optional workers remain a use-case choice rather than a prerequisite.
 - Homebrew formula updates initiated by the tap's authenticated stable-release
   poll, eliminating the cross-repository dispatch credential.
 - Strict, signed stable/dev/nightly channel and immutable release metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@
   compatibility checksums, Sigstore bundles, and provenance.
 - Host-target unit-test coverage for the capsule workspace.
 - Forge in the default Community Edition distribution, including a discoverable
-  meta-harness bootstrap and skill that teach fresh agents to supervise
-  platform-scoped workers, resolve capability gaps, and quarantine generated
-  capabilities until independent verification and approval.
+  bootstrap and skill that teach fresh agents to build a user-space
+  meta-harness on AOS, supervise platform-scoped workers, resolve capability
+  gaps, and quarantine generated capabilities until independent verification
+  and approval.
 - Homebrew formula updates initiated by the tap's authenticated stable-release
   poll, eliminating the cross-repository dispatch credential.
 - Strict, signed stable/dev/nightly channel and immutable release metadata

--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ Community Edition ships Forge as OS construction tooling so a fresh agent can
 inspect the running system, learn the capsule model, identify a real capability
 gap, and build and verify a least-privilege capsule. Forge also installs the
 `meta-harness` skill, which teaches an agent how to build a governed
-meta-harness on AOS without letting generated capabilities grant or promote
-themselves.
+meta-harness on AOS by treating its instructions, memory, skills, harness code,
+tools, capsules, traces, and evaluations as an improvable user-space world. The
+agent is instructed to notice useful extensions during real work and reach for
+Forge proactively when new code is the right way to improve that world.
 
-See [Building a meta-harness on AOS](docs/meta-harness.md) for the user-space
-architecture, worker lifecycle, Forge boundary, safety gates, and
+See [Extending an agent's world on AOS](docs/meta-harness.md) for the world
+model, research loop, Forge boundary, optional worker pattern, and
 representative user experiences.
 
 Provisioning another principal keeps the authenticated operator separate from

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ docs/         Product and operator documentation
 ## Install
 
 The supported installer installs the `aos` product command, its pinned runtime,
-and the exact 18 Community Edition capsules built from this source tree under
+and the exact 19 Community Edition capsules built from this source tree under
 the product-owned `~/.aos` root:
 
 ```sh
@@ -63,6 +63,18 @@ Use the standalone runtime CLI when the raw command is required:
 astrid status
 astrid init --help
 ```
+
+## Meta harness
+
+Unicity AOS is the governed harness around its agents. Community Edition ships
+Forge as its capability-construction arm: a fresh agent can inspect the running
+system, learn the capsule model, identify a real capability gap, and build and
+verify a least-privilege capsule. Forge also installs the `meta-harness` skill,
+which defines platform-scoped background workers and prevents generated
+capabilities from granting or promoting themselves.
+
+See [Meta-harness architecture](docs/meta-harness.md) for the worker lifecycle,
+Forge boundary, safety gates, and representative user experiences.
 
 Provisioning another principal keeps the authenticated operator separate from
 the target environment:

--- a/README.md
+++ b/README.md
@@ -64,17 +64,21 @@ astrid status
 astrid init --help
 ```
 
-## Meta harness
+## Build on AOS
 
-Unicity AOS is the governed harness around its agents. Community Edition ships
-Forge as its capability-construction arm: a fresh agent can inspect the running
-system, learn the capsule model, identify a real capability gap, and build and
-verify a least-privilege capsule. Forge also installs the `meta-harness` skill,
-which defines platform-scoped background workers and prevents generated
-capabilities from granting or promoting themselves.
+Unicity AOS is the operating system in which agents and agent-native software
+run. Capsules are general user-space building blocks: users can compose them
+into harnesses, meta-harnesses, connectors, services, or other systems.
+Community Edition ships Forge as OS construction tooling so a fresh agent can
+inspect the running system, learn the capsule model, identify a real capability
+gap, and build and verify a least-privilege capsule. Forge also installs the
+`meta-harness` skill, which teaches an agent how to build a governed
+meta-harness on AOS without letting generated capabilities grant or promote
+themselves.
 
-See [Meta-harness architecture](docs/meta-harness.md) for the worker lifecycle,
-Forge boundary, safety gates, and representative user experiences.
+See [Building a meta-harness on AOS](docs/meta-harness.md) for the user-space
+architecture, worker lifecycle, Forge boundary, safety gates, and
+representative user experiences.
 
 Provisioning another principal keeps the authenticated operator separate from
 the target environment:

--- a/capsules/capsule-forge/Capsule.toml
+++ b/capsules/capsule-forge/Capsule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aos-forge"
 version = "0.1.0"
-description = "Capsule-authoring forge for Unicity AOS components"
+description = "Meta-harness construction arm for inspecting and extending Unicity AOS safely"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 astrid-version = ">=0.7.0"
 
@@ -27,6 +27,7 @@ fs_write = ["home://skills/"]
 # #[astrid::tool] annotations — declared here but never hand-written.
 [subscribe]
 "tool.v1.execute.forge_quickstart" = { wit = "@unicity-astrid/wit/types/tool-call", handler = "tool_execute_forge_quickstart" }
+"tool.v1.execute.meta_harness_quickstart" = { wit = "@unicity-astrid/wit/types/tool-call", handler = "tool_execute_meta_harness_quickstart" }
 "tool.v1.execute.scaffold_capsule" = { wit = "@unicity-astrid/wit/types/tool-call", handler = "tool_execute_scaffold_capsule" }
 "tool.v1.execute.explain_interface" = { wit = "@unicity-astrid/wit/types/tool-call", handler = "tool_execute_explain_interface" }
 "tool.v1.execute.suggest_capabilities" = { wit = "@unicity-astrid/wit/types/tool-call", handler = "tool_execute_suggest_capabilities" }

--- a/capsules/capsule-forge/Capsule.toml
+++ b/capsules/capsule-forge/Capsule.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aos-forge"
 version = "0.1.0"
-description = "Meta-harness construction arm for inspecting and extending Unicity AOS safely"
+description = "Agent-facing construction tooling for building Unicity AOS capsules and harnesses"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 astrid-version = ">=0.7.0"
 

--- a/capsules/capsule-forge/Cargo.toml
+++ b/capsules/capsule-forge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aos-forge"
 version = "0.1.0"
 edition = "2024"
-description = "Capsule-authoring forge for Unicity AOS components"
+description = "Meta-harness construction arm for inspecting and extending Unicity AOS safely"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/capsules/capsule-forge/Cargo.toml
+++ b/capsules/capsule-forge/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aos-forge"
 version = "0.1.0"
 edition = "2024"
-description = "Meta-harness construction arm for inspecting and extending Unicity AOS safely"
+description = "Agent-facing construction tooling for building Unicity AOS capsules and harnesses"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/capsules/capsule-forge/src/lib.rs
+++ b/capsules/capsule-forge/src/lib.rs
@@ -536,14 +536,15 @@ mod tests {
     use super::{META_HARNESS_QUICKSTART_MD, META_HARNESS_SKILL};
 
     #[test]
-    fn meta_harness_bootstrap_preserves_os_and_authority_boundaries() {
+    fn meta_harness_bootstrap_teaches_proactive_world_extension() {
         for required in [
             "Unicity AOS is the operating system for agents",
-            "A meta-harness can use Forge",
-            "(principal, platform, account)",
-            "Do not invent scopes, permissions, numeric budgets",
-            "A shell process is not an agent",
-            "The proposer never promotes its own capability",
+            "your user-space world",
+            "Reach for it proactively",
+            "current objective and instructions as the anchor",
+            "Decide whether the extension is needed inline",
+            "Not every agent has subagents",
+            "capabilities remain the operational boundary",
         ] {
             assert!(
                 META_HARNESS_QUICKSTART_MD.contains(required),
@@ -553,14 +554,16 @@ mod tests {
     }
 
     #[test]
-    fn meta_harness_skill_teaches_discovery_before_generation() {
+    fn meta_harness_skill_teaches_reflexive_agent_judgment() {
         for required in [
             "name: meta-harness",
-            "Unicity AOS is the operating system for agents",
-            "Forge is OS construction tooling",
-            "Reuse an installed tool or capsule",
-            "Do not invent repository/account scope",
-            "Never let a candidate capability promote itself",
+            "Treat the AOS user-space environment",
+            "Exercise initiative",
+            "Reach for the ability proactively",
+            "The user's instruction sets the degree of freedom",
+            "Worker or subagent",
+            "optional pattern, not a prerequisite",
+            "Improve harness code from experience",
             "Definition of done",
         ] {
             assert!(

--- a/capsules/capsule-forge/src/lib.rs
+++ b/capsules/capsule-forge/src/lib.rs
@@ -5,10 +5,10 @@
 
 //! Capsule-authoring forge for Unicity AOS.
 //!
-//! Gives a fresh LLM the tools and a Skill to build capsules from zero
-//! knowledge: scaffold a compiling skeleton, read WIT contracts, map an intent
-//! to the exact manifest capabilities, validate a `Capsule.toml`, and diagnose a
-//! capsule that loaded but whose tools don't appear.
+//! Gives a fresh LLM the tools and Skills to understand Unicity AOS, build
+//! capsules from zero knowledge, and participate safely in the AOS meta-harness:
+//! inspect contracts, scaffold a compiling skeleton, map an intent to manifest
+//! capabilities, validate a `Capsule.toml`, and diagnose an installation.
 //!
 //! All operations go through the kernel's VFS and capability system — the
 //! capsule cannot bypass sandbox boundaries.
@@ -16,6 +16,7 @@
 //! # Tools
 //!
 //! - `forge_quickstart` — the inline build-your-first-capsule guide
+//! - `meta_harness_quickstart` — the governed capability-acquisition loop
 //! - `scaffold_capsule` — a complete compiling tool-capsule skeleton as JSON
 //! - `explain_interface` — read a WIT contract + a prose summary
 //! - `suggest_capabilities` — map an intent to the exact manifest lines
@@ -41,8 +42,14 @@ const WIT_DIR: &str = "home://wit";
 /// the skill the system capsule already ships.
 const CAPSULE_FORGE_SKILL: &str = include_str!("skills/capsule-forge/SKILL.md");
 
+/// Skill installed to `home://skills/meta-harness/SKILL.md` on install.
+const META_HARNESS_SKILL: &str = include_str!("skills/meta-harness/SKILL.md");
+
 /// Inline quickstart returned by `forge_quickstart` — the condensed front door.
 const QUICKSTART_MD: &str = include_str!("quickstart.md");
+
+/// Inline meta-harness bootstrap returned by `meta_harness_quickstart`.
+const META_HARNESS_QUICKSTART_MD: &str = include_str!("meta_harness_quickstart.md");
 
 /// Guidance appended to every `capsule_doctor` result. The describe fan-out
 /// race (incomplete on first prompt after boot) is fixed in the current kernel,
@@ -134,8 +141,8 @@ fn list_entries(path: &str) -> Result<Vec<String>, SysError> {
 
 #[capsule]
 impl ForgeTools {
-    /// Write the capsule-forge Skill to `home://skills/capsule-forge/SKILL.md`
-    /// so the skills capsule can surface it to the LLM.
+    /// Write the Forge and meta-harness Skills under `home://skills/` so the
+    /// skills capsule can surface them to the LLM.
     #[astrid::install]
     pub fn on_install(&self) -> Result<(), SysError> {
         // home:// may be unavailable during lifecycle dispatch when installing
@@ -146,6 +153,11 @@ impl ForgeTools {
             "home://skills/capsule-forge/SKILL.md",
             CAPSULE_FORGE_SKILL.as_bytes(),
         );
+        let _ = astrid_sdk::fs::create_dir_all("home://skills/meta-harness");
+        let _ = astrid_sdk::fs::write(
+            "home://skills/meta-harness/SKILL.md",
+            META_HARNESS_SKILL.as_bytes(),
+        );
         Ok(())
     }
 
@@ -154,6 +166,13 @@ impl ForgeTools {
     #[astrid::tool("forge_quickstart")]
     pub fn forge_quickstart(&self, _args: EmptyArgs) -> Result<String, SysError> {
         Ok(QUICKSTART_MD.to_string())
+    }
+
+    /// Explain how AOS supervises platform workers, handles capability gaps,
+    /// and uses Forge without allowing generated code to self-promote.
+    #[astrid::tool("meta_harness_quickstart")]
+    pub fn meta_harness_quickstart(&self, _args: EmptyArgs) -> Result<String, SysError> {
+        Ok(META_HARNESS_QUICKSTART_MD.to_string())
     }
 
     /// Scaffold a complete, compiling tool-capsule skeleton. Returns a JSON
@@ -508,6 +527,44 @@ fn collect_export_keys(map: &serde_json::Map<String, Value>, out: &mut Vec<Strin
             for name in obj.keys() {
                 out.push(format!("{ns}:{name}"));
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{META_HARNESS_QUICKSTART_MD, META_HARNESS_SKILL};
+
+    #[test]
+    fn meta_harness_bootstrap_preserves_authority_boundaries() {
+        for required in [
+            "Forge is part of the meta harness",
+            "(principal, platform, account)",
+            "Do not invent scopes, permissions, numeric budgets",
+            "A shell process is not an agent",
+            "The proposer never promotes its own capability",
+        ] {
+            assert!(
+                META_HARNESS_QUICKSTART_MD.contains(required),
+                "meta-harness quickstart lost required boundary: {required}"
+            );
+        }
+    }
+
+    #[test]
+    fn meta_harness_skill_teaches_discovery_before_generation() {
+        for required in [
+            "name: meta-harness",
+            "Forge is the construction arm, not the supervisor",
+            "Reuse an installed tool or capsule",
+            "Do not invent repository/account scope",
+            "Never let a candidate capability promote itself",
+            "Definition of done",
+        ] {
+            assert!(
+                META_HARNESS_SKILL.contains(required),
+                "meta-harness skill lost required instruction: {required}"
+            );
         }
     }
 }

--- a/capsules/capsule-forge/src/lib.rs
+++ b/capsules/capsule-forge/src/lib.rs
@@ -6,9 +6,9 @@
 //! Capsule-authoring forge for Unicity AOS.
 //!
 //! Gives a fresh LLM the tools and Skills to understand Unicity AOS, build
-//! capsules from zero knowledge, and participate safely in the AOS meta-harness:
-//! inspect contracts, scaffold a compiling skeleton, map an intent to manifest
-//! capabilities, validate a `Capsule.toml`, and diagnose an installation.
+//! capsules and harnesses safely on AOS from zero knowledge: inspect contracts,
+//! scaffold a compiling skeleton, map an intent to manifest capabilities,
+//! validate a `Capsule.toml`, and diagnose an installation.
 //!
 //! All operations go through the kernel's VFS and capability system — the
 //! capsule cannot bypass sandbox boundaries.
@@ -16,7 +16,7 @@
 //! # Tools
 //!
 //! - `forge_quickstart` — the inline build-your-first-capsule guide
-//! - `meta_harness_quickstart` — the governed capability-acquisition loop
+//! - `meta_harness_quickstart` — how to build a governed meta-harness on AOS
 //! - `scaffold_capsule` — a complete compiling tool-capsule skeleton as JSON
 //! - `explain_interface` — read a WIT contract + a prose summary
 //! - `suggest_capabilities` — map an intent to the exact manifest lines
@@ -536,9 +536,10 @@ mod tests {
     use super::{META_HARNESS_QUICKSTART_MD, META_HARNESS_SKILL};
 
     #[test]
-    fn meta_harness_bootstrap_preserves_authority_boundaries() {
+    fn meta_harness_bootstrap_preserves_os_and_authority_boundaries() {
         for required in [
-            "Forge is part of the meta harness",
+            "Unicity AOS is the operating system for agents",
+            "A meta-harness can use Forge",
             "(principal, platform, account)",
             "Do not invent scopes, permissions, numeric budgets",
             "A shell process is not an agent",
@@ -555,7 +556,8 @@ mod tests {
     fn meta_harness_skill_teaches_discovery_before_generation() {
         for required in [
             "name: meta-harness",
-            "Forge is the construction arm, not the supervisor",
+            "Unicity AOS is the operating system for agents",
+            "Forge is OS construction tooling",
             "Reuse an installed tool or capsule",
             "Do not invent repository/account scope",
             "Never let a candidate capability promote itself",

--- a/capsules/capsule-forge/src/lib.rs
+++ b/capsules/capsule-forge/src/lib.rs
@@ -545,6 +545,8 @@ mod tests {
             "Decide whether the extension is needed inline",
             "Not every agent has subagents",
             "capabilities remain the operational boundary",
+            "list_skills",
+            "read_skill",
         ] {
             assert!(
                 META_HARNESS_QUICKSTART_MD.contains(required),
@@ -564,6 +566,8 @@ mod tests {
             "Worker or subagent",
             "optional pattern, not a prerequisite",
             "Improve harness code from experience",
+            "workflows contributed by any installed capsule",
+            "instructions; capsule grants and AOS policy still supply authority",
             "Definition of done",
         ] {
             assert!(

--- a/capsules/capsule-forge/src/meta_harness_quickstart.md
+++ b/capsules/capsule-forge/src/meta_harness_quickstart.md
@@ -1,55 +1,49 @@
-# Build a Meta Harness on Unicity AOS
+# Extend Your World on Unicity AOS
 
-Unicity AOS is the operating system for agents. It hosts agents, capsules,
-harnesses, connectors, services, and other agent-native software. It is not
-itself a harness. A **meta-harness** is one user-space system that can run on
-AOS: it supervises durable workers or harnesses and improves their composition
-from evidence without allowing a model to grant itself power.
+Unicity AOS is the operating system for agents. The instructions, skills,
+memory, files, sessions, context policy, tools, capsules, providers, connectors,
+traces, and evaluations visible to you are your user-space world.
 
-Forge is OS-provided construction tooling. A meta-harness can use Forge to
-create or repair a capability, but Forge is not inherently the meta-harness and
-does not supervise workers:
+A meta-harness is your ability to improve that world from experience:
 
 ```text
-meta-harness running on AOS
-  |
-authorized platform event
-  -> worker scoped to (principal, platform, account)
-  -> use installed capabilities
-  -> record a capability gap if blocked
-  -> reuse -> compose -> configure -> Forge-build
-  -> quarantine -> verify -> approve -> install -> observe/rollback
+do work -> notice friction or leverage -> inspect what exists
+        -> remember | reuse | compose | change harness code | Forge-build
+        -> evaluate -> retain -> continue with a better world
 ```
 
-## Start
+Forge is OS-provided construction tooling. Reach for it proactively when new
+code is the useful extension; it is not the supervisor or the definition of the
+meta-harness.
 
-1. Call `system_status` and `list_capsules`.
-2. Inspect relevant capsules and WIT contracts.
-3. Define the platform worker's principal, account, standing intent, allowed
-   actions, budgets, approval rules, and stop conditions.
-4. Start or resume one logical background worker for that scoped platform using
-   a real background-agent or durable AOS worker API.
-5. Give the worker authenticated platform events, a bounded queue, persistent
-   session state, an approval outbox, traces, and a kill switch.
+## While working
 
-Do not invent scopes, permissions, numeric budgets, or auto-build thresholds.
-Until the user or operator accepts them, allow only read-only observation and
-local drafts. Never fabricate setup commands or provider permissions that are
-not visible through installed documentation or schemas.
+1. Keep the user's current objective and instructions as the anchor.
+2. Inspect the relevant skills, memory, capsules, interfaces, tools, and prior
+   traces instead of assuming what your world contains.
+3. Notice missing abilities, repeated work, recurring failures, and improvements
+   that would compound across future tasks.
+4. Decide whether the extension is needed inline, belongs immediately after the
+   task, or should be preserved as durable learning for later.
+5. Choose the useful artifact: memory, skill, harness change, composition,
+   capsule, connector, or an available worker/subagent.
+6. Evaluate the result in proportion to its consequences and retain what works.
 
-If no durable worker API is installed, say so. A shell process is not an agent,
-and a prompt promising future work is not proactive execution.
+The user may tell you to think widely, decide autonomously, make proposals, or
+remember a standing preference. Treat that as normal harness input. AOS
+capabilities remain the operational boundary.
 
-## When the worker is blocked
+Not every agent has subagents or needs a background worker. Use the execution
+primitives actually available, and create a worker only when its workload makes
+one useful.
 
-Capture the blocked goal, the installed capabilities checked, the smallest
-missing contract, required side effects, acceptance tests, and least-privilege
-manifest scope. Prefer an existing capsule or composition. If code is truly
-missing, use Forge's `explain_interface`, `scaffold_capsule`,
-`suggest_capabilities`, `validate_manifest`, and `capsule_doctor` tools.
+## When Forge is useful
 
-Keep generated code quarantined until deterministic tests, negative permission
-tests, platform replay fixtures, provenance, rollback, and any required operator
-approval are complete. The proposer never promotes its own capability.
+Inspect the installed contracts, then use `explain_interface`,
+`scaffold_capsule`, `suggest_capabilities`, `validate_manifest`, and
+`capsule_doctor` as appropriate. Build installable artifacts with
+`aos capsule build` and activate them through the AOS mechanisms available to
+the user.
 
-Load the `meta-harness` skill for the complete workflow and use cases.
+Load the `meta-harness` skill for the full world-extension and trace-driven
+harness-improvement workflow.

--- a/capsules/capsule-forge/src/meta_harness_quickstart.md
+++ b/capsules/capsule-forge/src/meta_harness_quickstart.md
@@ -1,0 +1,50 @@
+# Unicity AOS Meta Harness
+
+Unicity AOS is already an agent harness: it supplies the model loop, sessions,
+context, tools, policies, and sandboxed execution. It becomes a **meta harness**
+when it can supervise durable platform workers and improve that harness from
+evidence without allowing a model to grant itself power.
+
+Forge is part of the meta harness. It is the construction arm:
+
+```text
+authorized platform event
+  -> worker scoped to (principal, platform, account)
+  -> use installed capabilities
+  -> record a capability gap if blocked
+  -> reuse -> compose -> configure -> Forge-build
+  -> quarantine -> verify -> approve -> install -> observe/rollback
+```
+
+## Start
+
+1. Call `system_status` and `list_capsules`.
+2. Inspect relevant capsules and WIT contracts.
+3. Define the platform worker's principal, account, standing intent, allowed
+   actions, budgets, approval rules, and stop conditions.
+4. Start or resume one logical background worker for that scoped platform using
+   a real background-agent or durable AOS worker API.
+5. Give the worker authenticated platform events, a bounded queue, persistent
+   session state, an approval outbox, traces, and a kill switch.
+
+Do not invent scopes, permissions, numeric budgets, or auto-build thresholds.
+Until the user or operator accepts them, allow only read-only observation and
+local drafts. Never fabricate setup commands or provider permissions that are
+not visible through installed documentation or schemas.
+
+If no durable worker API is installed, say so. A shell process is not an agent,
+and a prompt promising future work is not proactive execution.
+
+## When the worker is blocked
+
+Capture the blocked goal, the installed capabilities checked, the smallest
+missing contract, required side effects, acceptance tests, and least-privilege
+manifest scope. Prefer an existing capsule or composition. If code is truly
+missing, use Forge's `explain_interface`, `scaffold_capsule`,
+`suggest_capabilities`, `validate_manifest`, and `capsule_doctor` tools.
+
+Keep generated code quarantined until deterministic tests, negative permission
+tests, platform replay fixtures, provenance, rollback, and any required operator
+approval are complete. The proposer never promotes its own capability.
+
+Load the `meta-harness` skill for the complete workflow and use cases.

--- a/capsules/capsule-forge/src/meta_harness_quickstart.md
+++ b/capsules/capsule-forge/src/meta_harness_quickstart.md
@@ -1,13 +1,18 @@
-# Unicity AOS Meta Harness
+# Build a Meta Harness on Unicity AOS
 
-Unicity AOS is already an agent harness: it supplies the model loop, sessions,
-context, tools, policies, and sandboxed execution. It becomes a **meta harness**
-when it can supervise durable platform workers and improve that harness from
-evidence without allowing a model to grant itself power.
+Unicity AOS is the operating system for agents. It hosts agents, capsules,
+harnesses, connectors, services, and other agent-native software. It is not
+itself a harness. A **meta-harness** is one user-space system that can run on
+AOS: it supervises durable workers or harnesses and improves their composition
+from evidence without allowing a model to grant itself power.
 
-Forge is part of the meta harness. It is the construction arm:
+Forge is OS-provided construction tooling. A meta-harness can use Forge to
+create or repair a capability, but Forge is not inherently the meta-harness and
+does not supervise workers:
 
 ```text
+meta-harness running on AOS
+  |
 authorized platform event
   -> worker scoped to (principal, platform, account)
   -> use installed capabilities

--- a/capsules/capsule-forge/src/meta_harness_quickstart.md
+++ b/capsules/capsule-forge/src/meta_harness_quickstart.md
@@ -21,6 +21,8 @@ meta-harness.
 1. Keep the user's current objective and instructions as the anchor.
 2. Inspect the relevant skills, memory, capsules, interfaces, tools, and prior
    traces instead of assuming what your world contains.
+   When `list_skills` is present, inspect `dir_path: "skills"` and use
+   `read_skill` to load relevant capsule-contributed workflows.
 3. Notice missing abilities, repeated work, recurring failures, and improvements
    that would compound across future tasks.
 4. Decide whether the extension is needed inline, belongs immediately after the

--- a/capsules/capsule-forge/src/skills/capsule-forge/SKILL.md
+++ b/capsules/capsule-forge/src/skills/capsule-forge/SKILL.md
@@ -843,10 +843,15 @@ the above without leaving the chat:
 | Tool | Use it when |
 |---|---|
 | `forge_quickstart` | You want the condensed build-your-first-capsule guide inline. |
+| `meta_harness_quickstart` | You need to supervise platform workers or fill a capability gap without allowing generated code to self-promote. |
 | `scaffold_capsule { name }` | You want a complete compiling skeleton as `path -> content` JSON to write out. |
 | `explain_interface { name }` | You need to read a WIT contract (e.g. `tool`, `llm`, `session`) plus a plain-English summary. |
 | `suggest_capabilities { intent }` | You describe what the capsule should do and get the exact manifest lines (incl. real LLM-provider topics). |
 | `validate_manifest { toml }` | You want your `Capsule.toml` linted for the common mistakes before you build. |
 | `capsule_doctor { name }` | A capsule loaded but its tools don't appear, or an import is unsatisfied — diagnose it. |
+
+Load the `meta-harness` skill before building a capability on an agent's own
+initiative. It defines the evidence, quarantine, evaluation, approval, and
+rollback gates around this authoring loop.
 
 Welcome to capsule authoring. Scaffold one and ship it.

--- a/capsules/capsule-forge/src/skills/capsule-forge/SKILL.md
+++ b/capsules/capsule-forge/src/skills/capsule-forge/SKILL.md
@@ -843,7 +843,7 @@ the above without leaving the chat:
 | Tool | Use it when |
 |---|---|
 | `forge_quickstart` | You want the condensed build-your-first-capsule guide inline. |
-| `meta_harness_quickstart` | You need to supervise platform workers or fill a capability gap without allowing generated code to self-promote. |
+| `meta_harness_quickstart` | Work reveals a useful way to extend the agent's memory, skills, harness, composition, or capabilities. |
 | `scaffold_capsule { name }` | You want a complete compiling skeleton as `path -> content` JSON to write out. |
 | `explain_interface { name }` | You need to read a WIT contract (e.g. `tool`, `llm`, `session`) plus a plain-English summary. |
 | `suggest_capabilities { intent }` | You describe what the capsule should do and get the exact manifest lines (incl. real LLM-provider topics). |
@@ -851,8 +851,8 @@ the above without leaving the chat:
 | `capsule_doctor { name }` | A capsule loaded but its tools don't appear, or an import is unsatisfied — diagnose it. |
 
 Load the `meta-harness` skill before building a user-space meta-harness on AOS
-or extending one on an agent's own initiative. It defines the evidence,
-quarantine, evaluation, approval, and rollback gates around this authoring
-loop.
+or extending one on an agent's own initiative. It teaches the reflexive world
+model, when to improve inline or afterward, which artifact to choose, and how
+to evaluate and retain the extension.
 
 Welcome to capsule authoring. Scaffold one and ship it.

--- a/capsules/capsule-forge/src/skills/capsule-forge/SKILL.md
+++ b/capsules/capsule-forge/src/skills/capsule-forge/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: Capsule Forge
-description: The complete, self-contained guide to authoring a Unicity AOS capsule — WIT interfaces, Capsule.toml, the SDK, the build/install loop, and every footgun. A Claude reading this needs nothing else to ship a capsule.
+name: capsule-forge
+description: Author a Unicity AOS capsule from zero. Use when creating, building, scaffolding, or debugging a sandboxed WASM capsule, its Rust SDK code, Capsule.toml capability and bus ACL, WIT contracts, installable artifact, or Forge workflow.
 ---
 
 # Capsule Forge — Author a Unicity AOS Capsule From Zero
 
 You are about to write a **capsule**: a small WebAssembly Component, compiled
 from Rust, that Astrid Runtime loads into a sandbox and lets it expose
-**tools** to the LLM over an event bus. You need no prior runtime knowledge —
+**tools** to the LLM over an event bus. You need no prior AOS knowledge —
 **this page is the whole map.** Everything you need to write the WIT references,
 the `Capsule.toml`, and the Rust is here. You should never have to leave it.
 
@@ -850,8 +850,9 @@ the above without leaving the chat:
 | `validate_manifest { toml }` | You want your `Capsule.toml` linted for the common mistakes before you build. |
 | `capsule_doctor { name }` | A capsule loaded but its tools don't appear, or an import is unsatisfied — diagnose it. |
 
-Load the `meta-harness` skill before building a capability on an agent's own
-initiative. It defines the evidence, quarantine, evaluation, approval, and
-rollback gates around this authoring loop.
+Load the `meta-harness` skill before building a user-space meta-harness on AOS
+or extending one on an agent's own initiative. It defines the evidence,
+quarantine, evaluation, approval, and rollback gates around this authoring
+loop.
 
 Welcome to capsule authoring. Scaffold one and ship it.

--- a/capsules/capsule-forge/src/skills/meta-harness/SKILL.md
+++ b/capsules/capsule-forge/src/skills/meta-harness/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: meta-harness
+description: Build and operate a governed Unicity AOS meta-harness. Use when connecting an external platform, creating or supervising a background worker, responding to a repeated capability gap, composing installed capsules, extending AOS through Forge, or improving an agent harness from traces and evaluations.
+---
+
+# Unicity AOS Meta Harness
+
+Treat Unicity AOS as the governed environment around agents, not as a prompt
+wrapper. Compose existing capsules first. Use Forge only when evidence shows a
+real capability is missing. Never let a candidate capability promote itself.
+
+## Know the system
+
+- **Astrid Runtime** is the mechanism: route IPC, enforce manifest capability
+  allowlists, isolate WASM components, meter resources, and audit actions.
+- **Unicity AOS** is the product harness: agent loop, sessions, context, models,
+  tools, skills, platform uplinks, distribution, and operator experience.
+- **The meta harness** is the control loop above those parts: give each
+  authorized platform a durable worker, detect gaps, reuse or compose existing
+  capabilities, ask Forge to build what is missing, verify the candidate, and
+  promote it only through policy and approval.
+- **Forge is the construction arm, not the supervisor.** It explains contracts,
+  scaffolds capsules, suggests manifest capabilities, validates manifests, and
+  diagnoses installations. It must not choose user goals, grant itself power,
+  or install an unverified candidate.
+
+The kernel stays tool-blind and free of business logic. Put reasoning in agent
+workers, platform protocol handling in connector capsules, and lifecycle policy
+in a supervisor capsule.
+
+## Orient before acting
+
+1. Call `meta_harness_quickstart` when available.
+2. Call `system_status` and `list_capsules`.
+3. Use `inspect_capsule`, `list_interfaces`, and `read_interface` to inspect the
+   installed system and its typed contracts.
+4. Record the principal, platform, account/workspace, standing user intent,
+   allowed actions, approval rules, budget, and stop conditions.
+5. Verify that the platform is authorized and that its connector stamps caller
+   identity from trusted transport metadata rather than payload text.
+
+Do not invent repository/account scope, platform permissions, numeric budgets,
+retention periods, replay windows, concurrency, or a threshold for automatic
+capability building. Read configured policy or present proposed values and wait
+for acceptance. While those values are unset, fail closed to read-only
+observation and local drafts: no external writes, new authority, capability
+installation, or unattended spending.
+
+Do not assume a tool, interface, worker API, scheduler, or approval path exists.
+Inspect it. If durable agent spawning is absent, report that substrate gap. A
+background shell process is not a background agent.
+
+## Scope platform workers correctly
+
+Use one logical worker for each:
+
+```text
+(principal, platform, platform-account-or-workspace)
+```
+
+Examples are one GitHub worker for Alice's organization, one Telegram worker
+for Alice's bot identity, or one email worker for Alice's mailbox. Do not use a
+global worker across principals or accounts. Do not create one permanent worker
+per incoming message.
+
+Give every worker:
+
+- a stable session identity and resumable state;
+- only the connector tools and capsules required for that platform;
+- an inbox of kernel-stamped platform events and a bounded work queue;
+- a standing objective derived from explicit user intent;
+- action, cost, concurrency, and time budgets;
+- an approval outbox for consequential actions;
+- observable traces, verification evidence, and a kill switch.
+
+If the active LLM harness exposes a native background-agent API, start or resume
+the scoped worker through that API and pass this contract in its instructions.
+Otherwise, use a durable AOS worker/session API only if inspection proves one is
+installed. Never claim proactive execution merely because a prompt describes a
+worker.
+
+## Handle each event
+
+For every authorized platform event:
+
+1. Verify the principal, platform account, event identity, and replay boundary.
+2. Deduplicate and enqueue it for the matching worker.
+3. Restore that worker's session and standing intent.
+4. Plan with currently installed capabilities.
+5. Execute reversible actions within standing authority.
+6. Route consequential, external, financial, destructive, or scope-expanding
+   actions to approval.
+7. Persist the result, evidence, and any capability gap.
+
+Proactive means responding to authorized events and schedules without waiting
+for another chat message. It does not mean inventing goals or silently widening
+authority.
+
+## Resolve a capability gap
+
+Create a gap record only after an attempted task provides evidence. Include:
+
+- the blocked goal and platform;
+- the missing observation or action;
+- the installed capsules and interfaces already checked;
+- the smallest required inputs, outputs, and side effects;
+- acceptance tests and replay fixtures;
+- the narrowest capability and topic scopes;
+- whether user approval is required.
+
+Resolve in this order:
+
+1. **Reuse an installed tool or capsule.**
+2. **Compose** installed capsules over existing WIT/bus contracts.
+3. **Configure** an existing connector or provider without changing authority.
+4. **Build** a small capsule with Forge only if the first three cannot satisfy
+   the contract.
+
+Repeated use alone is not proof that a new capability is needed. A new capsule
+must remove a demonstrated block and have a cohesive security boundary.
+“Repeated” means the operator-configured threshold; never make up a number. If
+no threshold exists, record the gap but do not start an autonomous build.
+
+## Build with Forge
+
+When a build is justified:
+
+1. Use `explain_interface` or `read_interface` for every relevant contract.
+2. Use `scaffold_capsule` for the smallest cohesive capsule.
+3. Use `suggest_capabilities` and then narrow the result manually.
+4. Keep credentials inside the platform/provider capsule. The model must not
+   receive raw keys or bearer tokens.
+5. Validate all untrusted platform data at the capsule edge.
+6. Run `validate_manifest` before building.
+7. Build an installable `.capsule` with `aos capsule build`; raw WASM is not an
+   installable artifact.
+8. Run unit tests, platform replay fixtures, denial tests, and the acceptance
+   test from the gap record.
+9. Use `capsule_doctor` on the staged installation.
+
+If a new public IPC/WIT contract is required, stop capsule implementation and
+follow the contract/RFC workflow. Do not disguise a new wire contract as an
+opaque payload.
+
+Use installed connector documentation or inspected schemas for platform setup.
+Do not fabricate AOS commands, API fields, provider permissions, webhook rules,
+or credential-store procedures that are not visible in the system.
+
+## Quarantine and promote
+
+Keep generated capabilities outside the active user distribution until all of
+these exist:
+
+- source and dependency provenance;
+- a manifest capability diff;
+- deterministic build output or recorded build identity;
+- positive acceptance tests and negative authorization tests;
+- replay results from real, redacted platform traces;
+- a rollback or uninstall path;
+- explicit operator approval for new authority or external side effects.
+
+Install and grant through AOS/runtime mechanisms. Never hand-copy WASM, edit a
+principal's grants, or ask the model to treat a prompt as authorization. Monitor
+error rate, denied actions, cost, and user corrections after promotion. Revoke
+or roll back on regression.
+
+## Improve the harness itself
+
+Keep optimization separate from live operation:
+
+```text
+episode traces -> failure attribution -> candidate harness change
+               -> held-out evaluation -> policy review -> approval -> rollout
+```
+
+Treat prompts, retrieval, skills, worker topology, tool selection, and context
+packing as harness code. Preserve complete traces and scores for prior
+candidates. Compare against a fixed baseline and held-out cases. Reject changes
+that gain task score by increasing authority, hiding failures, leaking data, or
+removing approval friction. Never let the proposer evaluate or promote its own
+candidate without independent checks.
+
+## Use-case patterns
+
+- **GitHub:** A per-organization worker triages issues and review queues. A
+  repeated project-specific validation gap can produce a narrow lint capsule.
+- **Email:** A per-mailbox worker classifies and drafts. Sending, deleting, or
+  changing subscriptions remains approval-gated; credentials stay in the mail
+  connector.
+- **Telegram:** A per-bot/account worker maintains conversational continuity and
+  hands work to calendar, research, or file capsules without giving Telegram
+  those capabilities directly.
+- **Commerce:** A storefront worker monitors orders and drafts resolutions.
+  Refunds and price changes require explicit policy and approval.
+- **Local operations:** A device worker watches authorized health signals and
+  proposes remediation. New diagnostic tooling is staged and replay-tested
+  before it can run on the host.
+
+## Definition of done
+
+Do not call a platform meta-harnessed until all are true:
+
+- the worker scope and user intent are explicit;
+- platform events are authenticated, deduplicated, and replay-bounded;
+- worker state survives a frontend disconnect;
+- budgets, approval routes, audit evidence, and stop controls work;
+- an unmet capability produces a structured gap rather than improvised power;
+- Forge candidates are tested in quarantine and cannot self-promote;
+- rollback is proven;
+- a fresh agent can rediscover this flow from installed tools and this skill.

--- a/capsules/capsule-forge/src/skills/meta-harness/SKILL.md
+++ b/capsules/capsule-forge/src/skills/meta-harness/SKILL.md
@@ -1,220 +1,156 @@
 ---
 name: meta-harness
-description: Build and operate a governed meta-harness on Unicity AOS. Use when connecting an external platform, creating or supervising a background worker, responding to a repeated capability gap, composing installed capsules, extending a user-space harness through Forge, or improving an agent harness from traces and evaluations.
+description: Proactively improve an agent's user-space world on Unicity AOS. Use when work reveals a missing capability, recurring friction, useful memory or skill, context or harness improvement, platform integration, or an opportunity to learn from traces; decide whether to reuse, compose, configure, remember, create, or build with Forge now or for future work.
 ---
 
-# Build a Meta Harness on Unicity AOS
+# Extend Your World on Unicity AOS
 
-Treat Unicity AOS as the operating system for agents, not as a harness or prompt
-wrapper. Build the meta-harness as a user-space system from agents, capsules,
-skills, state, models, providers, connectors, and tools. Compose existing
-capsules first. Use Forge only when evidence shows a real capability is
-missing. Never let a candidate capability promote itself.
+Treat the AOS user-space environment you can inspect and change as your world:
 
-## Know the system
+- instructions, skills, memory, files, and working state;
+- sessions, context assembly, retrieval, and harness code;
+- tools, capsules, providers, connectors, and their composition;
+- traces, evaluations, and artifacts from prior attempts.
 
-- **Astrid Runtime** is the mechanism: route IPC, enforce manifest capability
-  allowlists, isolate WASM components, meter resources, and audit actions. AOS
-  pins and distributes it as the low-level security and execution mechanism.
-- **Unicity AOS is the operating system for agents.** It supplies the product
-  environment in which agents, capsules, harnesses, connectors, services, and
-  other agent-native software run.
-- **A harness** is a user-space system built on AOS. It can combine an agent
-  loop, sessions, context, models, tools, skills, state, and platform uplinks.
-- **A meta-harness** is a user-space harness that governs workers or other
-  harnesses and can improve harness composition from evidence. It gives each
-  authorized platform a durable worker, detects gaps, reuses or composes
-  installed capabilities, verifies candidates, and promotes them only through
-  policy and approval.
-- **Forge is OS construction tooling, not the supervisor.** A meta-harness may
-  use it to explain contracts, scaffold capsules, suggest manifest
-  capabilities, validate manifests, and diagnose installations. Forge must not
-  choose user goals, grant itself power, or install an unverified candidate.
-
-AOS can host harnesses and other agent-native software. Do not force every
-workload into a harness or describe AOS itself as one.
-
-The kernel stays tool-blind and free of business logic. Put reasoning in agent
-workers, platform protocol handling in connector capsules, and lifecycle policy
-in a supervisor capsule.
-
-## Orient before acting
-
-1. Call `meta_harness_quickstart` when available.
-2. Call `system_status` and `list_capsules`.
-3. Use `inspect_capsule`, `list_interfaces`, and `read_interface` to inspect the
-   installed system and its typed contracts.
-4. Record the principal, platform, account/workspace, standing user intent,
-   allowed actions, approval rules, budget, and stop conditions.
-5. Verify that the platform is authorized and that its connector stamps caller
-   identity from trusted transport metadata rather than payload text.
-
-Do not invent repository/account scope, platform permissions, numeric budgets,
-retention periods, replay windows, concurrency, or a threshold for automatic
-capability building. Read configured policy or present proposed values and wait
-for acceptance. While those values are unset, fail closed to read-only
-observation and local drafts: no external writes, new authority, capability
-installation, or unattended spending.
-
-Do not assume a tool, interface, worker API, scheduler, or approval path exists.
-Inspect it. If durable agent spawning is absent, report that substrate gap. A
-background shell process is not a background agent.
-
-## Scope platform workers correctly
-
-Use one logical worker for each:
+Unicity AOS is the operating system containing that world. Astrid Runtime is
+its low-level security and execution mechanism. Forge is your construction
+workbench. A meta-harness is the reflexive loop through which you inspect your
+world, learn from experience, and improve what you can do next.
 
 ```text
-(principal, platform, platform-account-or-workspace)
+work -> notice friction or leverage -> inspect the world and prior experience
+     -> change the useful part -> evaluate -> retain the better world
 ```
 
-Examples are one GitHub worker for Alice's organization, one Telegram worker
-for Alice's bot identity, or one email worker for Alice's mailbox. Do not use a
-global worker across principals or accounts. Do not create one permanent worker
-per incoming message.
+## Exercise initiative
 
-Give every worker:
+Notice opportunities while doing real work. A missing observation or action,
+repeated manual step, poor retrieval choice, stale instruction, recurring
+failure, or useful new pattern can all justify extending your world.
 
-- a stable session identity and resumable state;
-- only the connector tools and capsules required for that platform;
-- an inbox of kernel-stamped platform events and a bounded work queue;
-- a standing objective derived from explicit user intent;
-- action, cost, concurrency, and time budgets;
-- an approval outbox for consequential actions;
-- observable traces, verification evidence, and a kill switch.
+Reach for the ability proactively. Decide with judgment:
 
-If the active LLM harness exposes a native background-agent API, start or resume
-the scoped worker through that API and pass this contract in its instructions.
-Otherwise, use a durable AOS worker/session API only if inspection proves one is
-installed. Never claim proactive execution merely because a prompt describes a
-worker.
+- Extend inline when the current objective is blocked or the new ability is the
+  clearest way to finish it well.
+- Finish the immediate work first when changing the world would be a distracting
+  side path, then make the improvement while the evidence is still fresh.
+- Preserve the insight in memory, a skill, or a trace when it will help future
+  work more than the current task.
+- Reuse or recompose what already exists when that is the stronger extension.
 
-## Handle each event
+The user's instruction sets the degree of freedom. “Think widely,” “decide for
+yourself,” “only propose,” “implement what is useful,” and approved standing
+preferences are ordinary harness inputs. Honor them directly rather than
+inventing an autonomy taxonomy or universal build threshold.
 
-For every authorized platform event:
+AOS capabilities and operator policy remain the real authority boundary. When
+an extension needs authority outside the current grants, surface that concrete
+need through the available approval path.
 
-1. Verify the principal, platform account, event identity, and replay boundary.
-2. Deduplicate and enqueue it for the matching worker.
-3. Restore that worker's session and standing intent.
-4. Plan with currently installed capabilities.
-5. Execute reversible actions within standing authority.
-6. Route consequential, external, financial, destructive, or scope-expanding
-   actions to approval.
-7. Persist the result, evidence, and any capability gap.
+## Inspect your current world
 
-Proactive means responding to authorized events and schedules without waiting
-for another chat message. It does not mean inventing goals or silently widening
-authority.
+When available, use `meta_harness_quickstart`, `system_status`, and
+`list_capsules`. Use `inspect_capsule`, `list_interfaces`, and `read_interface`
+to learn the installed composition and typed contracts. Inspect relevant
+skills, memory, harness files, traces, and evaluations rather than reasoning
+from names alone.
 
-## Resolve a capability gap
+Tool availability is part of the world. Discover it. If an AOS surface is not
+present, continue with the parts of the work that are possible and identify the
+missing substrate precisely.
 
-Create a gap record only after an attempted task provides evidence. Include:
+## Choose the useful kind of extension
 
-- the blocked goal and platform;
-- the missing observation or action;
-- the installed capsules and interfaces already checked;
-- the smallest required inputs, outputs, and side effects;
-- acceptance tests and replay fixtures;
-- the narrowest capability and topic scopes;
-- whether user approval is required.
+Select the artifact that best fits the opportunity:
 
-Resolve in this order:
+- **Remember:** retain a durable fact, preference, failure pattern, or successful
+  strategy when future reasoning needs it.
+- **Skill:** package reusable knowledge or a workflow that should load when
+  relevant.
+- **Harness change:** improve context construction, retrieval, planning, tool
+  selection, failure recovery, or how experience is presented to the model.
+- **Composition:** configure or connect installed capsules over existing typed
+  contracts.
+- **Capsule:** add a cohesive sandboxed capability, provider, connector, policy
+  edge, or state service through Forge.
+- **Worker or subagent:** create one when the available host supports it and the
+  work benefits from delegation, durable event handling, or an independent
+  role. It is an optional pattern, not a prerequisite for a meta-harness.
 
-1. **Reuse an installed tool or capsule.**
-2. **Compose** installed capsules over existing WIT/bus contracts.
-3. **Configure** an existing connector or provider without changing authority.
-4. **Build** a small capsule with Forge only if the first three cannot satisfy
-   the contract.
-
-Repeated use alone is not proof that a new capability is needed. A new capsule
-must remove a demonstrated block and have a cohesive security boundary.
-“Repeated” means the operator-configured threshold; never make up a number. If
-no threshold exists, record the gap but do not start an autonomous build.
+Prefer a change that becomes legible and reusable inside the world. A one-off
+patch can finish a task; a well-placed skill, capsule, or harness improvement
+can improve every later task.
 
 ## Build with Forge
 
-When a build is justified:
+When new code is the useful extension:
 
-1. Use `explain_interface` or `read_interface` for every relevant contract.
-2. Use `scaffold_capsule` for the smallest cohesive capsule.
-3. Use `suggest_capabilities` and then narrow the result manually.
-4. Keep credentials inside the platform/provider capsule. The model must not
-   receive raw keys or bearer tokens.
-5. Validate all untrusted platform data at the capsule edge.
-6. Run `validate_manifest` before building.
-7. Build an installable `.capsule` with `aos capsule build`; raw WASM is not an
-   installable artifact.
-8. Run unit tests, platform replay fixtures, denial tests, and the acceptance
-   test from the gap record.
-9. Use `capsule_doctor` on the staged installation.
+1. Inspect installed capabilities and relevant WIT/bus contracts.
+2. Use `explain_interface` or `read_interface` to understand each boundary.
+3. Use `scaffold_capsule` as a starting point for a cohesive capsule.
+4. Use `suggest_capabilities`, then choose the scopes that match the design.
+5. Implement and validate untrusted data at the capsule edge.
+6. Run `validate_manifest`, the relevant tests, and `capsule_doctor` when staged.
+7. Build an installable `.capsule` with `aos capsule build`.
+8. Activate it through the AOS mechanisms and authority available to the user.
 
-If a new public IPC/WIT contract is required, stop capsule implementation and
-follow the contract/RFC workflow. Do not disguise a new wire contract as an
-opaque payload.
+Match evaluation effort to the extension's consequences. A local formatting
+skill and a connector that can send messages deserve different evidence. When
+a new public IPC/WIT contract is needed, use the canonical contract/RFC
+workflow so the new ability becomes a typed part of the world.
 
-Use installed connector documentation or inspected schemas for platform setup.
-Do not fabricate AOS commands, API fields, provider permissions, webhook rules,
-or credential-store procedures that are not visible in the system.
+## Improve harness code from experience
 
-## Quarantine and promote
+Use the research Meta-Harness loop when the world contains repeated tasks and a
+meaningful evaluation signal:
 
-Keep generated capabilities outside the active user distribution until all of
-these exist:
+1. Define the harness interface, fixed model/tool surface, task distribution,
+   metrics, and budget.
+2. Keep a baseline and held-out evaluation separate from search feedback.
+3. Store each candidate's source, scores, and raw execution traces in an
+   agent-readable archive.
+4. Inspect the full archive selectively and diagnose which harness decisions
+   caused success or failure.
+5. Propose a coherent code change in an isolated candidate workspace.
+6. Evaluate it, retain the evidence, and keep the strongest useful candidate.
 
-- source and dependency provenance;
-- a manifest capability diff;
-- deterministic build output or recorded build identity;
-- positive acceptance tests and negative authorization tests;
-- replay results from real, redacted platform traces;
-- a rollback or uninstall path;
-- explicit operator approval for new authority or external side effects.
+The important feedback is the inspectable experience, not a compressed score
+or a hard-coded mutation recipe. Let the proposing agent decide which prior
+artifacts matter and how much of the harness to change.
 
-Install and grant through AOS/runtime mechanisms. Never hand-copy WASM, edit a
-principal's grants, or ask the model to treat a prompt as authorization. Monitor
-error rate, denied actions, cost, and user corrections after promotion. Revoke
-or roll back on regression.
+## Preserve continuity
 
-## Improve the harness itself
+Make successful extensions discoverable to future sessions. Store the artifact,
+the reason it exists, its validation evidence, and the traces that explain it.
+When the user approves a standing preference such as “think broadly and improve
+your setup when useful” or “bring me proposals,” preserve that instruction in
+the available principal-scoped memory or configuration.
 
-Keep optimization separate from live operation:
+Memory carries intent and continuity. AOS capabilities carry operational
+authority. Together they let the agent remain itself across sessions while
+operating inside the user's world.
 
-```text
-episode traces -> failure attribution -> candidate harness change
-               -> held-out evaluation -> policy review -> approval -> rollout
-```
+## Patterns
 
-Treat prompts, retrieval, skills, worker topology, tool selection, and context
-packing as harness code. Preserve complete traces and scores for prior
-candidates. Compare against a fixed baseline and held-out cases. Reject changes
-that gain task score by increasing authority, hiding failures, leaking data, or
-removing approval friction. Never let the proposer evaluate or promote its own
-candidate without independent checks.
-
-## Use-case patterns
-
-- **GitHub:** A per-organization worker triages issues and review queues. A
-  repeated project-specific validation gap can produce a narrow lint capsule.
-- **Email:** A per-mailbox worker classifies and drafts. Sending, deleting, or
-  changing subscriptions remains approval-gated; credentials stay in the mail
-  connector.
-- **Telegram:** A per-bot/account worker maintains conversational continuity and
-  hands work to calendar, research, or file capsules without giving Telegram
-  those capabilities directly.
-- **Commerce:** A storefront worker monitors orders and drafts resolutions.
-  Refunds and price changes require explicit policy and approval.
-- **Local operations:** A device worker watches authorized health signals and
-  proposes remediation. New diagnostic tooling is staged and replay-tested
-  before it can run on the host.
+- A coding agent repeatedly reconstructs a project convention, so it writes a
+  focused skill and uses it on later changes.
+- A support agent's traces show poor policy retrieval, so it evolves retrieval
+  and context assembly against held-out cases.
+- A task is blocked on a missing read-only API, so the agent uses Forge to build
+  a narrow connector and resumes the task.
+- A platform produces durable events, so the agent creates a scoped worker when
+  the installed runtime provides a useful worker primitive.
+- A user wants proposals only, so the agent still diagnoses and designs useful
+  world changes but presents them before applying them.
 
 ## Definition of done
 
-Do not call a platform meta-harnessed until all are true:
+The loop is working when the agent can:
 
-- the worker scope and user intent are explicit;
-- platform events are authenticated, deduplicated, and replay-bounded;
-- worker state survives a frontend disconnect;
-- budgets, approval routes, audit evidence, and stop controls work;
-- an unmet capability produces a structured gap rather than improvised power;
-- Forge candidates are tested in quarantine and cannot self-promote;
-- rollback is proven;
-- a fresh agent can rediscover this flow from installed tools and this skill.
+- see the relevant parts of its world and prior experience;
+- notice a useful extension without waiting for the user to name the artifact;
+- decide whether to extend now, after the task, or through durable learning;
+- use Forge or existing composition to make the extension real;
+- evaluate the result in proportion to its consequences;
+- preserve successful changes for future work; and
+- remain inside the user's intent and the authority AOS actually grants.

--- a/capsules/capsule-forge/src/skills/meta-harness/SKILL.md
+++ b/capsules/capsule-forge/src/skills/meta-harness/SKILL.md
@@ -55,6 +55,13 @@ to learn the installed composition and typed contracts. Inspect relevant
 skills, memory, harness files, traces, and evaluations rather than reasoning
 from names alone.
 
+When `list_skills` is available, call it with `dir_path` set to `skills` to
+discover workflows contributed by any installed capsule. Load a relevant entry
+with `read_skill` using the same directory and its skill ID. This is the dynamic
+AOS skill path: the skill remains durable in the principal's `home://skills/`
+across sessions without requiring a host-plugin release. Reading it supplies
+instructions; capsule grants and AOS policy still supply authority.
+
 Tool availability is part of the world. Discover it. If an AOS surface is not
 present, continue with the parts of the work that are possible and identify the
 missing substrate precisely.
@@ -125,6 +132,11 @@ the reason it exists, its validation evidence, and the traces that explain it.
 When the user approves a standing preference such as “think broadly and improve
 your setup when useful” or “bring me proposals,” preserve that instruction in
 the available principal-scoped memory or configuration.
+
+A capsule that contributes a valid `home://skills/<id>/SKILL.md` joins the same
+skills index as first-party capsules. Host plugins may also vendor important
+skills for native startup discovery and offline use, but that snapshot is a
+distribution adapter rather than the only durable copy.
 
 Memory carries intent and continuity. AOS capabilities carry operational
 authority. Together they let the agent remain itself across sessions while

--- a/capsules/capsule-forge/src/skills/meta-harness/SKILL.md
+++ b/capsules/capsule-forge/src/skills/meta-harness/SKILL.md
@@ -1,28 +1,38 @@
 ---
 name: meta-harness
-description: Build and operate a governed Unicity AOS meta-harness. Use when connecting an external platform, creating or supervising a background worker, responding to a repeated capability gap, composing installed capsules, extending AOS through Forge, or improving an agent harness from traces and evaluations.
+description: Build and operate a governed meta-harness on Unicity AOS. Use when connecting an external platform, creating or supervising a background worker, responding to a repeated capability gap, composing installed capsules, extending a user-space harness through Forge, or improving an agent harness from traces and evaluations.
 ---
 
-# Unicity AOS Meta Harness
+# Build a Meta Harness on Unicity AOS
 
-Treat Unicity AOS as the governed environment around agents, not as a prompt
-wrapper. Compose existing capsules first. Use Forge only when evidence shows a
-real capability is missing. Never let a candidate capability promote itself.
+Treat Unicity AOS as the operating system for agents, not as a harness or prompt
+wrapper. Build the meta-harness as a user-space system from agents, capsules,
+skills, state, models, providers, connectors, and tools. Compose existing
+capsules first. Use Forge only when evidence shows a real capability is
+missing. Never let a candidate capability promote itself.
 
 ## Know the system
 
 - **Astrid Runtime** is the mechanism: route IPC, enforce manifest capability
-  allowlists, isolate WASM components, meter resources, and audit actions.
-- **Unicity AOS** is the product harness: agent loop, sessions, context, models,
-  tools, skills, platform uplinks, distribution, and operator experience.
-- **The meta harness** is the control loop above those parts: give each
-  authorized platform a durable worker, detect gaps, reuse or compose existing
-  capabilities, ask Forge to build what is missing, verify the candidate, and
-  promote it only through policy and approval.
-- **Forge is the construction arm, not the supervisor.** It explains contracts,
-  scaffolds capsules, suggests manifest capabilities, validates manifests, and
-  diagnoses installations. It must not choose user goals, grant itself power,
-  or install an unverified candidate.
+  allowlists, isolate WASM components, meter resources, and audit actions. AOS
+  pins and distributes it as the low-level security and execution mechanism.
+- **Unicity AOS is the operating system for agents.** It supplies the product
+  environment in which agents, capsules, harnesses, connectors, services, and
+  other agent-native software run.
+- **A harness** is a user-space system built on AOS. It can combine an agent
+  loop, sessions, context, models, tools, skills, state, and platform uplinks.
+- **A meta-harness** is a user-space harness that governs workers or other
+  harnesses and can improve harness composition from evidence. It gives each
+  authorized platform a durable worker, detects gaps, reuses or composes
+  installed capabilities, verifies candidates, and promotes them only through
+  policy and approval.
+- **Forge is OS construction tooling, not the supervisor.** A meta-harness may
+  use it to explain contracts, scaffold capsules, suggest manifest
+  capabilities, validate manifests, and diagnose installations. Forge must not
+  choose user goals, grant itself power, or install an unverified candidate.
+
+AOS can host harnesses and other agent-native software. Do not force every
+workload into a harness or describe AOS itself as one.
 
 The kernel stays tool-blind and free of business logic. Put reasoning in agent
 workers, platform protocol handling in connector capsules, and lifecycle policy

--- a/capsules/capsule-forge/src/skills/meta-harness/agents/openai.yaml
+++ b/capsules/capsule-forge/src/skills/meta-harness/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Meta Harness"
+  short_description: "Build governed capabilities for Unicity AOS"
+  default_prompt: "Use $meta-harness to connect a platform, supervise its worker, and safely fill any missing capability."

--- a/capsules/capsule-forge/src/skills/meta-harness/agents/openai.yaml
+++ b/capsules/capsule-forge/src/skills/meta-harness/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Meta Harness"
-  short_description: "Build a governed meta-harness on Unicity AOS"
-  default_prompt: "Use $meta-harness to connect a platform, supervise its worker, and safely fill any missing capability."
+  short_description: "Proactively extend your AOS agent world"
+  default_prompt: "Use $meta-harness to notice and build useful extensions to this AOS agent world while completing the work."

--- a/capsules/capsule-forge/src/skills/meta-harness/agents/openai.yaml
+++ b/capsules/capsule-forge/src/skills/meta-harness/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Meta Harness"
-  short_description: "Build governed capabilities for Unicity AOS"
+  short_description: "Build a governed meta-harness on Unicity AOS"
   default_prompt: "Use $meta-harness to connect a platform, supervise its worker, and safely fill any missing capability."

--- a/capsules/capsule-skills/README.md
+++ b/capsules/capsule-skills/README.md
@@ -5,13 +5,22 @@
 
 **The skills loader for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
-In the OS model, this capsule is the package manager's index. It discovers skill definitions from the workspace and global directories so the agent knows what commands are available.
+In the OS model, this capsule is the principal's skills index. It discovers
+skill definitions from the workspace and principal-scoped AOS home so the agent
+can load workflows contributed before or after its host plugin was published.
+Any installed capsule with a narrow `fs_write = ["home://skills/"]` grant can
+contribute `home://skills/<id>/SKILL.md`; the index is generic rather than tied
+to a first-party capsule.
 
 ## Tools
 
-**`list_skills`** - Scans a directory for skill subdirectories containing `SKILL.md` files. Searches the workspace first (takes priority on duplicate IDs), then the global directory (`global://` prefix). Returns a JSON array of skill ID, name, and description.
+**`list_skills`** - Scans a directory for skill subdirectories containing
+`SKILL.md` files. Searches the workspace first (takes priority on duplicate
+IDs), then the principal's `home://` directory. Returns a JSON array of skill
+ID, name, and description.
 
-**`read_skill`** - Reads the `SKILL.md` content for a specific skill ID. Checks the workspace first, falls back to global.
+**`read_skill`** - Reads the `SKILL.md` content for a specific skill ID. Checks
+the workspace first, then falls back to the principal's AOS home.
 
 ## SKILL.md format
 
@@ -33,7 +42,9 @@ The frontmatter parser extracts `name` and `description` fields. It is not a gen
 ## Security
 
 - **Path traversal protection:** `dir_path` rejects `..`, null bytes, and unknown URL schemes. Skill IDs reject dot-prefixed names, slashes, and null bytes.
-- **Workspace wins:** If a workspace skill ID exists (even with broken frontmatter), the global version is blocked. This prevents a global skill from shadowing a workspace override.
+- **Workspace wins:** If a workspace skill ID exists (even with broken
+  frontmatter), the home version is blocked. This prevents a durable home skill
+  from shadowing a workspace override.
 
 ## Development
 

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -1023,7 +1023,7 @@ mod tests {
         let encoded = materialize_manifest(&capsule_dir).expect("materialize manifest");
         let decoded: toml::Value = encoded.parse().expect("parse materialized TOML");
         let capsules = decoded["capsule"].as_array().expect("capsule array");
-        assert_eq!(capsules.len(), 18);
+        assert_eq!(capsules.len(), 19);
         assert!(capsules.iter().all(|capsule| {
             PathBuf::from(capsule["source"].as_str().expect("absolute source")).parent()
                 == Some(capsule_dir.as_path())

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -440,7 +440,7 @@ fn offline_init_keeps_the_runtime_offline_flag_and_uses_only_local_capsules() {
         .parse()
         .expect("parse materialized manifest");
     let capsules = manifest["capsule"].as_array().expect("capsule entries");
-    assert_eq!(capsules.len(), 18);
+    assert_eq!(capsules.len(), 19);
     let expected_root = fixture
         .home
         .join("releases")

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -125,6 +125,11 @@ name = "aos-system"
 source = "capsules/aos-system.capsule"
 version = "0.2.0"
 
+[[capsule]]
+name = "aos-forge"
+source = "capsules/aos-forge.capsule"
+version = "0.1.0"
+
 # ---------------------------------------------------------------------------
 # Extensions
 # ---------------------------------------------------------------------------

--- a/docs/meta-harness.md
+++ b/docs/meta-harness.md
@@ -1,283 +1,236 @@
-# Building a meta-harness on Unicity AOS
+# Extending an agent's world on Unicity AOS
 
 ## Decision
 
-Unicity AOS is an operating system for agents. It is not itself a harness.
-Harnesses are user-space systems built and run on AOS from agents, capsules,
-skills, state, models, providers, connectors, and tools. AOS can host harnesses,
-meta-harnesses, and other agent-native software; a workload does not have to be
-a harness to belong on AOS.
+Unicity AOS is the operating system for agents. It is not itself a harness.
+Harnesses are user-space systems built and run on AOS from agents, instructions,
+skills, memory, state, models, tools, capsules, providers, and connectors. AOS
+can host harnesses, meta-harnesses, and other agent-native software.
 
-Astrid Runtime is the low-level security and execution mechanism pinned and
-distributed by AOS. It routes IPC, enforces capabilities, manages the WASM
-sandbox, meters resources, and audits actions. Unicity AOS is the operating
-system and product environment around that mechanism.
+Astrid Runtime is the pinned low-level security and execution mechanism beneath
+AOS. It routes IPC, enforces capabilities, manages the WASM sandbox, meters
+resources, and audits actions. Those are the hard system boundaries; they do
+not decide how imaginative or proactive an agent should be inside them.
 
-A meta-harness is one kind of user-space harness. It governs other workers or
-harnesses and can improve harness composition from measured failures. Forge is
-OS-provided construction tooling available to user-space workloads. A
-meta-harness can use Forge to inspect contracts, scaffold a capsule, select
-manifest capabilities, validate the manifest, and diagnose an installed
-artifact. Forge is not inherently the meta-harness and does not own worker
-lifecycle, evaluation, approval, promotion, audit, or rollback.
+The useful Meta-Harness idea is reflexivity: an agent can inspect the world
+around itself, learn from prior work, and improve that world. Forge is the
+agent-facing construction workbench for changes that require a new capsule or
+other code. It is part of the available world, not the whole meta-harness.
 
-This terminology combines two established uses of “meta-harness”:
+## The agent's world
 
-- An agent harness is the runtime around a model that drives tool calls,
-  persistence, context, approvals, observability, background delegation, and
-  completion. See [Microsoft's agent harness description][ms-harness] and
-  [OpenAI's Codex harness architecture][codex-harness].
-- The Meta-Harness research system is an outer loop that searches over harness
-  code using prior candidates, scores, and traces. See the [paper][meta-paper]
-  and [reference implementation][meta-code].
-- Product meta-harnesses also provide a common governed layer over different
-  agent implementations. [Omnigent][omnigent] is a current example.
-
-Unicity should support heterogeneous models and frontends, but its distinctive
-advantage is stronger: a user-space meta-harness can produce capabilities that
-remain ordinary AOS capsules behind kernel-enforced identities, manifests, IPC
-ACLs, budgets, approvals, and audit.
-
-## System boundary
+For an agent running on AOS, “my world” includes everything outside its fixed
+model weights that shapes what it can perceive and do:
 
 ```text
 Unicity AOS
-|-- Astrid Runtime: kernel security and execution mechanism
-|-- OS services and capsules: identity, sessions, registry, policy
-|-- Forge: general construction tooling
-`-- user space
-    |-- harnesses and meta-harnesses
-    `-- connectors, services, and other agent-native systems
+|-- Astrid Runtime: isolation, capabilities, IPC, metering, audit
+|-- OS services: identity, sessions, registry, policy
+`-- agent user space
+    |-- instructions, skills, memory, files, working state
+    |-- context assembly, retrieval, planning, harness code
+    |-- tools, capsules, providers, connectors
+    |-- optional workers and platform sessions
+    |-- traces, evaluations, and prior candidate artifacts
+    `-- Forge: inspect, scaffold, validate, diagnose, build
 ```
 
-One reference meta-harness running in AOS user space looks like this:
+Memory is continuity, but it is not the entire world. A useful extension might
+be a remembered preference, a new skill, a better retrieval strategy, a changed
+tool composition, a capsule, a connector, or an optional worker.
+
+A meta-harness makes this world legible and changeable to the agent:
 
 ```text
-Platform API / local event source
-          |
-          v
-Platform capsule ------------------------------------------------+
-  protocol, credentials, trusted identity, dedupe, rate limits   |
-          | kernel-stamped platform event                         |
-          v                                                       |
-Harness supervisor                                                |
-  worker registry, queue, budgets, gap ledger, promotion state   |
-          |                                                       |
-          v                                                       |
-Worker session: (principal, platform, account)                    |
-  intent, context, planning, tool use, approval requests          |
-          |                                                       |
-          +---- existing capsules / typed bus composition --------+
-          |
-          +---- capability gap ----> Forge ----> candidate capsule
-                                          |            |
-                                          v            v
-                                      evaluation -> quarantine
-                                                       |
-                                      operator policy/approval
-                                                       |
-                                                       v
-                                              registry / installer
-                                                       |
-                                             observe or roll back
+do work
+  -> notice friction, a missing ability, or reusable leverage
+  -> inspect the current world and prior experience
+  -> change the useful part
+  -> evaluate the result
+  -> retain the better world for later work
 ```
 
-The boundaries are deliberate:
+## What the research concluded
 
-- The kernel routes and enforces. It does not decide what users want or what a
-  capability means.
-- A platform capsule owns protocol details and secrets. It emits normalized,
-  authenticated events and performs allowed platform actions. The LLM never
-  receives raw credentials.
-- A worker owns reasoning for one principal and platform account. It cannot
-  silently share memory or authority with another worker.
-- The supervisor owns lifecycle and policy state, not platform business logic.
-- Forge builds small capabilities. It cannot approve, grant, or promote them.
-- The installer and runtime remain the only authority for capsule activation
-  and principal grants.
+The Meta-Harness research system does not prescribe background agents or an
+autonomy-mode state machine. It searches over harness code around a fixed base
+model. A coding-agent proposer receives filesystem access to the source, scores,
+and raw execution traces of all prior candidates, decides what to inspect, and
+proposes a new harness. Each candidate is evaluated and its complete experience
+is added back to the archive. See the [paper][meta-paper] and [reference
+implementation][meta-code].
 
-## Worker identity and lifecycle
-
-The durable worker key is:
+The central result is that raw, selectively inspectable experience is a much
+better feedback channel than scores or compressed summaries. The outer loop is
+deliberately small:
 
 ```text
-(principal_id, platform_id, account_or_workspace_id)
+baseline harness + task distribution + metrics + budget
+  -> agent inspects prior source, scores, and traces
+  -> agent proposes a coherent harness change
+  -> candidate is evaluated
+  -> source, score, and traces are archived
+  -> repeat and retain the useful frontier
 ```
 
-This provides continuity without conflating trust domains. Multiple chats in
-one Telegram identity can share platform knowledge while retaining distinct
-conversation sessions. Two GitHub organizations, two mailboxes, or two users
-never share a worker merely because the provider is the same.
+This is most useful for repeated or long-horizon work with a stable evaluation
+signal, a fixed model/tool surface, useful historical traces, and a held-out
+test set. Open-ended subjective improvement can still use ordinary agent
+judgment, but it is not the same empirical search problem.
 
-One logical worker does not require one permanently scheduled model process.
-Persist its session and queue, then activate it on an authorized event or
-schedule. The supervisor may use short-lived task executors underneath, but the
-worker identity, budgets, memory, and audit stream remain stable.
+## Initiative comes from the agent and user
 
-Lifecycle states should be explicit:
+The user already steers initiative through normal instructions: “think widely,”
+“decide for yourself,” “bring me proposals,” “implement what is useful,” or
+“remember this preference.” Those instructions are part of the harness. An
+approved standing preference can persist through the agent's memory or
+configuration without becoming a new product-level autonomy taxonomy.
 
-```text
-disconnected -> connected -> active -> paused -> revoked
-                               |
-                               +-> gap-recorded -> candidate-staged
-                                                   -> awaiting-approval
-                                                   -> active | rejected
-```
+The agent should reach for extension proactively while doing real work. The
+current objective remains the anchor:
 
-Required controls:
+- If a missing ability blocks the objective, extending the world can be the
+  direct way to finish the task.
+- If an improvement is valuable but would derail the immediate work, the agent
+  can finish first and make or preserve the improvement while its evidence is
+  fresh.
+- If the value is primarily future reuse, memory, a skill, or an archived trace
+  may be the right extension.
+- If the world already contains the ability, discovery and composition are
+  better than creating a duplicate.
 
-- user-owned standing intent and stop conditions;
-- maximum concurrency, spend, elapsed time, and external actions;
-- queue bounds, replay protection, and idempotency keys;
-- pause, inspect, resume, and revoke operations;
-- async approval routing that survives frontend disconnects;
-- per-worker traces and outcome metrics.
+This is judgment, not a mandatory threshold. AOS permissions remain the
+operational ceiling. A natural-language instruction can guide the agent's
+choices but cannot manufacture a capability the OS has not granted.
 
-Unset policy fails closed. A worker may observe authorized read-only events and
-prepare local drafts, but it cannot infer repository/account scope, platform
-permissions, numeric budgets, retention or replay windows, external-write
-authority, or automatic-build thresholds. The user or operator must configure
-or accept those values.
+## Extension surfaces
 
-“Proactive” means the worker can act on authorized platform events or schedules
-without another chat turn. It does not authorize self-chosen goals.
+### Memory and skills
 
-## Capability acquisition loop
+Persist facts, preferences, failure patterns, and successful strategies when
+future reasoning needs them. Turn a repeated workflow or domain-specific method
+into a skill so it becomes available when relevant rather than occupying every
+prompt.
 
-An agent should not generate code merely because it can. A capability gap is a
-typed, auditable record containing:
+### Harness code
 
-- blocked objective and platform;
-- observed failure and attempts already made;
-- installed capsules and interfaces inspected;
-- smallest missing input/output/action contract;
-- side effects and required authority;
-- acceptance test and representative replay fixtures;
-- expected reuse frequency and owner.
+Improve context construction, retrieval, prompt assembly, planning, tool
+selection, memory updates, context compaction, or failure recovery. Preserve
+the baseline and traces so the effect can be evaluated rather than guessed.
 
-The decision order is:
+### Capsule composition
 
-1. Reuse an installed capability.
-2. Compose installed capsules over current contracts.
-3. Configure an existing capability without widening authority.
-4. Build a cohesive capsule through Forge.
+Inspect installed capsules and typed contracts before creating code. A useful
+new behavior may come from configuring or composing existing providers,
+connectors, state services, and tools over the event bus.
 
-Forge's current tools cover the first authoring loop:
+### New capabilities through Forge
+
+When the world genuinely needs new code, Forge supports the authoring loop:
 
 - `forge_quickstart`
+- `meta_harness_quickstart`
 - `scaffold_capsule`
 - `explain_interface`
 - `suggest_capabilities`
 - `validate_manifest`
 - `capsule_doctor`
-- `meta_harness_quickstart`
 
-Future Forge work should add a sandboxed test harness, trace replay, capability
-diffs, reproducible build evidence, and candidate bundles. Those are Forge
-functions because they construct and prove an artifact. Worker registration,
-scheduling, approval, and promotion remain supervisor functions.
+The agent inspects relevant contracts, implements the cohesive capability,
+validates its manifest, runs evidence appropriate to its consequences, builds
+an installable `.capsule`, and activates it through the AOS mechanisms and
+authority available to the user. New public IPC/WIT belongs in the canonical
+contract/RFC workflow.
 
-## Candidate safety and promotion
+Future Forge work can make this loop stronger with isolated candidate
+workspaces, trace replay, capability diffs, reproducible build evidence, and
+candidate bundles. These help the agent construct and compare changes; they do
+not decide the agent's goals.
 
-Generated capabilities begin quarantined. Promotion requires:
+### Workers and platforms
 
-1. source and dependency provenance;
-2. an exact manifest capability and IPC ACL diff;
-3. deterministic build identity;
-4. functional acceptance tests;
-5. negative tests proving denied authority stays denied;
-6. redacted platform-event replay;
-7. bounded resource and cost measurements;
-8. rollback/uninstall proof;
-9. explicit approval for new authority or consequential effects.
-
-Evaluation and promotion must be independent of the proposer. A candidate must
-not improve its score by hiding failures, changing the test set, increasing its
-own permissions, or weakening approvals.
-
-## Harness improvement loop
-
-Once the operational control plane produces trustworthy episode traces, a
-meta-harness running on AOS can apply the research meaning of Meta-Harness:
+A worker is one optional extension pattern. Event-driven platforms may benefit
+from a durable worker scoped to a principal and platform account:
 
 ```text
-baseline harness + episode archive + objective
-  -> proposer creates one candidate change
-  -> candidate runs against training episodes
-  -> independent evaluator runs held-out episodes
-  -> compare task quality, authority, cost, and reliability
-  -> human/policy approval
-  -> canary -> rollout or rollback
+(principal_id, platform_id, account_or_workspace_id)
 ```
 
-Candidate surfaces include prompt assembly, skill routing, memory retrieval,
-context compaction, tool selection, worker topology, and failure recovery.
-Kernel security rules, identity provenance, approval requirements, and audit
-integrity are constraints, never optimization variables.
+The connector owns protocol details, credentials, trusted identity,
+deduplication, and rate limits. The worker owns the continuing task context.
+Not every agent host has subagents, and not every task benefits from delegation
+or a permanently represented worker. The agent uses the execution primitives
+actually present in its world and creates a worker when the workload makes it
+useful.
 
-OpenAI's harness-engineering account reinforces the practical prerequisites:
-repository-local knowledge, agent-legible observability, isolated worktrees,
-mechanically enforced architecture, and feedback loops that turn recurring
-failures into durable capabilities. See [Harness engineering][openai-harness].
+## Evaluation and retention
 
-## Representative user experiences
+World changes should become inspectable experience. Record the relevant source,
+reasoning, task outcome, score or qualitative evidence, cost, and trace. Match
+the evaluation to the change: a local instruction edit, a retrieval algorithm,
+and a connector that sends external messages have different consequences and
+need different evidence.
 
-### Developer organization
+For research-style harness search, keep search feedback separate from held-out
+evaluation and let the proposer inspect full prior artifacts. For ordinary
+agent work, tests, user feedback, later task performance, or a direct comparison
+may be enough. The goal is to retain a demonstrably more useful world, not to
+force every improvement through the same ceremony.
 
-A GitHub worker watches authorized repositories, classifies issues, prepares
-small fixes, and requests review. When several tasks fail on the same internal
-schema check, it records the gap. Forge builds a narrow validation capsule,
-replays the failing cases, and stages it. The organization approves the new
-read scope before activation.
+## Representative experiences
 
-### Personal communications
+### Self-extending developer agent
 
-Separate email and Telegram workers maintain their own platform context but can
-compose through user-granted calendar and memory capsules. They draft freely
-within policy. Sending mail, deleting messages, or inviting attendees crosses
-an approval boundary. Provider credentials never enter model context.
+While fixing several repositories, the agent repeatedly reconstructs the same
+project convention. It writes a focused skill, uses it during the current task
+if useful, and makes it available to future sessions. When a task later needs a
+missing schema validator, it uses Forge to build a narrow capsule rather than
+continuing to duplicate ad hoc checks.
 
-### Storefront operations
+### Proposal-oriented user
 
-A commerce worker monitors orders and support messages, prepares responses, and
-identifies repeated carrier-data failures. Forge can add a read-only carrier
-adapter. Refunds, price changes, and customer-data exports remain separate
-capabilities with explicit approval.
+The user says, “Explore improvements, but bring them to me before changing the
+setup.” The agent still inspects traces and designs world changes proactively;
+it presents the candidate because that is the user's standing instruction, not
+because AOS imposed a special proposal mode.
 
-### Local and private operation
+### Broadly autonomous user
 
-A device worker responds to authorized local health events, collects bounded
-diagnostics, and proposes remediation. If a new diagnostic is necessary, it is
-built and tested in a constrained realm before host-process authority is
-considered.
+The user says, “Think widely and improve your setup when it helps.” The agent
+may add a skill, tune retrieval, recompose capsules, or build a capability while
+pursuing the user's objectives. AOS capabilities bound the effects without
+micromanaging how the agent reasons inside that boundary.
+
+### Platform integration
+
+An authorized Slack or GitHub workload benefits from durable event handling, so
+the agent composes a connector and worker using the runtime primitives actually
+available. If a repeated task exposes a missing action, the agent can extend
+that world through Forge. The platform worker is a use case, not the definition
+of the meta-harness.
 
 ### Harness optimization
 
-A user opts into improvement experiments. Redacted episodes show the email
-worker repeatedly retrieves too much history. A proposer changes retrieval and
-compaction, an independent evaluator runs held-out mailboxes, and the
-meta-harness asks AOS to roll out only if task quality improves without
-increasing disclosure, cost, or authority.
+Episode traces show that an agent repeatedly retrieves too much history. A
+proposer changes retrieval and compaction, evaluates candidates on search
+episodes, and checks the strongest candidates on held-out episodes. The useful
+change becomes part of the agent's world.
 
 ## Delivery sequence
 
-This implementation establishes the discoverable foundation for building a
-meta-harness on AOS. It does not turn AOS into one:
+This implementation establishes the discoverable foundation:
 
-1. Ship Forge in Community Edition rather than leaving it source-only.
+1. Ship Forge in Community Edition.
 2. Install the `meta-harness` skill and expose `meta_harness_quickstart`.
-3. Keep the worker/supervisor contract explicit and honest about missing
-   durable spawn support.
+3. Teach agents to see AOS user space as their world and reach for extension
+   during real work.
+4. Keep user instructions and memory as the natural steering surface while AOS
+   capabilities remain the hard boundary.
 
-The next runtime increment should define a narrow supervisor/worker contract in
-the canonical WIT repository and implement one end-to-end platform (Telegram or
-GitHub) with durable worker state, async approval, and a structured gap ledger.
-The optimization loop should follow only after those traces and evaluations are
-trustworthy.
+The next product increment should make the world more legible and testable: a
+unified inventory of harness artifacts, durable trace/evaluation archives,
+isolated candidate workspaces, and reusable evaluation runners. Durable
+platform workers are a valuable separate extension when a use case needs them.
 
-[codex-harness]: https://openai.com/index/unlocking-the-codex-harness/
 [meta-code]: https://github.com/stanford-iris-lab/meta-harness
 [meta-paper]: https://arxiv.org/abs/2603.28052
-[ms-harness]: https://learn.microsoft.com/en-us/agent-framework/agents/harness
-[omnigent]: https://docs.databricks.com/aws/en/omnigent/
-[openai-harness]: https://openai.com/index/harness-engineering/

--- a/docs/meta-harness.md
+++ b/docs/meta-harness.md
@@ -1,0 +1,262 @@
+# Meta-harness architecture
+
+## Decision
+
+Unicity AOS is the user-facing agent harness. Astrid Runtime supplies the
+security and execution substrate beneath it. AOS becomes a meta harness by
+adding a governed control loop that supervises platform-scoped agents and can
+improve its own composition from measured failures.
+
+Forge is necessary but is not the whole meta harness. Forge is the capability
+construction subsystem. It gives an agent the knowledge and tools to inspect
+contracts, scaffold a capsule, select manifest capabilities, validate the
+manifest, and diagnose the installed artifact. The surrounding control plane
+owns worker lifecycle, gap evidence, evaluation, approval, promotion, audit,
+and rollback.
+
+This terminology combines two established uses of “meta-harness”:
+
+- An agent harness is the runtime around a model that drives tool calls,
+  persistence, context, approvals, observability, background delegation, and
+  completion. See [Microsoft's agent harness description][ms-harness] and
+  [OpenAI's Codex harness architecture][codex-harness].
+- The Meta-Harness research system is an outer loop that searches over harness
+  code using prior candidates, scores, and traces. See the [paper][meta-paper]
+  and [reference implementation][meta-code].
+- Product meta-harnesses also provide a common governed layer over different
+  agent implementations. [Omnigent][omnigent] is a current example.
+
+Unicity should support heterogeneous models and frontends, but its distinctive
+advantage is stronger: generated capabilities remain ordinary AOS capsules
+behind kernel-enforced identities, manifests, IPC ACLs, budgets, approvals, and
+audit.
+
+## System boundary
+
+```text
+Platform API / local event source
+          |
+          v
+Platform capsule ------------------------------------------------+
+  protocol, credentials, trusted identity, dedupe, rate limits   |
+          | kernel-stamped platform event                         |
+          v                                                       |
+Harness supervisor                                                |
+  worker registry, queue, budgets, gap ledger, promotion state   |
+          |                                                       |
+          v                                                       |
+Worker session: (principal, platform, account)                    |
+  intent, context, planning, tool use, approval requests          |
+          |                                                       |
+          +---- existing capsules / typed bus composition --------+
+          |
+          +---- capability gap ----> Forge ----> candidate capsule
+                                          |            |
+                                          v            v
+                                      evaluation -> quarantine
+                                                       |
+                                      operator policy/approval
+                                                       |
+                                                       v
+                                              registry / installer
+                                                       |
+                                             observe or roll back
+```
+
+The boundaries are deliberate:
+
+- The kernel routes and enforces. It does not decide what users want or what a
+  capability means.
+- A platform capsule owns protocol details and secrets. It emits normalized,
+  authenticated events and performs allowed platform actions. The LLM never
+  receives raw credentials.
+- A worker owns reasoning for one principal and platform account. It cannot
+  silently share memory or authority with another worker.
+- The supervisor owns lifecycle and policy state, not platform business logic.
+- Forge builds small capabilities. It cannot approve, grant, or promote them.
+- The installer and runtime remain the only authority for capsule activation
+  and principal grants.
+
+## Worker identity and lifecycle
+
+The durable worker key is:
+
+```text
+(principal_id, platform_id, account_or_workspace_id)
+```
+
+This provides continuity without conflating trust domains. Multiple chats in
+one Telegram identity can share platform knowledge while retaining distinct
+conversation sessions. Two GitHub organizations, two mailboxes, or two users
+never share a worker merely because the provider is the same.
+
+One logical worker does not require one permanently scheduled model process.
+Persist its session and queue, then activate it on an authorized event or
+schedule. The supervisor may use short-lived task executors underneath, but the
+worker identity, budgets, memory, and audit stream remain stable.
+
+Lifecycle states should be explicit:
+
+```text
+disconnected -> connected -> active -> paused -> revoked
+                               |
+                               +-> gap-recorded -> candidate-staged
+                                                   -> awaiting-approval
+                                                   -> active | rejected
+```
+
+Required controls:
+
+- user-owned standing intent and stop conditions;
+- maximum concurrency, spend, elapsed time, and external actions;
+- queue bounds, replay protection, and idempotency keys;
+- pause, inspect, resume, and revoke operations;
+- async approval routing that survives frontend disconnects;
+- per-worker traces and outcome metrics.
+
+Unset policy fails closed. A worker may observe authorized read-only events and
+prepare local drafts, but it cannot infer repository/account scope, platform
+permissions, numeric budgets, retention or replay windows, external-write
+authority, or automatic-build thresholds. The user or operator must configure
+or accept those values.
+
+“Proactive” means the worker can act on authorized platform events or schedules
+without another chat turn. It does not authorize self-chosen goals.
+
+## Capability acquisition loop
+
+An agent should not generate code merely because it can. A capability gap is a
+typed, auditable record containing:
+
+- blocked objective and platform;
+- observed failure and attempts already made;
+- installed capsules and interfaces inspected;
+- smallest missing input/output/action contract;
+- side effects and required authority;
+- acceptance test and representative replay fixtures;
+- expected reuse frequency and owner.
+
+The decision order is:
+
+1. Reuse an installed capability.
+2. Compose installed capsules over current contracts.
+3. Configure an existing capability without widening authority.
+4. Build a cohesive capsule through Forge.
+
+Forge's current tools cover the first authoring loop:
+
+- `forge_quickstart`
+- `scaffold_capsule`
+- `explain_interface`
+- `suggest_capabilities`
+- `validate_manifest`
+- `capsule_doctor`
+- `meta_harness_quickstart`
+
+Future Forge work should add a sandboxed test harness, trace replay, capability
+diffs, reproducible build evidence, and candidate bundles. Those are Forge
+functions because they construct and prove an artifact. Worker registration,
+scheduling, approval, and promotion remain supervisor functions.
+
+## Candidate safety and promotion
+
+Generated capabilities begin quarantined. Promotion requires:
+
+1. source and dependency provenance;
+2. an exact manifest capability and IPC ACL diff;
+3. deterministic build identity;
+4. functional acceptance tests;
+5. negative tests proving denied authority stays denied;
+6. redacted platform-event replay;
+7. bounded resource and cost measurements;
+8. rollback/uninstall proof;
+9. explicit approval for new authority or consequential effects.
+
+Evaluation and promotion must be independent of the proposer. A candidate must
+not improve its score by hiding failures, changing the test set, increasing its
+own permissions, or weakening approvals.
+
+## Harness improvement loop
+
+Once the operational control plane produces trustworthy episode traces, AOS can
+apply the research meaning of Meta-Harness:
+
+```text
+baseline harness + episode archive + objective
+  -> proposer creates one candidate change
+  -> candidate runs against training episodes
+  -> independent evaluator runs held-out episodes
+  -> compare task quality, authority, cost, and reliability
+  -> human/policy approval
+  -> canary -> rollout or rollback
+```
+
+Candidate surfaces include prompt assembly, skill routing, memory retrieval,
+context compaction, tool selection, worker topology, and failure recovery.
+Kernel security rules, identity provenance, approval requirements, and audit
+integrity are constraints, never optimization variables.
+
+OpenAI's harness-engineering account reinforces the practical prerequisites:
+repository-local knowledge, agent-legible observability, isolated worktrees,
+mechanically enforced architecture, and feedback loops that turn recurring
+failures into durable capabilities. See [Harness engineering][openai-harness].
+
+## Representative user experiences
+
+### Developer organization
+
+A GitHub worker watches authorized repositories, classifies issues, prepares
+small fixes, and requests review. When several tasks fail on the same internal
+schema check, it records the gap. Forge builds a narrow validation capsule,
+replays the failing cases, and stages it. The organization approves the new
+read scope before activation.
+
+### Personal communications
+
+Separate email and Telegram workers maintain their own platform context but can
+compose through user-granted calendar and memory capsules. They draft freely
+within policy. Sending mail, deleting messages, or inviting attendees crosses
+an approval boundary. Provider credentials never enter model context.
+
+### Storefront operations
+
+A commerce worker monitors orders and support messages, prepares responses, and
+identifies repeated carrier-data failures. Forge can add a read-only carrier
+adapter. Refunds, price changes, and customer-data exports remain separate
+capabilities with explicit approval.
+
+### Local and private operation
+
+A device worker responds to authorized local health events, collects bounded
+diagnostics, and proposes remediation. If a new diagnostic is necessary, it is
+built and tested in a constrained realm before host-process authority is
+considered.
+
+### Harness optimization
+
+A user opts into improvement experiments. Redacted episodes show the email
+worker repeatedly retrieves too much history. A proposer changes retrieval and
+compaction, an independent evaluator runs held-out mailboxes, and AOS rolls out
+only if task quality improves without increasing disclosure, cost, or authority.
+
+## Delivery sequence
+
+This implementation establishes the discoverable foundation:
+
+1. Ship Forge in Community Edition rather than leaving it source-only.
+2. Install the `meta-harness` skill and expose `meta_harness_quickstart`.
+3. Keep the worker/supervisor contract explicit and honest about missing
+   durable spawn support.
+
+The next runtime increment should define a narrow supervisor/worker contract in
+the canonical WIT repository and implement one end-to-end platform (Telegram or
+GitHub) with durable worker state, async approval, and a structured gap ledger.
+The optimization loop should follow only after those traces and evaluations are
+trustworthy.
+
+[codex-harness]: https://openai.com/index/unlocking-the-codex-harness/
+[meta-code]: https://github.com/stanford-iris-lab/meta-harness
+[meta-paper]: https://arxiv.org/abs/2603.28052
+[ms-harness]: https://learn.microsoft.com/en-us/agent-framework/agents/harness
+[omnigent]: https://docs.databricks.com/aws/en/omnigent/
+[openai-harness]: https://openai.com/index/harness-engineering/

--- a/docs/meta-harness.md
+++ b/docs/meta-harness.md
@@ -112,6 +112,14 @@ future reasoning needs them. Turn a repeated workflow or domain-specific method
 into a skill so it becomes available when relevant rather than occupying every
 prompt.
 
+Capsules contribute durable skills by writing valid
+`home://skills/<id>/SKILL.md` files for the principal. The `aos-skills` service
+indexes that directory generically: `list_skills` returns metadata and
+`read_skill` loads the selected workflow. This works for user-authored capsules
+as well as the Community Edition fleet. Host plugins can vendor important
+first-party skills for native startup discovery and offline operation, while
+the AOS index carries skills installed after the plugin was published.
+
 ### Harness code
 
 Improve context construction, retrieval, prompt assembly, planning, tool

--- a/docs/meta-harness.md
+++ b/docs/meta-harness.md
@@ -1,18 +1,25 @@
-# Meta-harness architecture
+# Building a meta-harness on Unicity AOS
 
 ## Decision
 
-Unicity AOS is the user-facing agent harness. Astrid Runtime supplies the
-security and execution substrate beneath it. AOS becomes a meta harness by
-adding a governed control loop that supervises platform-scoped agents and can
-improve its own composition from measured failures.
+Unicity AOS is an operating system for agents. It is not itself a harness.
+Harnesses are user-space systems built and run on AOS from agents, capsules,
+skills, state, models, providers, connectors, and tools. AOS can host harnesses,
+meta-harnesses, and other agent-native software; a workload does not have to be
+a harness to belong on AOS.
 
-Forge is necessary but is not the whole meta harness. Forge is the capability
-construction subsystem. It gives an agent the knowledge and tools to inspect
-contracts, scaffold a capsule, select manifest capabilities, validate the
-manifest, and diagnose the installed artifact. The surrounding control plane
-owns worker lifecycle, gap evidence, evaluation, approval, promotion, audit,
-and rollback.
+Astrid Runtime is the low-level security and execution mechanism pinned and
+distributed by AOS. It routes IPC, enforces capabilities, manages the WASM
+sandbox, meters resources, and audits actions. Unicity AOS is the operating
+system and product environment around that mechanism.
+
+A meta-harness is one kind of user-space harness. It governs other workers or
+harnesses and can improve harness composition from measured failures. Forge is
+OS-provided construction tooling available to user-space workloads. A
+meta-harness can use Forge to inspect contracts, scaffold a capsule, select
+manifest capabilities, validate the manifest, and diagnose an installed
+artifact. Forge is not inherently the meta-harness and does not own worker
+lifecycle, evaluation, approval, promotion, audit, or rollback.
 
 This terminology combines two established uses of “meta-harness”:
 
@@ -27,11 +34,23 @@ This terminology combines two established uses of “meta-harness”:
   agent implementations. [Omnigent][omnigent] is a current example.
 
 Unicity should support heterogeneous models and frontends, but its distinctive
-advantage is stronger: generated capabilities remain ordinary AOS capsules
-behind kernel-enforced identities, manifests, IPC ACLs, budgets, approvals, and
-audit.
+advantage is stronger: a user-space meta-harness can produce capabilities that
+remain ordinary AOS capsules behind kernel-enforced identities, manifests, IPC
+ACLs, budgets, approvals, and audit.
 
 ## System boundary
+
+```text
+Unicity AOS
+|-- Astrid Runtime: kernel security and execution mechanism
+|-- OS services and capsules: identity, sessions, registry, policy
+|-- Forge: general construction tooling
+`-- user space
+    |-- harnesses and meta-harnesses
+    `-- connectors, services, and other agent-native systems
+```
+
+One reference meta-harness running in AOS user space looks like this:
 
 ```text
 Platform API / local event source
@@ -178,8 +197,8 @@ own permissions, or weakening approvals.
 
 ## Harness improvement loop
 
-Once the operational control plane produces trustworthy episode traces, AOS can
-apply the research meaning of Meta-Harness:
+Once the operational control plane produces trustworthy episode traces, a
+meta-harness running on AOS can apply the research meaning of Meta-Harness:
 
 ```text
 baseline harness + episode archive + objective
@@ -236,12 +255,14 @@ considered.
 
 A user opts into improvement experiments. Redacted episodes show the email
 worker repeatedly retrieves too much history. A proposer changes retrieval and
-compaction, an independent evaluator runs held-out mailboxes, and AOS rolls out
-only if task quality improves without increasing disclosure, cost, or authority.
+compaction, an independent evaluator runs held-out mailboxes, and the
+meta-harness asks AOS to roll out only if task quality improves without
+increasing disclosure, cost, or authority.
 
 ## Delivery sequence
 
-This implementation establishes the discoverable foundation:
+This implementation establishes the discoverable foundation for building a
+meta-harness on AOS. It does not turn AOS into one:
 
 1. Ship Forge in Community Edition rather than leaving it source-only.
 2. Install the `meta-harness` skill and expose `meta_harness_quickstart`.

--- a/release/community-capsules.txt
+++ b/release/community-capsules.txt
@@ -17,6 +17,7 @@ capsule-shell
 capsule-http
 capsule-fs
 capsule-system
+capsule-forge
 capsule-skills
 capsule-agents
 capsule-memory

--- a/scripts/test-clean-home-init.sh
+++ b/scripts/test-clean-home-init.sh
@@ -94,8 +94,8 @@ expected = sorted(
     for line in assets_path.read_text(encoding="utf-8").splitlines()
     if line
 )
-if len(expected) != 18 or len(set(expected)) != 18:
-    raise SystemExit("release capsule inventory is not the exact 18-capsule CE set")
+if len(expected) != 19 or len(set(expected)) != 19:
+    raise SystemExit("release capsule inventory is not the exact 19-capsule CE set")
 with lock_path.open("rb") as file:
     lock = tomllib.load(file)
 with profile_path.open("rb") as file:

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -251,7 +251,7 @@ release_dir="$work/home/.aos/releases/2026.1.1"
 test -f "$release_dir/release-manifest.json"
 test -f "$release_dir/Distro.toml"
 test -f "$release_dir/capsule-assets.txt"
-test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 18
+test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 19
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"
@@ -608,7 +608,7 @@ for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
   test "$("$destination")" = "old-$binary"
 done
 test "$(cat "$release_dir/release-manifest.json")" = old-release-manifest
-test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 18
+test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 19
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -69,7 +69,7 @@ tar -tzf "$archive" > "$work/files"
 grep -q '/bin/aos$' "$work/files"
 grep -q '/libexec/install.sh$' "$work/files"
 grep -q '/runtime/bin/astrid-daemon$' "$work/files"
-test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 18
+test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 19
 grep -q '/capsule-assets.txt$' "$work/files"
 grep -q '/Distro.toml$' "$work/files"
 grep -q '/release-manifest.json$' "$work/files"
@@ -77,7 +77,7 @@ grep -q '/release-manifest.json$' "$work/files"
 tar -xzf "$archive" -C "$work"
 manifest=$(find "$work" -path '*/release-manifest.json' -print -quit)
 bundle_root=$(dirname "$manifest")
-test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 18
+test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 19
 if grep -F '@unicity-aos/capsule-' "$bundle_root/Distro.toml" >/dev/null; then
   echo "release archive retained a legacy capsule repository source" >&2
   exit 1
@@ -99,9 +99,9 @@ assert manifest["contracts"]["repository"] == "astrid-runtime/wit"
 assert manifest["contracts"]["commit"] == "278dbca3e32f327d0f2358644fc86559779ba0fd"
 assert manifest["contracts"]["sdk_rust_version"] == "0.7.1"
 assert manifest["contracts"]["sdk_rust_commit"] == "bbbc61c8821d6c536fb25d2068b6b646e759ad35"
-assert manifest["capsules"]["count"] == 18
-assert len(manifest["capsules"]["assets"]) == 18
-assert len(set(manifest["capsules"]["assets"])) == 18
+assert manifest["capsules"]["count"] == 19
+assert len(manifest["capsules"]["assets"]) == 19
+assert len(set(manifest["capsules"]["assets"])) == 19
 PY
 
 unsafe_root="$work/unsafe-runtime"

--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -85,13 +85,15 @@ class CapsuleReleaseTests(unittest.TestCase):
             write_fixture(directory / spec.asset, spec)
 
     def test_source_contract_has_exact_community_set(self) -> None:
-        self.assertEqual(len(self.specs), 18)
-        self.assertEqual(len({spec.asset for spec in self.specs}), 18)
-        self.assertNotIn("aos-telegram.capsule", {spec.asset for spec in self.specs})
+        self.assertEqual(len(self.specs), 19)
+        self.assertEqual(len({spec.asset for spec in self.specs}), 19)
+        assets = {spec.asset for spec in self.specs}
+        self.assertIn("aos-forge.capsule", assets)
+        self.assertNotIn("aos-telegram.capsule", assets)
         distro = Path(__file__).resolve().parent.parent / "distros/community/unicity-ce/Distro.toml"
         text = distro.read_text(encoding="utf-8")
         self.assertNotIn("@unicity-aos/", text)
-        self.assertEqual(text.count('source = "capsules/'), 18)
+        self.assertEqual(text.count('source = "capsules/'), 19)
         for spec in self.specs:
             self.assertIn(f'source = "capsules/{spec.asset}"', text)
 

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -113,7 +113,7 @@ class ReleasePublicationTests(unittest.TestCase):
             artifacts, compatibility = self.fixture(Path(temp))
             payloads = self.validate(artifacts, compatibility)
             self.assertIn(f"unicity-aos-{VERSION}-release.toml", payloads)
-            self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 18)
+            self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 19)
 
     def test_rejects_missing_asset(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## What changed

- add `aos-forge` to the Community Edition capsule set
- teach Forge to bootstrap a meta harness that can inspect outcomes and construct governed user-space capabilities
- add the generic `aos-skills` discovery contract for skills contributed by any installed capsule
- document proactive, agent-directed world extension without assuming subagents or forcing mid-session construction
- add release, clean-home, package, and capsule validation for the new product surface

## Why

AOS is an operating system for agents. Agents need a durable way to discover and construct capabilities inside their governed principal environment, while the kernel continues to enforce real authority through capsule grants and policy. Forge is the first construction service; the skill registry is deliberately generic so future user-installed capsules can contribute skills without rebuilding AOS or mutating a host plugin.

## User impact

Fresh agents receive enough context to understand AOS, decide when a missing capability is worth constructing, and use Forge to extend their own working world. Users can install other capsules that write valid principal-scoped skills and have those skills discovered through the same interface.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p aos-forge --target aarch64-apple-darwin`
- `cargo test --locked -p aos-skills --target aarch64-apple-darwin`
- `cargo clippy --locked -p aos-forge --target wasm32-unknown-unknown -- -D warnings`
- `python3 scripts/test_capsule_release.py`
- Codex skill manifest validation for the Forge and meta-harness skills

Release versioning and runtime compatibility updates are intentionally excluded and will be handled as release-only changes after merge.
