### PR TITLE
feat(skills): discover installed capsule declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
   tools, capsules, traces, and evaluations as an improvable world. Agents reach
   for Forge proactively when real work reveals a useful new capability, while
   optional workers remain a use-case choice rather than a prerequisite.
+- Generic capsule-contributed Skill discovery from installed `[[skill]]`
+  declarations. Workspace and principal-home Skills remain higher-priority
+  overrides, while Forge and System ship declarative assets instead of relying
+  on one-shot install-hook writes. Closes #43.
 - Homebrew formula updates initiated by the tap's authenticated stable-release
   poll, eliminating the cross-repository dispatch credential.
 - Strict, signed stable/dev/nightly channel and immutable release metadata

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "astrid-sdk 0.7.1",
  "serde",
  "serde_json",
+ "toml",
 ]
 
 [[package]]

--- a/capsules/capsule-forge/Capsule.toml
+++ b/capsules/capsule-forge/Capsule.toml
@@ -12,7 +12,16 @@ type = "executable"
 
 [capabilities]
 fs_read  = ["home://"]
-fs_write = ["home://skills/"]
+
+[[skill]]
+name = "capsule-forge"
+description = "Build and diagnose current Unicity AOS capsules and harnesses"
+file = "src/skills/capsule-forge/SKILL.md"
+
+[[skill]]
+name = "meta-harness"
+description = "Proactively improve an agent's user-space world on Unicity AOS"
+file = "src/skills/meta-harness/SKILL.md"
 
 # Publish ACL: the [publish] keys are the only IPC-publish declaration.
 # These two are the mandatory tool-bus boilerplate — without them tool

--- a/capsules/capsule-forge/src/lib.rs
+++ b/capsules/capsule-forge/src/lib.rs
@@ -37,14 +37,6 @@ const CAPSULES_DIR: &str = "home://.local/capsules";
 /// Standard WIT interface directory — per-principal, accessible via `home://wit/`.
 const WIT_DIR: &str = "home://wit";
 
-/// Skill installed to `home://skills/capsule-forge/SKILL.md` on install.
-/// Named `capsule-forge` (not `capsule-development`) to avoid colliding with
-/// the skill the system capsule already ships.
-const CAPSULE_FORGE_SKILL: &str = include_str!("skills/capsule-forge/SKILL.md");
-
-/// Skill installed to `home://skills/meta-harness/SKILL.md` on install.
-const META_HARNESS_SKILL: &str = include_str!("skills/meta-harness/SKILL.md");
-
 /// Inline quickstart returned by `forge_quickstart` — the condensed front door.
 const QUICKSTART_MD: &str = include_str!("quickstart.md");
 
