### PR TITLE
feat: add capacity planning and readiness-driven multiplexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@
   changing runtime state, and proves clean daemon shutdown before publication.
 - Native `aos status` output for authenticated running state and verified
   stopped state without invoking the runtime CLI.
+- A system-served `capacity-planning` Skill and deterministic `model_capacity`
+  tool. Agents can fit shared-plus-marginal memory, distinguish configured
+  ceilings from measured saturation, and derive memory, persistent-stream, and
+  readiness-set bounds without an invented universal agent count. Workspace and
+  principal-home Skills retain override priority over the built-in.
 - An opt-in daily nightly train with deterministic run-dated versions, exact
   Astrid compatibility pins, protected publication and promotion, and
   idempotent recovery after interrupted release or pointer updates. It is
@@ -78,6 +83,10 @@
   Astrid 0.9.4 home shape and a final-candidate runtime boot hook.
 - Present product-facing capsule copy consistently as Unicity AOS while
   preserving stable Astrid Runtime crate, WIT, topic, artifact, and ABI names.
+- Drive the CLI uplink and model registry from Component Model readiness. Idle
+  proxy cost no longer grows with connected clients, targeted egress uses a
+  principal/session index, and registry reload or CLI events no longer wait
+  behind a five-second primary-subscription timeout.
 - Treat the runtime's expected shutdown-response disconnect as a successful
   `aos stop` only after every coordination marker is gone and the singleton
   lock is available; all other inherited runtime failures retain their output

--- a/capsules/capsule-cli/src/lib.rs
+++ b/capsules/capsule-cli/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use astrid_sdk::net::{TcpStream, TryRecvError, bind_unix};
 use astrid_sdk::prelude::*;