@@ -141,26 +133,6 @@ fn list_entries(path: &str) -> Result<Vec<String>, SysError> {
 
 #[capsule]
 impl ForgeTools {
-    /// Write the Forge and meta-harness Skills under `home://skills/` so the
-    /// skills capsule can surface them to the LLM.
-    #[astrid::install]
-    pub fn on_install(&self) -> Result<(), SysError> {
-        // home:// may be unavailable during lifecycle dispatch when installing
-        // without a running daemon; ignore host errors so the skill is written
-        // on the next full boot once the principal home is mounted.
-        let _ = astrid_sdk::fs::create_dir_all("home://skills/capsule-forge");
-        let _ = astrid_sdk::fs::write(
-            "home://skills/capsule-forge/SKILL.md",
-            CAPSULE_FORGE_SKILL.as_bytes(),
-        );
-        let _ = astrid_sdk::fs::create_dir_all("home://skills/meta-harness");
-        let _ = astrid_sdk::fs::write(
-            "home://skills/meta-harness/SKILL.md",
-            META_HARNESS_SKILL.as_bytes(),
-        );
-        Ok(())
-    }
-
     /// Get the build-your-first-capsule guide: the minimal file set, the
     /// build→install→verify loop, and the top footguns. Start here.
     #[astrid::tool("forge_quickstart")]
@@ -357,8 +329,11 @@ fn suggest_from_intent(intent: &str) -> Vec<Value> {
         ));
     }
     if any(&["write file", "write files", "save file", "write to disk"]) {
-        out.push(cap("write files", "[capabilities]\nfs_write = [\"home://data/\"]",
-            "Write under a narrow prefix. fs_write to home://skills/ is how a capsule ships a Skill."));
+        out.push(cap(
+            "write files",
+            "[capabilities]\nfs_write = [\"home://data/\"]",
+            "Write under the narrowest prefix that contains the capsule's mutable data.",
+        ));
     }
     if any(&[
         "http",
@@ -533,7 +508,9 @@ fn collect_export_keys(map: &serde_json::Map<String, Value>, out: &mut Vec<Strin
 
 #[cfg(test)]
 mod tests {
-    use super::{META_HARNESS_QUICKSTART_MD, META_HARNESS_SKILL};
+    use super::META_HARNESS_QUICKSTART_MD;
+
+    const META_HARNESS_SKILL: &str = include_str!("skills/meta-harness/SKILL.md");
 
     #[test]
     fn meta_harness_bootstrap_teaches_proactive_world_extension() {

--- a/capsules/capsule-forge/src/quickstart.md
+++ b/capsules/capsule-forge/src/quickstart.md
@@ -119,8 +119,9 @@ aos status                                      # confirm the daemon is healthy
 3. **No checked-in `wit/`** — the WIT is generated at build time.
 4. **Install via `aos capsule install`**, never hand-copy the `.wasm` — install is
    content-addressed.
-5. **A Skill needs an `#[astrid::install]` hook** (`include_str!` + `fs::write`) to land;
-   the static engine is a no-op.
+5. **Declare shipped Skills with `[[skill]]`** and a relative file path. The
+   builder packages the asset and AOS indexes it from the installed capsule;
+   do not copy it from an install hook.
 6. **No hot-reload** — rebuild and reinstall to iterate.
 7. **`tool_describe` must publish, not return** — handled for you by depending on
    `astrid-sdk = "0.7"` (0.7.1+). If a tool is in the manifest but the model can't see it,

--- a/capsules/capsule-forge/src/skills/capsule-forge/SKILL.md
+++ b/capsules/capsule-forge/src/skills/capsule-forge/SKILL.md
@@ -580,9 +580,9 @@ vs. shared from operator action. (The forge `validate_manifest` warns if you try
 - `[[command]]` — slash-command registrations.
 - `[[mcp_server]]` — stdio MCP servers (the "airlock override"; `command` must be
   in `host_process`; this breaks out of the WASM sandbox into a host process).
-- `[[skill]]` — Skills the capsule contributes. **Note:** the StaticEngine that
-  would place these is currently a no-op — to actually land a Skill, write it from
-  an `#[astrid::install]` hook (footgun 5).
+- `[[skill]]` — Skills the capsule contributes. Set `name`, `description`, and a
+  relative `file` path. `astrid capsule build` packages the declared file, and
+  the AOS Skills index discovers it from installed capsule introspection.
 - `[[context_file]]`, `[[uplink]]`, `[[tool]]`, `[[topic]]` (legacy).
 
 ---
@@ -602,7 +602,7 @@ some take a **bool**. Getting this wrong is a parse/semantics error.
 | `net_bind` | **list** | Bind a listening socket. `["unix:*"]`. Rare. |
 | `kv` | **list** | Reserved (declared, NOT yet gate-enforced). Per-capsule KV already works without it (auto-scoped per capsule + principal). Use `kv = []` or omit. |
 | `fs_read` | **list** | Read under the given VFS prefixes. `["home://"]`. |
-| `fs_write` | **list** | Write under the given prefixes. `["home://skills/"]`. |
+| `fs_write` | **list** | Write mutable data under the given prefixes. Prefer a capsule-specific path such as `["home://data/my-capsule/"]`. |
 | `host_process` | **list** | Spawn the named host binaries via `process`. `["git", "cargo"]`. The "airlock override". |
 | `allow_persistent` | **bool** | Operator sub-grant on top of `host_process`: allow persistent (instance-outliving) child processes. |
 | `identity` | **list** | Identity ops. Values: `"resolve"` < `"link"` < `"admin"` (each implies the lesser). `["resolve"]`. |
@@ -773,11 +773,11 @@ ask the LLM to call the tool    # verify behaviour
    `aos capsule install ./dist/<name>.capsule`. **Do not** hand-copy the
    `.wasm` into the runtime home — install records a BLAKE3 hash in `meta.json`, and a
    capsule whose binary doesn't match (or wasn't installed this way) fails to load.
-5. **A Skill needs an `#[astrid::install]` hook to land.** The StaticEngine that
-   would place `[[skill]]` files is a no-op stub. If your capsule ships a Skill,
-   `include_str!` it into a `const` and `fs::write` it to
-   `home://skills/<name>/SKILL.md` from an `#[astrid::install]` hook (create the
-   dir first with `create_dir_all`). Otherwise the file never appears.
+5. **Declare every shipped Skill.** Put the `SKILL.md` inside the capsule source
+   tree and reference it with `[[skill]] name`, `description`, and `file`.
+   Current `astrid capsule build` packages that asset; AOS discovers it from the
+   installed capsule mirror. Do not copy shipped Skills from an install hook or
+   request `fs_write` merely for distribution.
 6. **`tool_describe` must publish, not return** — covered by depending on
    `astrid-sdk = "0.7"` (0.7.1+). The macro does it right; don't hand-roll describe.
 7. **Empty `[publish]`/`[subscribe]` = silent muteness.** Fail-closed means no

--- a/capsules/capsule-forge/src/skills/meta-harness/SKILL.md
+++ b/capsules/capsule-forge/src/skills/meta-harness/SKILL.md
@@ -58,8 +58,9 @@ from names alone.
 When `list_skills` is available, call it with `dir_path` set to `skills` to
 discover workflows contributed by any installed capsule. Load a relevant entry
 with `read_skill` using the same directory and its skill ID. This is the dynamic
-AOS skill path: the skill remains durable in the principal's `home://skills/`
-across sessions without requiring a host-plugin release. Reading it supplies
+AOS skill path: user overrides remain in workspace or `home://skills/`, while
+capsule-shipped workflows remain durable in the installed capsule mirror across
+sessions without requiring a host-plugin release. Reading a Skill supplies
 instructions; capsule grants and AOS policy still supply authority.
 
 Tool availability is part of the world. Discover it. If an AOS surface is not
@@ -133,10 +134,11 @@ When the user approves a standing preference such as “think broadly and improv
 your setup when useful” or “bring me proposals,” preserve that instruction in
 the available principal-scoped memory or configuration.
 
-A capsule that contributes a valid `home://skills/<id>/SKILL.md` joins the same
-skills index as first-party capsules. Host plugins may also vendor important
-skills for native startup discovery and offline use, but that snapshot is a
-distribution adapter rather than the only durable copy.
+A capsule that ships a valid `[[skill]]` declaration joins the same Skills index
+as first-party capsules. Workspace and principal-home entries can override its
+global skill ID. Host plugins may also vendor important Skills for native
+startup discovery and offline use, but that snapshot is a distribution adapter
+rather than the only durable copy.
 
 Memory carries intent and continuity. AOS capabilities carry operational
 authority. Together they let the agent remain itself across sessions while

--- a/capsules/capsule-skills/Cargo.toml
+++ b/capsules/capsule-skills/Cargo.toml
@@ -12,3 +12,4 @@ crate-type = ["cdylib"]
 astrid-sdk = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }

--- a/capsules/capsule-skills/README.md
+++ b/capsules/capsule-skills/README.md
@@ -6,21 +6,22 @@
 **The skills loader for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
 
 In the OS model, this capsule is the principal's skills index. It discovers
-skill definitions from the workspace and principal-scoped AOS home so the agent
-can load workflows contributed before or after its host plugin was published.
-Any installed capsule with a narrow `fs_write = ["home://skills/"]` grant can
-contribute `home://skills/<id>/SKILL.md`; the index is generic rather than tied
-to a first-party capsule.
+skill definitions from the workspace, principal-scoped AOS home, and
+`[[skill]]` declarations in installed capsule mirrors so the agent can load
+workflows contributed before or after its host plugin was published. The index
+is generic rather than tied to a first-party capsule.
 
 ## Tools
 
 **`list_skills`** - Scans a directory for skill subdirectories containing
-`SKILL.md` files. Searches the workspace first (takes priority on duplicate
-IDs), then the principal's `home://` directory. Returns a JSON array of skill
-ID, name, and description.
+`SKILL.md` files. Searches the workspace first, then the principal's `home://`
+directory. For `dir_path: "skills"`, it then indexes declarations from
+`home://.local/capsules/*/Capsule.toml`. Returns a JSON array of skill ID, name,
+and description.
 
 **`read_skill`** - Reads the `SKILL.md` content for a specific skill ID. Checks
-the workspace first, then falls back to the principal's AOS home.
+the workspace first, then falls back to the principal's AOS home and the exact
+installed capsule declaration selected by the list operation.
 
 ## SKILL.md format
 
@@ -45,6 +46,9 @@ The frontmatter parser extracts `name` and `description` fields. It is not a gen
 - **Workspace wins:** If a workspace skill ID exists (even with broken
   frontmatter), the home version is blocked. This prevents a durable home skill
   from shadowing a workspace override.
+- **Declarative assets:** Capsule names, skill IDs, and relative asset paths are
+  validated before reading a declared Skill. Capsule declarations have lower
+  priority than workspace and principal-home Skills.
 
 ## Development
 

--- a/capsules/capsule-skills/src/lib.rs
+++ b/capsules/capsule-skills/src/lib.rs
@@ -10,6 +10,13 @@ use serde::{Deserialize, Serialize};
 /// URI scheme prefix for the principal's home directory.
 const HOME_SCHEME: &str = "home://";
 
+/// Installed-capsule introspection tree materialized for this principal.
+const CAPSULES_DIR: &str = "home://.local/capsules";
+
+/// The standard AOS skill index. Capsule declarations join this index, while
+/// callers using a custom directory retain directory-only behavior.
+const AOS_SKILLS_DIR: &str = "skills";
+
 #[derive(Default)]
 pub struct SkillsLoader;
 
@@ -30,12 +37,31 @@ struct SkillInfo {
     description: String,
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct CapsuleSkillManifest {
+    #[serde(default, rename = "skill")]
+    skills: Vec<CapsuleSkillDef>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CapsuleSkillDef {
+    name: String,
+    file: String,
+}
+
+#[derive(Debug, PartialEq)]
+struct DeclaredCapsuleSkill {
+    id: String,
+    path: String,
+}
+
 #[derive(Debug, Default, Deserialize, astrid_sdk::schemars::JsonSchema)]
 pub struct ListSkillsArgs {
     /// Directory containing the skills (e.g., ".gemini/skills").
     /// The capsule will search both the workspace and the principal's
-    /// home (`home://`) directory, merging results (workspace wins on
-    /// duplicate skill IDs).
+    /// home (`home://`) directory. The standard `skills` index also includes
+    /// skills declared by installed capsules. Earlier sources win duplicate
+    /// skill IDs.
     pub dir_path: String,
 }
 
@@ -43,7 +69,8 @@ pub struct ListSkillsArgs {
 pub struct ReadSkillArgs {
     /// Directory containing the skills (e.g., ".gemini/skills").
     /// The capsule checks the workspace first, then falls back to
-    /// the principal's home (`home://`) directory.
+    /// the principal's home (`home://`) directory. The standard `skills`
+    /// index then falls back to installed capsule declarations.
     pub dir_path: String,
     /// The ID/folder name of the skill to read
     pub skill_id: String,
@@ -53,13 +80,15 @@ pub struct ReadSkillArgs {
 ///
 /// Skills are reusable prompt templates stored as SKILL.md files with YAML
 /// frontmatter (name, description). They live in workspace or home
-/// directories and are merged with workspace taking priority.
+/// directories, or are declared by installed capsules. User-controlled
+/// workspace and principal-home sources take priority.
 #[capsule]
 impl SkillsLoader {
     /// List all available skills in a directory. Scans both the workspace and
-    /// home (`~/.astrid/home/{principal}/`) directories, merging results.
-    /// Returns a JSON array of `{id, name, description}` objects. Workspace
-    /// skills take priority over home skills with the same ID.
+    /// home (`~/.astrid/home/{principal}/`) directories, then installed
+    /// capsule declarations for the standard `skills` index. Returns a JSON
+    /// array of `{id, name, description}` objects. Precedence is workspace,
+    /// principal home, then installed capsule.
     #[astrid::tool("list_skills")]
     pub fn list_skills(&self, args: ListSkillsArgs) -> Result<String, SysError> {
         let bare_dir = bare_path(validate_dir_path(&args.dir_path)?);
@@ -74,13 +103,27 @@ impl SkillsLoader {
         let home_dir = format!("{HOME_SCHEME}{bare_dir}");
         collect_skills_from(&home_dir, &mut skills, &mut seen_ids);
 
+        if bare_dir == AOS_SKILLS_DIR {
+            match collect_declared_capsule_skills() {
+                Ok(declared) => {
+                    collect_declared_skill_info(declared, &mut skills, &mut seen_ids);
+                }
+                Err(error) => log::warn(format!(
+                    "failed to scan installed capsule skills: {error:?}"
+                )),
+            }
+        }
+
+        skills.sort_by(|left, right| left.id.cmp(&right.id));
+
         let json = serde_json::to_string(&skills)?;
         Ok(json)
     }
 
     /// Read the full content of a specific skill by its ID. Returns the raw
     /// SKILL.md content including frontmatter. Checks the workspace directory
-    /// first, then falls back to the home directory.
+    /// first, then the principal home, then an installed capsule declaration
+    /// for the standard `skills` index.
     #[astrid::tool("read_skill")]
     pub fn read_skill(&self, args: ReadSkillArgs) -> Result<String, SysError> {
         let bare_dir = bare_path(validate_dir_path(&args.dir_path)?);
@@ -104,15 +147,36 @@ impl SkillsLoader {
         let home_skill_path =
             resolve_skill_path(&format!("{HOME_SCHEME}{bare_dir}"), &args.skill_id)?;
         match read_file_string(&home_skill_path) {
-            Ok(content) => Ok(content),
-            Err(e) => {
-                log::warn(format!("failed to read skill '{}': {:?}", args.skill_id, e));
-                Err(SysError::ApiError(format!(
-                    "Skill '{}' could not be read",
+            Ok(content) => return Ok(content),
+            Err(wit_fs::ErrorCode::NotFound) => {}
+            Err(error) => {
+                return Err(SysError::ApiError(format!(
+                    "Failed to read skill '{}' from principal home: {error:?}",
                     args.skill_id
-                )))
+                )));
             }
         }
+
+        if bare_dir == AOS_SKILLS_DIR {
+            let declared = collect_declared_capsule_skills().map_err(|error| {
+                SysError::ApiError(format!(
+                    "Failed to scan installed capsule skills: {error:?}"
+                ))
+            })?;
+            if let Some(skill) = declared.iter().find(|skill| skill.id == args.skill_id) {
+                return read_file_string(&skill.path).map_err(|error| {
+                    SysError::ApiError(format!(
+                        "Failed to read declared skill '{}' from '{}': {error:?}",
+                        args.skill_id, skill.path
+                    ))
+                });
+            }
+        }
+
+        Err(SysError::ApiError(format!(
+            "Skill '{}' could not be read",
+            args.skill_id
+        )))
     }
 }
 
@@ -218,6 +282,122 @@ fn collect_skills_from(
             } else {
                 log::warn(format!("skipping {dir}/{name}: invalid frontmatter"));
             }
+        }
+    }
+}
+
+/// Discover `[[skill]]` entries in the installed capsule mirrors.
+///
+/// Capsule manifests are untrusted input even after installation. Capsule
+/// names, global skill IDs, and asset paths are validated before constructing
+/// a VFS path. Capsule order is sorted and the first declaration owns a
+/// duplicate ID, making list/read resolution deterministic.
+fn collect_declared_capsule_skills() -> Result<Vec<DeclaredCapsuleSkill>, wit_fs::ErrorCode> {
+    let mut capsule_names = match wit_fs::fs_readdir(CAPSULES_DIR) {
+        Ok(names) => names,
+        Err(wit_fs::ErrorCode::NotFound) => return Ok(Vec::new()),
+        Err(error) => return Err(error),
+    };
+    capsule_names.sort();
+
+    let mut declared = Vec::new();
+    let mut seen_ids = std::collections::HashSet::new();
+    for capsule_name in capsule_names {
+        if !is_safe_name(&capsule_name) {
+            log::warn(format!(
+                "skipping unsafe capsule introspection entry: {capsule_name:?}"
+            ));
+            continue;
+        }
+        let manifest_path = format!("{CAPSULES_DIR}/{capsule_name}/Capsule.toml");
+        let manifest = match read_file_string(&manifest_path) {
+            Ok(content) => content,
+            Err(wit_fs::ErrorCode::NotFound) => continue,
+            Err(error) => {
+                log::warn(format!("failed to read {manifest_path}: {error:?}"));
+                continue;
+            }
+        };
+        let Some(skills) = declared_skills_from_manifest(&capsule_name, &manifest) else {
+            log::warn(format!(
+                "skipping invalid skill declarations in {manifest_path}"
+            ));
+            continue;
+        };
+        for skill in skills {
+            if seen_ids.insert(skill.id.clone()) {
+                declared.push(skill);
+            } else {
+                log::warn(format!(
+                    "ignoring duplicate capsule-declared skill ID {:?}",
+                    skill.id
+                ));
+            }
+        }
+    }
+    Ok(declared)
+}
+
+/// Parse and validate a single installed capsule's skill declarations.
+fn declared_skills_from_manifest(
+    capsule_name: &str,
+    manifest: &str,
+) -> Option<Vec<DeclaredCapsuleSkill>> {
+    if !is_safe_name(capsule_name) {
+        return None;
+    }
+    let manifest: CapsuleSkillManifest = toml::from_str(manifest).ok()?;
+    let mut declared = Vec::new();
+    for skill in manifest.skills {
+        if !is_safe_name(&skill.name) || !is_safe_declared_file(&skill.file) {
+            return None;
+        }
+        declared.push(DeclaredCapsuleSkill {
+            id: skill.name,
+            path: format!("{CAPSULES_DIR}/{capsule_name}/{}", skill.file),
+        });
+    }
+    Some(declared)
+}
+
+/// A declared asset path must be a non-empty relative slash-separated path.
+fn is_safe_declared_file(path: &str) -> bool {
+    !path.is_empty()
+        && !path.starts_with('/')
+        && !path.contains('\0')
+        && !path.contains('\\')
+        && !path.contains("://")
+        && path
+            .split('/')
+            .all(|component| !component.is_empty() && component != "." && component != "..")
+}
+
+/// Append capsule-declared Skills after the caller's override layers.
+fn collect_declared_skill_info(
+    declared: Vec<DeclaredCapsuleSkill>,
+    skills: &mut Vec<SkillInfo>,
+    seen_ids: &mut std::collections::HashSet<String>,
+) {
+    for skill in declared {
+        if !seen_ids.insert(skill.id.clone()) {
+            continue;
+        }
+        match read_file_string(&skill.path) {
+            Ok(content) => {
+                if let Some(frontmatter) = parse_frontmatter(&content) {
+                    skills.push(SkillInfo {
+                        id: skill.id,
+                        name: frontmatter.name,
+                        description: frontmatter.description,
+                    });
+                } else {
+                    log::warn(format!(
+                        "skipping {}: invalid skill frontmatter",
+                        skill.path
+                    ));
+                }
+            }
+            Err(error) => log::warn(format!("failed to read {}: {error:?}", skill.path)),
         }
     }
 }
@@ -407,5 +587,53 @@ mod tests {
     fn test_resolve_skill_path_with_home_prefix() {
         let path = resolve_skill_path("home://skills", "my-skill").unwrap();
         assert_eq!(path, "home://skills/my-skill/SKILL.md");
+    }
+
+    #[test]
+    fn test_declared_skills_from_manifest() {
+        let manifest = r#"
+            [package]
+            name = "aos-forge"
+            version = "0.1.0"
+
+            [[skill]]
+            name = "capsule-forge"
+            description = "Build capsules"
+            file = "src/skills/capsule-forge/SKILL.md"
+
+            [[skill]]
+            name = "meta-harness"
+            file = "src/skills/meta-harness/SKILL.md"
+        "#;
+
+        assert_eq!(
+            declared_skills_from_manifest("aos-forge", manifest),
+            Some(vec![
+                DeclaredCapsuleSkill {
+                    id: "capsule-forge".into(),
+                    path: "home://.local/capsules/aos-forge/src/skills/capsule-forge/SKILL.md"
+                        .into(),
+                },
+                DeclaredCapsuleSkill {
+                    id: "meta-harness".into(),
+                    path: "home://.local/capsules/aos-forge/src/skills/meta-harness/SKILL.md"
+                        .into(),
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn test_declared_skill_manifest_rejects_unsafe_paths_and_ids() {
+        for manifest in [
+            "[[skill]]\nname = \"../escape\"\nfile = \"skills/ok/SKILL.md\"\n",
+            "[[skill]]\nname = \"safe\"\nfile = \"../escape/SKILL.md\"\n",
+            "[[skill]]\nname = \"safe\"\nfile = \"/absolute/SKILL.md\"\n",
+            "[[skill]]\nname = \"safe\"\nfile = \"skills\\\\escape\\\\SKILL.md\"\n",
+            "[[skill]]\nname = \"safe\"\nfile = \"https://example.com/SKILL.md\"\n",
+        ] {
+            assert!(declared_skills_from_manifest("capsule", manifest).is_none());
+        }
+        assert!(declared_skills_from_manifest("../capsule", "").is_none());
     }
 }

--- a/capsules/capsule-skills/src/lib.rs
+++ b/capsules/capsule-skills/src/lib.rs
@@ -163,13 +163,10 @@ impl SkillsLoader {
                     "Failed to scan installed capsule skills: {error:?}"
                 ))
             })?;
-            if let Some(skill) = declared.iter().find(|skill| skill.id == args.skill_id) {
-                return read_file_string(&skill.path).map_err(|error| {
-                    SysError::ApiError(format!(
-                        "Failed to read declared skill '{}' from '{}': {error:?}",
-                        args.skill_id, skill.path
-                    ))
-                });
+            for skill in declared.iter().filter(|skill| skill.id == args.skill_id) {
+                if let Some((content, _)) = read_valid_declared_skill(skill) {
+                    return Ok(content);
+                }
             }
         }
 
@@ -290,8 +287,9 @@ fn collect_skills_from(
 ///
 /// Capsule manifests are untrusted input even after installation. Capsule
 /// names, global skill IDs, and asset paths are validated before constructing
-/// a VFS path. Capsule order is sorted and the first declaration owns a
-/// duplicate ID, making list/read resolution deterministic.
+/// a VFS path. Capsule order is sorted; duplicate declarations are retained so
+/// list/read resolution can select the first declaration whose asset is
+/// readable and has valid frontmatter.
 fn collect_declared_capsule_skills() -> Result<Vec<DeclaredCapsuleSkill>, wit_fs::ErrorCode> {
     let mut capsule_names = match wit_fs::fs_readdir(CAPSULES_DIR) {
         Ok(names) => names,
@@ -301,7 +299,6 @@ fn collect_declared_capsule_skills() -> Result<Vec<DeclaredCapsuleSkill>, wit_fs
     capsule_names.sort();
 
     let mut declared = Vec::new();
-    let mut seen_ids = std::collections::HashSet::new();
     for capsule_name in capsule_names {
         if !is_safe_name(&capsule_name) {
             log::warn(format!(
@@ -324,16 +321,7 @@ fn collect_declared_capsule_skills() -> Result<Vec<DeclaredCapsuleSkill>, wit_fs
             ));
             continue;
         };
-        for skill in skills {
-            if seen_ids.insert(skill.id.clone()) {
-                declared.push(skill);
-            } else {
-                log::warn(format!(
-                    "ignoring duplicate capsule-declared skill ID {:?}",
-                    skill.id
-                ));
-            }
-        }
+        declared.extend(skills);
     }
     Ok(declared)
 }
@@ -378,26 +366,50 @@ fn collect_declared_skill_info(
     skills: &mut Vec<SkillInfo>,
     seen_ids: &mut std::collections::HashSet<String>,
 ) {
+    collect_declared_skill_info_with(declared, skills, seen_ids, read_valid_declared_skill);
+}
+
+fn collect_declared_skill_info_with<F>(
+    declared: Vec<DeclaredCapsuleSkill>,
+    skills: &mut Vec<SkillInfo>,
+    seen_ids: &mut std::collections::HashSet<String>,
+    mut load: F,
+) where
+    F: FnMut(&DeclaredCapsuleSkill) -> Option<(String, SkillFrontmatter)>,
+{
     for skill in declared {
-        if !seen_ids.insert(skill.id.clone()) {
+        if seen_ids.contains(&skill.id) {
             continue;
         }
-        match read_file_string(&skill.path) {
-            Ok(content) => {
-                if let Some(frontmatter) = parse_frontmatter(&content) {
-                    skills.push(SkillInfo {
-                        id: skill.id,
-                        name: frontmatter.name,
-                        description: frontmatter.description,
-                    });
-                } else {
-                    log::warn(format!(
-                        "skipping {}: invalid skill frontmatter",
-                        skill.path
-                    ));
-                }
+        if let Some((_, frontmatter)) = load(&skill) {
+            seen_ids.insert(skill.id.clone());
+            skills.push(SkillInfo {
+                id: skill.id,
+                name: frontmatter.name,
+                description: frontmatter.description,
+            });
+        }
+    }
+}
+
+/// Load a declared skill asset and require valid frontmatter before it can
+/// claim its global ID. A broken declaration therefore cannot shadow a later
+/// valid declaration from another installed capsule.
+fn read_valid_declared_skill(skill: &DeclaredCapsuleSkill) -> Option<(String, SkillFrontmatter)> {
+    match read_file_string(&skill.path) {
+        Ok(content) => match parse_frontmatter(&content) {
+            Some(frontmatter) => Some((content, frontmatter)),
+            None => {
+                log::warn(format!(
+                    "skipping {}: invalid skill frontmatter",
+                    skill.path
+                ));
+                None
             }
-            Err(error) => log::warn(format!("failed to read {}: {error:?}", skill.path)),
+        },
+        Err(error) => {
+            log::warn(format!("failed to read {}: {error:?}", skill.path));
+            None
         }
     }
 }
@@ -635,5 +647,38 @@ mod tests {
             assert!(declared_skills_from_manifest("capsule", manifest).is_none());
         }
         assert!(declared_skills_from_manifest("../capsule", "").is_none());
+    }
+
+    #[test]
+    fn broken_declaration_does_not_claim_duplicate_skill_id() {
+        let declared = vec![
+            DeclaredCapsuleSkill {
+                id: "shared-skill".into(),
+                path: "first/SKILL.md".into(),
+            },
+            DeclaredCapsuleSkill {
+                id: "shared-skill".into(),
+                path: "second/SKILL.md".into(),
+            },
+        ];
+        let mut skills = Vec::new();
+        let mut seen_ids = std::collections::HashSet::new();
+
+        collect_declared_skill_info_with(declared, &mut skills, &mut seen_ids, |skill| {
+            (skill.path == "second/SKILL.md").then(|| {
+                (
+                    "valid content".into(),
+                    SkillFrontmatter {
+                        name: "Shared Skill".into(),
+                        description: "Loaded from the later valid declaration".into(),
+                    },
+                )
+            })
+        });
+
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].id, "shared-skill");
+        assert_eq!(skills[0].name, "Shared Skill");
+        assert!(seen_ids.contains("shared-skill"));
     }
 }

--- a/capsules/capsule-system/Capsule.toml
+++ b/capsules/capsule-system/Capsule.toml
@@ -12,7 +12,11 @@ type = "executable"
 
 [capabilities]
 fs_read  = ["home://"]
-fs_write = ["home://skills/"]
+
+[[skill]]
+name = "capsule-development"
+description = "Build, test, package, install, and debug a current Unicity AOS capsule"
+file = "src/skills/capsule-development/SKILL.md"
 
 # Publish ACL: the [publish] keys are the only IPC-publish declaration.
 [publish]

--- a/capsules/capsule-system/src/lib.rs
+++ b/capsules/capsule-system/src/lib.rs
@@ -27,9 +27,6 @@ const CAPSULES_DIR: &str = "home://.local/capsules";
 /// Standard WIT interface directory — per-principal, accessible via `home://wit/`.
 const WIT_DIR: &str = "home://wit";
 
-/// Skill installed to `home://skills/capsule-development/SKILL.md` on install.
-const CAPSULE_DEV_SKILL: &str = include_str!("skills/capsule-development/SKILL.md");
-
 #[derive(Default)]
 pub struct SystemTools;
 
@@ -114,25 +111,6 @@ fn list_entries(path: &str) -> Result<Vec<String>, SysError> {
 
 #[capsule]
 impl SystemTools {
-    /// Install the capsule-development skill to `home://skills/capsule-development/SKILL.md`
-    /// so the skills capsule can surface it to the LLM.
-    #[astrid::install]
-    pub fn on_install(&self) -> Result<(), SysError> {
-        // home:// may not be available during lifecycle dispatch when installing
-        // without a running daemon. Ignore the host errors (`let _ = ...`) to
-        // silently skip — the skill will be written on the next full boot
-        // once the principal home is mounted.
-        //
-        // `create_dir_all` is idempotent and creates missing parents in a single
-        // host call, replacing the prior exists-then-create_dir ladder.
-        let _ = astrid_sdk::fs::create_dir_all("home://skills/capsule-development");
-        let _ = astrid_sdk::fs::write(
-            "home://skills/capsule-development/SKILL.md",
-            CAPSULE_DEV_SKILL.as_bytes(),
-        );
-        Ok(())
-    }
-
     /// List all installed capsules with their names and versions. Use `inspect_capsule`
     /// for a capsule's manifest, exports, imports, and capabilities.
     /// Returns a JSON array of capsule summaries.

--- a/capsules/capsule-system/src/skills/capsule-development/SKILL.md
+++ b/capsules/capsule-system/src/skills/capsule-development/SKILL.md
@@ -117,6 +117,21 @@ fs_write = ["home://data/my-capsule/"]
 "tool.v1.request.describe" = { wit = "@unicity-astrid/wit/tool/describe-request", handler = "tool_describe" }
 ```
 
+To ship a reusable Skill with the capsule, keep the file inside the capsule
+source tree and declare it in the same manifest:
+
+```toml
+[[skill]]
+name = "my-capsule-workflow"
+description = "Use my capsule for its supported workflow"
+file = "skills/my-capsule-workflow/SKILL.md"
+```
+
+The capsule builder packages the declared file. AOS Skills discovers it from
+the installed capsule mirror for each materialized agent principal. An install
+hook and `fs_write = ["home://skills/"]` are not required for distribution;
+workspace and principal-home Skills remain higher-priority user overrides.
+
 The published `@unicity-astrid/wit/...` strings and `astrid:*` WIT namespaces
 are stable runtime identifiers. Keep them exact even though the product CLI is
 `aos`.

--- a/scripts/build-capsule-assets.sh
+++ b/scripts/build-capsule-assets.sh
@@ -48,6 +48,8 @@ while IFS=$'\t' read -r directory package; do
   test -f "$output_dir/$package.capsule"
 done < "$plan"
 
+python3 "$repo_root/scripts/validate_capsule_skills.py" "$output_dir"
+
 if ! cmp -s "$lock_snapshot" "$repo_root/Cargo.lock"; then
   echo "capsule builds changed Cargo.lock; release builds must use the committed lock" >&2
   exit 1

--- a/scripts/capsule_release.py
+++ b/scripts/capsule_release.py
@@ -13,6 +13,8 @@ import unicodedata
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
+from validate_capsule_skills import safe_relative_asset
+
 try:
     import tomllib
 except ModuleNotFoundError:  # Python 3.10 and older
@@ -34,6 +36,7 @@ class CapsuleSpec:
     package: str
     version: str
     components: tuple[str, ...]
+    skills: tuple[str, ...]
     manifest: Path
 
     @property
@@ -130,6 +133,21 @@ def source_contract() -> list[CapsuleSpec]:
         if len(components) != len(set(components)):
             raise ContractError(f"{manifest_path}: duplicate component filename")
 
+        skill_entries = manifest.get("skill", [])
+        if not isinstance(skill_entries, list):
+            raise ContractError(f"{manifest_path}: [[skill]] entries must be an array")
+        skills: list[str] = []
+        for skill in skill_entries:
+            filename = skill.get("file") if isinstance(skill, dict) else None
+            if not isinstance(filename, str) or not safe_relative_asset(filename):
+                raise ContractError(f"{manifest_path}: unsafe skill asset path {filename!r}")
+            skills.append(filename)
+        if len(skills) != len(set(skills)):
+            raise ContractError(f"{manifest_path}: duplicate skill asset path")
+        reserved_members = {"Capsule.toml", *components}
+        if reserved_members.intersection(skills):
+            raise ContractError(f"{manifest_path}: skill asset collides with a reserved member")
+
         distro_entry = distro_by_name.get(cargo_name)
         if distro_entry is None:
             raise ContractError(f"{member}: {cargo_name} is not selected by Unicity CE")
@@ -150,6 +168,7 @@ def source_contract() -> list[CapsuleSpec]:
                 package=cargo_name,
                 version=cargo_version,
                 components=tuple(components),
+                skills=tuple(skills),
                 manifest=manifest_path,
             )
         )
@@ -215,7 +234,7 @@ def validate_archive(asset: Path, spec: CapsuleSpec) -> None:
             names[canonical_name] = member
             portability_names[portability_name] = canonical_name
 
-        expected_members = {"Capsule.toml", *spec.components}
+        expected_members = {"Capsule.toml", *spec.components, *spec.skills}
         if set(names) != expected_members:
             raise ContractError(
                 f"{asset}: archive member set differs; "
@@ -248,6 +267,19 @@ def validate_archive(asset: Path, spec: CapsuleSpec) -> None:
             member = names.get(component)
             if member is None or not member.isfile():
                 raise ContractError(f"{asset}: component {component} is missing")
+
+        embedded_skills = embedded.get("skill", [])
+        if not isinstance(embedded_skills, list):
+            raise ContractError(f"{asset}: embedded [[skill]] entries are invalid")
+        skill_files = tuple(
+            skill.get("file") for skill in embedded_skills if isinstance(skill, dict)
+        )
+        if skill_files != spec.skills:
+            raise ContractError(f"{asset}: embedded skill asset list does not match source manifest")
+        for skill in spec.skills:
+            member = names.get(skill)
+            if member is None or not member.isfile():
+                raise ContractError(f"{asset}: skill asset {skill} is missing")
 
 
 def validate_artifacts(directory: Path, specs: list[CapsuleSpec]) -> None:

--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -73,6 +73,14 @@ def write_fixture(path: Path, spec: CapsuleSpec, *, mutation: Optional[str] = No
             if mutation == "missing-component" and component == spec.components[0]:
                 continue
             add_bytes(archive, component, b"\x00asm")
+        for skill in spec.skills:
+            if mutation == "missing-skill" and skill == spec.skills[0]:
+                continue
+            add_bytes(
+                archive,
+                skill,
+                b"---\nname: fixture\ndescription: Release contract fixture\n---\n",
+            )
 
 
 class CapsuleReleaseTests(unittest.TestCase):
@@ -143,6 +151,23 @@ class CapsuleReleaseTests(unittest.TestCase):
 
     def test_rejects_missing_component(self) -> None:
         self.assert_mutation_rejected("missing-component")
+
+    def test_accepts_declared_skill_assets(self) -> None:
+        skill_specs = [spec for spec in self.specs if spec.skills]
+        self.assertTrue(skill_specs)
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            self.fixture_set(directory)
+            validate_artifacts(directory, self.specs)
+
+    def test_rejects_missing_declared_skill_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            self.fixture_set(directory)
+            spec = next(spec for spec in self.specs if spec.skills)
+            write_fixture(directory / spec.asset, spec, mutation="missing-skill")
+            with self.assertRaises(ContractError):
+                validate_artifacts(directory, self.specs)
 
     def test_rejects_unexpected_asset(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -42,6 +42,8 @@ class ReleasePublicationTests(unittest.TestCase):
                 add_file(archive, "Capsule.toml", spec.manifest.read_bytes())
                 for component in spec.components:
                     add_file(archive, component, b"\0asm")
+                for skill in spec.skills:
+                    add_file(archive, skill, (spec.manifest.parent / skill).read_bytes())
 
         for target in release_metadata.TARGETS:
             (artifacts / f"unicity-aos-{VERSION}-{target}.tar.gz").write_bytes(

--- a/scripts/test_validate_capsule_skills.py
+++ b/scripts/test_validate_capsule_skills.py
@@ -1,0 +1,65 @@
+import io
+import pathlib
+import sys
+import tarfile
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import validate_capsule_skills
+
+
+MANIFEST = b"""\
+[package]
+name = "test"
+version = "0.1.0"
+
+[[skill]]
+name = "test-skill"
+file = "skills/test-skill/SKILL.md"
+"""
+
+
+def _write_capsule(path: pathlib.Path, *, include_skill: bool = True) -> None:
+    with tarfile.open(path, "w:gz") as archive:
+        manifest = tarfile.TarInfo("Capsule.toml")
+        manifest.size = len(MANIFEST)
+        archive.addfile(manifest, io.BytesIO(MANIFEST))
+        if include_skill:
+            content = b"---\nname: test-skill\ndescription: Test\n---\n"
+            skill = tarfile.TarInfo("skills/test-skill/SKILL.md")
+            skill.size = len(content)
+            archive.addfile(skill, io.BytesIO(content))
+
+
+class ValidateCapsuleSkillsTests(unittest.TestCase):
+    def test_accepts_packaged_declared_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            capsule = pathlib.Path(directory, "test.capsule")
+            _write_capsule(capsule)
+            validate_capsule_skills.validate_capsule(capsule)
+
+    def test_rejects_missing_declared_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            capsule = pathlib.Path(directory, "test.capsule")
+            _write_capsule(capsule, include_skill=False)
+            with self.assertRaisesRegex(ValueError, "asset is absent"):
+                validate_capsule_skills.validate_capsule(capsule)
+
+    def test_rejects_unsafe_declared_skill_path(self) -> None:
+        unsafe = MANIFEST.replace(
+            b"skills/test-skill/SKILL.md", b"../outside/SKILL.md"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            capsule = pathlib.Path(directory, "test.capsule")
+            with tarfile.open(capsule, "w:gz") as archive:
+                manifest = tarfile.TarInfo("Capsule.toml")
+                manifest.size = len(unsafe)
+                archive.addfile(manifest, io.BytesIO(unsafe))
+            with self.assertRaisesRegex(ValueError, "unsafe file path"):
+                validate_capsule_skills.validate_capsule(capsule)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_capsule_skills.py
+++ b/scripts/validate_capsule_skills.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Verify that every capsule-declared Skill is present in its archive."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import tarfile
+import tomllib
+
+
+def _safe_relative_asset(value: str) -> bool:
+    if not value or value.startswith("/") or "\\" in value or "://" in value:
+        return False
+    parts = value.split("/")
+    return all(part not in {"", ".", ".."} for part in parts)
+
+
+def validate_capsule(path: pathlib.Path) -> None:
+    with tarfile.open(path, "r:gz") as archive:
+        members = {member.name: member for member in archive.getmembers()}
+        manifest_member = members.get("Capsule.toml")
+        if manifest_member is None or not manifest_member.isfile():
+            raise ValueError(f"{path.name}: missing regular Capsule.toml")
+        manifest_file = archive.extractfile(manifest_member)
+        if manifest_file is None:
+            raise ValueError(f"{path.name}: Capsule.toml cannot be read")
+        manifest = tomllib.loads(manifest_file.read().decode("utf-8"))
+
+        for skill in manifest.get("skill", []):
+            name = skill.get("name", "<unnamed>")
+            asset = skill.get("file")
+            if not isinstance(asset, str) or not _safe_relative_asset(asset):
+                raise ValueError(
+                    f"{path.name}: skill {name!r} has unsafe file path {asset!r}"
+                )
+            member = members.get(asset)
+            if member is None or not member.isfile():
+                raise ValueError(
+                    f"{path.name}: skill {name!r} asset is absent or not a regular file: {asset}"
+                )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("artifacts", type=pathlib.Path)
+    args = parser.parse_args()
+
+    capsules = sorted(args.artifacts.glob("*.capsule"))
+    if not capsules:
+        parser.error(f"no .capsule artifacts found in {args.artifacts}")
+    for capsule in capsules:
+        try:
+            validate_capsule(capsule)
+        except (OSError, UnicodeError, ValueError, tarfile.TarError) as error:
+            print(error, file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_capsule_skills.py
+++ b/scripts/validate_capsule_skills.py
@@ -10,7 +10,7 @@ import tarfile
 import tomllib
 
 
-def _safe_relative_asset(value: str) -> bool:
+def safe_relative_asset(value: str) -> bool:
     if not value or value.startswith("/") or "\\" in value or "://" in value:
         return False
     parts = value.split("/")
@@ -31,7 +31,7 @@ def validate_capsule(path: pathlib.Path) -> None:
         for skill in manifest.get("skill", []):
             name = skill.get("name", "<unnamed>")
             asset = skill.get("file")
-            if not isinstance(asset, str) or not _safe_relative_asset(asset):
+            if not isinstance(asset, str) or not safe_relative_asset(asset):
                 raise ValueError(
                     f"{path.name}: skill {name!r} has unsafe file path {asset!r}"
                 )


### PR DESCRIPTION
Closes #43

## Summary

Makes capsule-contributed Skills a declarative, principal-visible AOS capability instead of a one-shot install-hook side effect. Forge and System now ship `[[skill]]` assets, and `aos-skills` indexes declarations from the installed capsule introspection tree after workspace and principal-home overrides.

## Changes

- declare Forge, meta-harness, and capsule-development Skills in their capsule manifests
- remove the lifecycle hooks and `fs_write` grants previously used to copy those files into one principal home
- discover and read Skills from `home://.local/capsules/*/Capsule.toml` with deterministic collision handling
- validate capsule names, global Skill IDs, and relative asset paths before VFS reads
- preserve precedence: workspace, principal home, then installed capsule
- teach third-party capsule authors the same generic declarative path
- make release packaging verify that every declared Skill is a regular file in the `.capsule` archive

The archive gate intentionally rejects the currently released Astrid 0.10.2 builder, which omits declared assets. AOS release publication therefore fails closed until the pinned runtime builder contains astrid-runtime/astrid#1281. No product version or release pin is changed by this PR.

## Verification

- `cargo test --workspace`
- `cargo clippy -p aos-skills -p aos-forge -p aos-system --all-targets -- -D warnings`
- `python3 -m unittest scripts.test_validate_capsule_skills`
- `cargo fmt --all -- --check`
- built Forge, System, and Skills with the patched Astrid builder
- archive validator passed and confirmed:
  - `aos-forge.capsule` contains both Forge and meta-harness `SKILL.md` assets
  - `aos-system.capsule` contains capsule-development `SKILL.md`
- the released 0.10.2 builder was separately confirmed to fail the new archive gate because those declared files are absent

No release, version bump, channel promotion, or public artifact publication was triggered.