@@ -39,6 +39,9 @@ struct CliProxy;
 /// per-principal connection counter is driven by host-emitted
 /// `client.v1.connect` / `client.v1.disconnect`, not by these fields.
 struct ProxyClient {
+    // Pollables borrow their source host-side and fields drop in declaration
+    // order, so readiness must precede the stream.
+    readable: astrid_sdk::io::Pollable,
     stream: TcpStream,
     principal: Option<String>,
     session_id: Option<String>,
@@ -46,7 +49,9 @@ struct ProxyClient {
 
 impl ProxyClient {
     fn new(stream: TcpStream) -> Self {
+        let readable = stream.subscribe_readable();
         Self {
+            readable,
             stream,
             principal: None,
             session_id: None,
@@ -185,8 +190,14 @@ const CHAT_DELTA_TOPIC: &str = "agent.v1.stream.delta";
 /// Upper bound on concurrently-streaming sessions the proxy accumulates text
 /// for. A turn always drops its entry on its terminal response, so this is only
 /// a defensive ceiling against a turn that never finalizes; far above the
-/// host-enforced 8-connection cap.
+/// readiness-set capacity derived from the host contract.
 const MAX_STREAM_SESSIONS: usize = 64;
+
+fn max_polled_clients(subscription_count: usize) -> usize {
+    astrid_sdk::io::MAX_POLLABLES_PER_CALL
+        .saturating_sub(subscription_count)
+        .saturating_sub(1)
+}
 
 /// Extract the top-level `"session_id"` string from a message payload, if any.
 ///
@@ -349,6 +360,10 @@ impl CliProxy {
             .iter()
             .map(|t| ipc::subscribe(t))
             .collect::<Result<Vec<_>, _>>()?;
+        let sub_readiness: Vec<astrid_sdk::io::Pollable> = subs
+            .iter()
+            .map(ipc::Subscription::subscribe_readiness)
+            .collect();
 
         // Signal readiness so the kernel can proceed with loading dependent capsules.
         // Best-effort: failure means the host mutex is poisoned (unrecoverable).
@@ -362,9 +377,15 @@ impl CliProxy {
 
         log::info(format!("CLI Proxy: accepting connections on {path}"));
         let listener = bind_unix()?;
+        let listener_readiness = listener.subscribe_readiness();
+        let max_clients = max_polled_clients(subs.len());
+        log::info(format!(
+            "CLI Proxy: readiness capacity is {max_clients} concurrent clients"
+        ));
 
         // 3. Multi-connection accept loop.
-        // Supports up to 8 concurrent CLI clients (enforced at host level).
+        // Capacity is derived from the WIT poll contract: one listener plus
+        // every IPC subscription and client stream must fit in one wait set.
         //
         // Each connection binds to exactly one principal on its first message
         // (see `ProxyClient` / `decide_ingress`) and stays bound for life, and
@@ -398,43 +419,49 @@ impl CliProxy {
         let mut stream_accum: HashMap<String, String> = HashMap::new();
 
         'proxy: loop {
-            // Phase A: block until at least one client is connected.
-            if clients.is_empty() {
-                let stream = match listener.accept() {
-                    Ok(s) => s,
-                    Err(e) => {
-                        log::warn(format!("Accept error: {e:?}, backing off"));
-                        // `std::thread::sleep` panics on wasm32-unknown-unknown
-                        // ("can't sleep" — the unsupported thread shim), which
-                        // would kill the proxy run loop on the first accept
-                        // error. Use the host-backed sleep instead. Propagate a
-                        // sleep failure (`?`) rather than swallowing it: a failed
-                        // host sleep would otherwise let this arm `continue` with
-                        // no delay and busy-spin if `accept()` keeps erroring. The
-                        // host only errs here when tearing the capsule down, so
-                        // returning ends the loop cleanly.
-                        astrid_sdk::time::sleep(std::time::Duration::from_millis(100))?;
-                        continue;
+            // Wait once for the listener, every live client, and every IPC
+            // subscription. Idle cost is independent of client count.
+            let listen_included = clients.len() < max_clients;
+            let ready = {
+                let mut wait_set: Vec<&astrid_sdk::io::Pollable> = Vec::with_capacity(
+                    usize::from(listen_included) + clients.len() + sub_readiness.len(),
+                );
+                if listen_included {
+                    wait_set.push(&listener_readiness);
+                }
+                wait_set.extend(clients.iter().map(|client| &client.readable));
+                wait_set.extend(sub_readiness.iter());
+                astrid_sdk::io::poll(&wait_set)?
+            };
+
+            let client_offset = usize::from(listen_included);
+            let subscription_offset = client_offset + clients.len();
+            let mut ready_clients = Vec::new();
+            let mut ready_subscriptions = Vec::new();
+            let mut accept_ready = false;
+            for index in ready {
+                if listen_included && index == 0 {
+                    accept_ready = true;
+                } else if index < subscription_offset {
+                    ready_clients.push(index - client_offset);
+                } else {
+                    ready_subscriptions.push(index - subscription_offset);
+                }
+            }
+
+            if accept_ready {
+                match listener.accept() {
+                    Ok(stream) => {
+                        log::info("CLI client connected to proxy");
+                        clients.push(ProxyClient::new(stream));
                     }
-                };
-                log::info("CLI client connected to proxy");
-                clients.push(ProxyClient::new(stream));
+                    Err(error) => log::warn(format!("Accept error: {error:?}")),
+                }
             }
 
-            // Phase B: poll for one additional connection (non-blocking).
-            // Max one per iteration to bound handshake stall to ~5s worst case.
-            // The new try_accept takes a timeout - 0 means non-blocking, matching
-            // the pre-#752 semantics.
-            if let Ok(Some(new_stream)) = listener.try_accept(0) {
-                log::info("Additional CLI client connected to proxy");
-                clients.push(ProxyClient::new(new_stream));
-            }
-
-            // Phase C: read from all streams.
-            // NOTE: 50ms timeout per stream = linear scaling (N*50ms per iteration).
-            // Acceptable for CLI use (2-3 typical, 8 max = 400ms worst case).
-            let mut dead_indices: Vec<usize> = Vec::new();
-            for (i, client) in clients.iter_mut().enumerate() {
+            let mut dead_indices: HashSet<usize> = HashSet::new();
+            for i in ready_clients {
+                let client = &mut clients[i];
                 match client.stream.try_recv() {
                     Ok(bytes) => {
                         // Apply the binding state machine and forward if allowed.
@@ -457,27 +484,13 @@ impl CliProxy {
                     Err(TryRecvError::Empty) => {}
                     Err(TryRecvError::Closed) => {
                         log::info("CLI client disconnected from proxy");
-                        dead_indices.push(i);
+                        dead_indices.insert(i);
                     }
                 }
             }
 
-            // Remove dead streams in reverse order to preserve indices.
-            // Dropping the `ProxyClient` drops its `TcpStream`, which releases
-            // the host-side stream entry — and that drop is exactly where the
-            // host emits `client.v1.disconnect` for the kernel connection
-            // tracker, stamped with the connection's verified principal. The
-            // proxy no longer emits it (the old proxy-side emission fired after
-            // the connection's verified identity was gone, so the kernel
-            // stamped it `anonymous` and the per-principal count leaked).
-            for &i in dead_indices.iter().rev() {
-                clients.remove(i);
-            }
-
-            // Phase D: poll IPC subscriptions and broadcast to all live streams.
-            // NOTE: broadcast_dead indices are into clients AFTER Phase C removals.
-            let mut broadcast_dead: Vec<usize> = Vec::new();
-            for sub in &subs {
+            for sub_index in ready_subscriptions {
+                let sub = &subs[sub_index];
                 match sub.poll() {
                     Ok(result) => {
                         if !result.messages.is_empty() {
@@ -485,7 +498,7 @@ impl CliProxy {
                                 &clients,
                                 &result,
                                 &mut stream_accum,
-                                &mut broadcast_dead,
+                                &mut dead_indices,
                             );
                         }
                     }
@@ -496,17 +509,11 @@ impl CliProxy {
                 }
             }
 
-            // Remove streams that failed during broadcast.
-            // Multiple subscriptions may flag the same stream as dead in one
-            // iteration. sort + dedup before removal prevents double-removal panics.
-            broadcast_dead.sort_unstable();
-            broadcast_dead.dedup();
-            for &i in broadcast_dead.iter().rev() {
+            let mut dead_indices: Vec<usize> = dead_indices.into_iter().collect();
+            dead_indices.sort_unstable();
+            for i in dead_indices.into_iter().rev() {
                 clients.remove(i);
-                log::info("CLI client disconnected during broadcast");
-                // See the Phase-C removal above: the host emits
-                // `client.v1.disconnect` when the dropped stream's resource is
-                // torn down, so the proxy does not.
+                log::info("CLI client disconnected from proxy");
             }
         }
 
@@ -632,6 +639,33 @@ struct OutboundMessage {
     session: Option<String>,
 }
 
+fn send_outbound_to<I>(
+    clients: &[ProxyClient],
+    message: &OutboundMessage,
+    dead: &mut HashSet<usize>,
+    recipients: I,
+) where
+    I: IntoIterator<Item = usize>,
+{
+    for index in recipients {
+        if dead.contains(&index) {
+            continue;
+        }
+        debug_assert!(should_deliver(
+            message.target.as_deref(),
+            message.session.as_deref(),
+            clients[index].principal.as_deref(),
+            clients[index].session_id.as_deref(),
+        ));
+        if let Err(error) = clients[index].stream.send(&message.bytes) {
+            log::warn(format!(
+                "Socket send error, client likely disconnected: {error:?}"
+            ));
+            dead.insert(index);
+        }
+    }
+}
+
 /// Fan a `PollResult` out to connected clients, demultiplexed by principal AND
 /// session so a bound connection only sees IPC stamped with its own principal
 /// (plus unprincipaled system events), and a chat response only when it is on
@@ -644,7 +678,7 @@ fn broadcast_poll_messages(
     clients: &[ProxyClient],
     poll_result: &ipc::PollResult,
     stream_accum: &mut HashMap<String, String>,
-    dead: &mut Vec<usize>,
+    dead: &mut HashSet<usize>,
 ) {
     if poll_result.dropped > 0 {
         log::warn(format!(
@@ -686,32 +720,49 @@ fn broadcast_poll_messages(
         })
         .collect();
 
-    for (i, client) in clients.iter().enumerate() {
-        // Skip streams already marked dead by a previous subscription's broadcast.
-        if dead.contains(&i) {
-            continue;
+    let mut by_principal: HashMap<&str, Vec<usize>> = HashMap::new();
+    let mut by_session: HashMap<&str, Vec<usize>> = HashMap::new();
+    let mut by_principal_session: HashMap<(&str, &str), Vec<usize>> = HashMap::new();
+    for (index, client) in clients.iter().enumerate() {
+        if let Some(principal) = client.principal.as_deref() {
+            by_principal.entry(principal).or_default().push(index);
+            if let Some(session) = client.session_id.as_deref() {
+                by_principal_session
+                    .entry((principal, session))
+                    .or_default()
+                    .push(index);
+            }
         }
-        for msg in &outbound {
-            // Demux on principal AND session: a principaled message reaches only
-            // the matching bound client, and a session-scoped one only the
-            // client on that session (so same-principal connections on different
-            // sessions don't cross-talk). Unprincipaled/unsessioned messages go
-            // to everyone that clears the gates.
-            if !should_deliver(
-                msg.target.as_deref(),
-                msg.session.as_deref(),
-                client.principal.as_deref(),
-                client.session_id.as_deref(),
-            ) {
-                continue;
-            }
-            if let Err(e) = client.stream.send(&msg.bytes) {
-                log::warn(format!(
-                    "Socket send error, client likely disconnected: {e:?}"
-                ));
-                dead.push(i);
-                break; // Skip remaining messages for this dead stream.
-            }
+        if let Some(session) = client.session_id.as_deref() {
+            by_session.entry(session).or_default().push(index);
+        }
+    }
+
+    for message in &outbound {
+        match (message.target.as_deref(), message.session.as_deref()) {
+            (Some(principal), Some(session)) => send_outbound_to(
+                clients,
+                message,
+                dead,
+                by_principal_session
+                    .get(&(principal, session))
+                    .into_iter()
+                    .flatten()
+                    .copied(),
+            ),
+            (Some(principal), None) => send_outbound_to(
+                clients,
+                message,
+                dead,
+                by_principal.get(principal).into_iter().flatten().copied(),
+            ),
+            (None, Some(session)) => send_outbound_to(
+                clients,
+                message,
+                dead,
+                by_session.get(session).into_iter().flatten().copied(),
+            ),
+            (None, None) => send_outbound_to(clients, message, dead, 0..clients.len()),
         }
     }
 }

--- a/capsules/capsule-cli/src/lib_tests.rs
+++ b/capsules/capsule-cli/src/lib_tests.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+#[test]
+fn readiness_capacity_is_derived_from_poll_contract() {
+    assert_eq!(max_polled_clients(16), 239);
+    assert_eq!(max_polled_clients(255), 0);
+    assert_eq!(max_polled_clients(300), 0);
+}
+
 // --- principal format validation ---
 
 #[test]

--- a/capsules/capsule-registry/src/lib.rs
+++ b/capsules/capsule-registry/src/lib.rs
@@ -750,6 +750,14 @@ impl Registry {
         let run_sub = ipc::subscribe(CLI_RUN_TOPIC)?;
         let selection_sub = ipc::subscribe("registry.v1.selection.callback")?;
         let capsules_loaded_sub = ipc::subscribe("astrid.v1.capsules_loaded")?;
+        // Pollables borrow their subscriptions host-side. They are declared
+        // after the parents so normal reverse local-drop order releases every
+        // pollable first.
+        let registry_ready = sub.subscribe_readiness();
+        let command_ready = cmd_sub.subscribe_readiness();
+        let run_ready = run_sub.subscribe_readiness();
+        let selection_ready = selection_sub.subscribe_readiness();
+        let capsules_loaded_ready = capsules_loaded_sub.subscribe_readiness();
 
         let _ = runtime::signal_ready();
 
@@ -779,48 +787,41 @@ impl Registry {
         reconcile_active_model(&mut state);
         auto_select_defaults(&mut state);
 
-        // Event loop — blocks on the primary subscription, then drains auxiliary.
-        // All five subscriptions are RAII (`Subscription`); their `Drop`
-        // releases the kernel-side resource at scope exit, so no manual
-        // `unsubscribe` is required.
+        // Event loop — one heterogeneous readiness wait, then drain only the
+        // subscriptions that fired. This removes the former five-second
+        // head-of-line delay for reload and CLI events.
         loop {
-            match sub.recv(5000) {
-                Ok(result) => dispatch_registry_messages(&result),
-                Err(_) => break,
-            }
-
-            // Drain CLI command messages (non-blocking).
-            if let Ok(result) = cmd_sub.poll() {
-                dispatch_command_messages(&result);
-            }
-
-            // Drain scriptable `models` verb runs (non-blocking).
-            if let Ok(result) = run_sub.poll() {
-                dispatch_cli_run_messages(&result);
-            }
-
-            // Drain model selection callbacks from the TUI picker.
-            if let Ok(result) = selection_sub.poll() {
-                dispatch_selection_messages(&result);
-            }
-
-            // Re-discover providers on capsule reload.
-            if let Ok(result) = capsules_loaded_sub.poll()
-                && has_kernel_message(&result)
-            {
-                log::info("Capsules reloaded - re-discovering providers");
-                let providers = discover_providers();
-                let mut state = load_state();
-                if !providers.is_empty() {
-                    state.providers = providers;
-                    save_state(&state);
-                    reconcile_active_model(&mut state);
-                    auto_select_defaults(&mut state);
+            let wait_set = [
+                &registry_ready,
+                &command_ready,
+                &run_ready,
+                &selection_ready,
+                &capsules_loaded_ready,
+            ];
+            for index in astrid_sdk::io::poll(&wait_set)? {
+                match index {
+                    0 => dispatch_registry_messages(&sub.poll()?),
+                    1 => dispatch_command_messages(&cmd_sub.poll()?),
+                    2 => dispatch_cli_run_messages(&run_sub.poll()?),
+                    3 => dispatch_selection_messages(&selection_sub.poll()?),
+                    4 => {
+                        let result = capsules_loaded_sub.poll()?;
+                        if has_kernel_message(&result) {
+                            log::info("Capsules reloaded - re-discovering providers");
+                            let providers = discover_providers();
+                            let mut state = load_state();
+                            if !providers.is_empty() {
+                                state.providers = providers;
+                                save_state(&state);
+                                reconcile_active_model(&mut state);
+                                auto_select_defaults(&mut state);
+                            }
+                        }
+                    }
+                    _ => unreachable!("poll returned an index outside the input wait set"),
                 }
             }
         }
-
-        Ok(())
     }
 }
 

--- a/capsules/capsule-skills/src/lib.rs
+++ b/capsules/capsule-skills/src/lib.rs
@@ -10,6 +10,16 @@ use serde::{Deserialize, Serialize};
 /// URI scheme prefix for the principal's home directory.
 const HOME_SCHEME: &str = "home://";
 
+struct BuiltinSkill {
+    id: &'static str,
+    content: &'static str,
+}
+
+const BUILTIN_SKILLS: &[BuiltinSkill] = &[BuiltinSkill {
+    id: "capacity-planning",
+    content: include_str!("skills/capacity-planning/SKILL.md"),
+}];
+
 #[derive(Default)]
 pub struct SkillsLoader;
 
@@ -49,6 +59,52 @@ pub struct ReadSkillArgs {
     pub skill_id: String,
 }
 
+#[derive(Debug, Deserialize, astrid_sdk::schemars::JsonSchema)]
+pub struct CapacityModelArgs {
+    /// Shared steady-state memory in MiB with zero external agents attached.
+    pub shared_mib: f64,
+    /// Marginal steady-state memory in MiB per attached agent.
+    pub marginal_mib_per_agent: f64,
+    /// Attached-agent count at which to evaluate total memory and density.
+    pub agents: Option<u64>,
+    /// Operator-supplied memory budget in MiB after any desired reserve.
+    pub usable_memory_mib: Option<f64>,
+    /// Process-wide persistent network-stream limit.
+    pub host_net_streams: Option<u64>,
+    /// Persistent streams consumed independently of attached agents.
+    pub fixed_net_streams: Option<u64>,
+    /// Persistent streams required by each attached agent.
+    pub net_streams_per_agent: Option<f64>,
+    /// Operator-supplied file-descriptor budget after reserving headroom for
+    /// the OS and unrelated processes.
+    pub usable_file_descriptors: Option<u64>,
+    /// File descriptors consumed by the shared runtime before agents attach.
+    pub fixed_file_descriptors: Option<u64>,
+    /// Additional file descriptors consumed by each attached agent.
+    pub file_descriptors_per_agent: Option<f64>,
+    /// IPC subscriptions held by a multiplexing capsule. When supplied, the
+    /// tool derives its client capacity from the 256-entry poll contract.
+    pub ipc_subscriptions: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct CapacityModel {
+    formula: &'static str,
+    shared_mib: f64,
+    marginal_mib_per_agent: f64,
+    asymptotic_density_gain: f64,
+    evaluated_agents: Option<u64>,
+    evaluated_total_mib: Option<f64>,
+    evaluated_mib_per_agent: Option<f64>,
+    evaluated_density_gain: Option<f64>,
+    memory_bound_agents: Option<u64>,
+    net_stream_bound_agents: Option<u64>,
+    file_descriptor_bound_agents: Option<u64>,
+    poll_set_bound_clients: Option<u64>,
+    derived_bound_agents: Option<u64>,
+    bound_sources: Vec<&'static str>,
+}
+
 /// Skill discovery and loading tools.
 ///
 /// Skills are reusable prompt templates stored as SKILL.md files with YAML
@@ -57,7 +113,8 @@ pub struct ReadSkillArgs {
 #[capsule]
 impl SkillsLoader {
     /// List all available skills in a directory. Scans both the workspace and
-    /// home (`~/.astrid/home/{principal}/`) directories, merging results.
+    /// home (`~/.astrid/home/{principal}/`) directories and system built-ins,
+    /// merging results.
     /// Returns a JSON array of `{id, name, description}` objects. Workspace
     /// skills take priority over home skills with the same ID.
     #[astrid::tool("list_skills")]
@@ -74,6 +131,10 @@ impl SkillsLoader {
         let home_dir = format!("{HOME_SCHEME}{bare_dir}");
         collect_skills_from(&home_dir, &mut skills, &mut seen_ids);
 
+        // Built-ins are the final fallback. A workspace or principal-home skill
+        // with the same ID intentionally overrides the shipped version.
+        collect_builtin_skills(&mut skills, &mut seen_ids);
+
         skills.sort_by(|left, right| left.id.cmp(&right.id));
 
         let json = serde_json::to_string(&skills)?;
@@ -82,7 +143,7 @@ impl SkillsLoader {
 
     /// Read the full content of a specific skill by its ID. Returns the raw
     /// SKILL.md content including frontmatter. Checks the workspace directory
-    /// first, then falls back to the home directory.
+    /// first, then falls back to the home directory and system built-ins.
     #[astrid::tool("read_skill")]
     pub fn read_skill(&self, args: ReadSkillArgs) -> Result<String, SysError> {
         let bare_dir = bare_path(validate_dir_path(&args.dir_path)?);
@@ -116,11 +177,169 @@ impl SkillsLoader {
             }
         }
 
+        if let Some(content) = builtin_skill(&args.skill_id) {
+            return Ok(content.to_string());
+        }
+
         Err(SysError::ApiError(format!(
             "Skill '{}' could not be read",
             args.skill_id
         )))
     }
+
+    /// Evaluate the shared-plus-marginal capacity model and any resource
+    /// envelopes the caller measured. No safety factor is invented: pass an
+    /// already-reserved usable memory budget when a memory bound is wanted.
+    #[astrid::tool("model_capacity")]
+    pub fn model_capacity(&self, args: CapacityModelArgs) -> Result<String, SysError> {
+        serde_json::to_string(&calculate_capacity(&args)?).map_err(Into::into)
+    }
+}
+
+fn builtin_skill(skill_id: &str) -> Option<&'static str> {
+    BUILTIN_SKILLS
+        .iter()
+        .find(|skill| skill.id == skill_id)
+        .map(|skill| skill.content)
+}
+
+fn collect_builtin_skills(
+    skills: &mut Vec<SkillInfo>,
+    seen_ids: &mut std::collections::HashSet<String>,
+) {
+    for builtin in BUILTIN_SKILLS {
+        if seen_ids.contains(builtin.id) {
+            continue;
+        }
+        let Some(frontmatter) = parse_frontmatter(builtin.content) else {
+            log::warn(format!(
+                "built-in skill '{}' has invalid frontmatter",
+                builtin.id
+            ));
+            continue;
+        };
+        seen_ids.insert(builtin.id.to_string());
+        skills.push(SkillInfo {
+            id: builtin.id.to_string(),
+            name: frontmatter.name,
+            description: frontmatter.description,
+        });
+    }
+}
+
+fn finite_positive(value: f64, field: &str) -> Result<f64, SysError> {
+    if value.is_finite() && value > 0.0 {
+        Ok(value)
+    } else {
+        Err(SysError::ApiError(format!(
+            "{field} must be finite and greater than zero"
+        )))
+    }
+}
+
+fn floor_to_u64(value: f64) -> u64 {
+    if value <= 0.0 {
+        0
+    } else if value >= u64::MAX as f64 {
+        u64::MAX
+    } else {
+        value.floor() as u64
+    }
+}
+
+fn calculate_capacity(args: &CapacityModelArgs) -> Result<CapacityModel, SysError> {
+    let shared = finite_positive(args.shared_mib, "shared_mib")?;
+    let marginal = finite_positive(args.marginal_mib_per_agent, "marginal_mib_per_agent")?;
+    if args.agents == Some(0) {
+        return Err(SysError::ApiError(
+            "agents must be greater than zero when supplied".to_string(),
+        ));
+    }
+
+    let evaluated = args.agents.map(|agents| {
+        let count = agents as f64;
+        let total = shared + count * marginal;
+        (total, total / count, count * (shared + marginal) / total)
+    });
+
+    let memory_bound = match args.usable_memory_mib {
+        Some(budget) if budget.is_finite() && budget >= 0.0 => {
+            Some(floor_to_u64((budget - shared).max(0.0) / marginal))
+        }
+        Some(_) => {
+            return Err(SysError::ApiError(
+                "usable_memory_mib must be finite and non-negative".to_string(),
+            ));
+        }
+        None => None,
+    };
+
+    let net_stream_bound = match (args.host_net_streams, args.net_streams_per_agent) {
+        (Some(limit), Some(per_agent)) => {
+            let per_agent = finite_positive(per_agent, "net_streams_per_agent")?;
+            let available = limit.saturating_sub(args.fixed_net_streams.unwrap_or(0));
+            Some(floor_to_u64(available as f64 / per_agent))
+        }
+        (None, Some(per_agent)) => {
+            finite_positive(per_agent, "net_streams_per_agent")?;
+            None
+        }
+        _ => None,
+    };
+
+    let file_descriptor_bound = match (
+        args.usable_file_descriptors,
+        args.file_descriptors_per_agent,
+    ) {
+        (Some(limit), Some(per_agent)) => {
+            let per_agent = finite_positive(per_agent, "file_descriptors_per_agent")?;
+            let available = limit.saturating_sub(args.fixed_file_descriptors.unwrap_or(0));
+            Some(floor_to_u64(available as f64 / per_agent))
+        }
+        (None, Some(per_agent)) => {
+            finite_positive(per_agent, "file_descriptors_per_agent")?;
+            None
+        }
+        _ => None,
+    };
+
+    const POLLABLES_PER_CALL: u64 = 256;
+    let poll_set_bound = args.ipc_subscriptions.map(|subscriptions| {
+        POLLABLES_PER_CALL
+            .saturating_sub(subscriptions)
+            .saturating_sub(1)
+    });
+
+    let candidates = [
+        ("memory", memory_bound),
+        ("net_streams", net_stream_bound),
+        ("file_descriptors", file_descriptor_bound),
+        ("poll_set", poll_set_bound),
+    ];
+    let derived_bound = candidates.iter().filter_map(|(_, value)| *value).min();
+    let bound_sources = derived_bound.map_or_else(Vec::new, |minimum| {
+        candidates
+            .iter()
+            .filter_map(|(name, value)| (*value == Some(minimum)).then_some(*name))
+            .collect()
+    });
+
+    Ok(CapacityModel {
+        formula: "M(N) = shared_mib + N * marginal_mib_per_agent",
+        shared_mib: shared,
+        marginal_mib_per_agent: marginal,
+        asymptotic_density_gain: (shared + marginal) / marginal,
+        evaluated_agents: args.agents,
+        evaluated_total_mib: evaluated.map(|value| value.0),
+        evaluated_mib_per_agent: evaluated.map(|value| value.1),
+        evaluated_density_gain: evaluated.map(|value| value.2),
+        memory_bound_agents: memory_bound,
+        net_stream_bound_agents: net_stream_bound,
+        file_descriptor_bound_agents: file_descriptor_bound,
+        poll_set_bound_clients: poll_set_bound,
+        derived_bound_agents: derived_bound,
+        bound_sources,
+    })
 }
 
 /// Read a file as UTF-8 via the typed WIT fs host fn.
@@ -283,6 +502,61 @@ fn parse_frontmatter(content: &str) -> Option<SkillFrontmatter> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn built_in_capacity_skill_has_valid_frontmatter() {
+        let content = builtin_skill("capacity-planning").expect("built-in skill");
+        let frontmatter = parse_frontmatter(content).expect("valid frontmatter");
+        assert_eq!(frontmatter.name, "capacity-planning");
+        assert!(frontmatter.description.contains("attached agents"));
+    }
+
+    #[test]
+    fn capacity_model_matches_measured_shared_runtime_example() {
+        let model = calculate_capacity(&CapacityModelArgs {
+            shared_mib: 223.0,
+            marginal_mib_per_agent: 5.734,
+            agents: Some(8),
+            usable_memory_mib: Some(1024.0),
+            host_net_streams: Some(512),
+            fixed_net_streams: Some(8),
+            net_streams_per_agent: Some(1.0),
+            usable_file_descriptors: Some(4096),
+            fixed_file_descriptors: Some(128),
+            file_descriptors_per_agent: Some(3.0),
+            ipc_subscriptions: Some(16),
+        })
+        .expect("valid model");
+
+        assert!((model.evaluated_total_mib.expect("total") - 268.872).abs() < 0.001);
+        assert!((model.evaluated_density_gain.expect("gain") - 6.806).abs() < 0.01);
+        assert!((model.asymptotic_density_gain - 39.894).abs() < 0.01);
+        assert_eq!(model.memory_bound_agents, Some(139));
+        assert_eq!(model.net_stream_bound_agents, Some(504));
+        assert_eq!(model.file_descriptor_bound_agents, Some(1322));
+        assert_eq!(model.poll_set_bound_clients, Some(239));
+        assert_eq!(model.derived_bound_agents, Some(139));
+        assert_eq!(model.bound_sources, vec!["memory"]);
+    }
+
+    #[test]
+    fn capacity_model_rejects_arbitrary_or_invalid_inputs() {
+        let error = calculate_capacity(&CapacityModelArgs {
+            shared_mib: 0.0,
+            marginal_mib_per_agent: 1.0,
+            agents: None,
+            usable_memory_mib: None,
+            host_net_streams: None,
+            fixed_net_streams: None,
+            net_streams_per_agent: None,
+            usable_file_descriptors: None,
+            fixed_file_descriptors: None,
+            file_descriptors_per_agent: None,
+            ipc_subscriptions: None,
+        })
+        .expect_err("zero shared cost is not a measured model");
+        assert!(error.to_string().contains("shared_mib"));
+    }
 
     #[test]
     fn test_parse_valid_frontmatter() {

--- a/capsules/capsule-skills/src/skills/capacity-planning/SKILL.md
+++ b/capsules/capsule-skills/src/skills/capacity-planning/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: capacity-planning
+description: Measure and model how many attached agents an Astrid or Unicity AOS installation can safely support. Use when sizing multi-tenant deployments, investigating an apparent agent limit, tuning capsule concurrency or network-stream capacity, validating a performance change, or explaining density gains without mistaking a configured ceiling for a measured maximum.
+---
+
+# Capacity Planning
+
+Treat capacity as a measured envelope, not a universal agent count. Provisioned
+principals are cheap records; attached agents consume live runtime resources;
+active work adds workload-dependent CPU, memory, network, IPC, and provider
+pressure. Report each separately.
+
+## Measure
+
+1. Record host facts: usable memory after the operator's reserve, logical CPUs,
+   open-file limit, and relevant AOS config. Do not invent a reserve percentage.
+2. Warm an otherwise-idle installation with its normal system capsules and no
+   external agent attachments. Record steady resident memory as the first
+   estimate of shared cost `S`.
+3. Attach representative agents at geometric counts such as 1, 2, 4, 8, ... .
+   At each point, wait for steady state, perform a functional request, and record
+   resident memory, open descriptors, CPU, p95 latency, errors, and IPC drops.
+4. Estimate marginal attached-agent memory `A` from the median pairwise slope
+   `(memory_j - memory_i) / (agents_j - agents_i)`. Re-estimate shared cost as
+   the median `memory_i - A * agents_i`. More points beat one subtraction.
+5. Stop before host pressure. A safe logarithmic probe does not need to
+   saturate the machine to reveal the linear terms or the first bottleneck.
+
+If a probe stops at a round number, inspect configuration and contract limits
+before calling it a maximum. A quota proves only that the quota was reached.
+
+## Model
+
+For `N` attached agents:
+
+- total idle memory: `M(N) = S + N*A`
+- memory per agent: `A + S/N`
+- density gain over isolated per-agent runtimes:
+  `G(N) = N*(S+A)/(S+N*A)`
+- asymptotic density gain: `G(infinity) = (S+A)/A = 1 + S/A`
+- memory-bound count from an operator-supplied usable budget `B`:
+  `floor(max(0, B-S)/A)`
+
+Call the AOS `model_capacity` tool with measured `S`, `A`, and any known
+resource envelopes. It returns the math and candidate bounds without choosing
+an arbitrary safety factor. For descriptor modeling, pass an operator-chosen
+`usable_file_descriptors` value that already excludes desired OS headroom,
+along with the measured fixed and per-agent descriptor costs.
+
+The deployable count is the smallest independently justified bound:
+
+`min(memory, network streams, poll set, file descriptors, CPU/latency, IPC budgets, provider quotas)`
+
+Do not combine unlike states. Publish at least three numbers when relevant:
+provisioned principals, idle attached agents, and agents active at a stated
+workload and service-level objective.
+
+## Tune AOS
+
+Prefer existing operator controls:
+
+- `capsule.host_net_streams` controls the process-wide persistent network-stream
+  envelope. The host-derived default preserves descriptor headroom. The same
+  value can be supplied through `ASTRID_CAPSULE_HOST_NET_STREAMS` or the daemon
+  `--host-net-streams` override.
+- `capsule.host_io_concurrency` bounds asynchronous host I/O.
+- `capsule.host_blocking_concurrency` bounds blocking host calls.
+- `capsule.instance_pool_size` bounds concurrent pooled capsule instances.
+
+Raise a bound only after identifying it as the active bottleneck. Re-run the
+probe after every change and watch for the bottleneck moving elsewhere. Keep
+public wire contracts stable and prefer a shared host-level envelope when a
+per-store or per-capsule limit would multiply with pools.
+
+## Report
+
+State the evidence and claim boundary:
+
+- host and configuration used;
+- `S`, `A`, sample points, and fitting method;
+- formula-derived counts and which resource wins;
+- highest count functionally exercised;
+- whether that count was a configured stop, a safe test stop, or saturation;
+- active-workload definition and SLO for any throughput claim.
+
+Never present the asymptote as a tested density, or the highest exercised count
+as the maximum when saturation was not discovered.


### PR DESCRIPTION
## Summary

Make the AOS CLI and registry readiness-driven, and ship a built-in capacity-planning Skill plus a deterministic modeling tool. Together these changes remove arbitrary client scaling limits, avoid linear idle polling, and give agents an operational way to measure shared-runtime density without presenting a configured stop or asymptotic formula as a tested maximum.

## Dependencies

- Requires astrid-runtime/astrid#1311 for real listener, stream, and IPC readiness plus the host-wide stream envelope.
- Requires astrid-runtime/sdk-rust#65 and a subsequently approved SDK release/dependency bump. This repository currently pins published `astrid-sdk = "=0.7.1"`; the feature PR intentionally does not mix in release versioning.

The branch was validated by patching the SDK dependency locally to the exact SDK PR source. Normal registry-backed CI is expected to remain blocked until that dependency is published and the pin is updated.

## Changes

- replace the CLI proxy's per-client timeout scan with one heterogeneous readiness wait over its listener, live clients, and IPC subscriptions
- derive proxy client capacity from the 256-entry poll contract instead of assuming the old host cap of eight
- index outbound recipients by principal, session, and their pair, reducing delivery work from a client-by-message cross product to index construction plus actual recipients
- replace the registry's five-second primary-subscription wait and auxiliary scans with one readiness wait across all five subscriptions
- ship `capacity-planning` as a capsule-owned built-in Skill, with workspace then principal-home overrides taking precedence
- add `model_capacity` for the measured `M(N) = S + N*A` model and memory, network-stream, file-descriptor, and poll-set bounds without inventing a safety factor
- document evidence collection, geometric probing, bottleneck selection, tuning controls, and honest claim boundaries
- keep AI-client metadata and `[[skill]]` semantics out of the capsule manifest

## Verification

Using local SDK source at commit `c2c0ae9fb6e538509c6eb39a66115e76e36d4477`:

- CLI capsule: 32 tests passed
- Registry capsule: 24 tests passed
- Skills capsule: 19 tests passed
- strict Clippy passed for CLI, Registry, and Skills capsules
- `cargo fmt --all -- --check`
- `git diff --check`
- AOS `Cargo.lock` was restored to its published dependency sources after local-patch validation

## Agent experience

After this ships, the system capacity workflow appears through the AOS Skills capsule and can be overridden in workspace or principal home. The native plugin Meta Harness Skill remains the startup trigger that tells a fresh agent to inspect its world proactively; this capsule-owned Skill supplies version-matched operational guidance through governed AOS tools.
