### PR TITLE
Activate Meta Harness on exact host prompt turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Runtime import holds the standalone daemon's existing singleton lock without
   changing the source, and interrupted unreceipted cutovers always roll back
   before recopying the current locked source.
-- A signed release path for the 19 installable `aos-*` artifacts
+- A signed release path for the 20 installable `aos-*` artifacts
   built from this source tree and selected locally by Community Edition, with
   exact source/manifest identity checks, product-archive inclusion, offline
   provisioning, archive safety validation, BLAKE3 checksums, SHA-256
@@ -31,13 +31,18 @@
   tools, capsules, traces, and evaluations as an improvable world. Agents reach
   for Forge proactively when real work reveals a useful new capability, while
   optional workers remain a use-case choice rather than a prerequisite.
+- An authenticated `aos hook` ingress and Community Edition Meta Harness
+  capsule that normalize Codex, Claude, and Grok host events onto the generic
+  hook bus, collect private same-turn prompt context, and route it back only to
+  the exact originating session. Adaptive, propose, automatic, and off modes
+  preserve the agent's judgment while respecting its existing authority.
 - Homebrew formula updates initiated by the tap's authenticated stable-release
   poll, eliminating the cross-repository dispatch credential.
 - Strict, signed stable/dev/nightly channel and immutable release metadata
   contracts with exact workflow identities, expiry, replay-resistant generation
   state, and fail-closed direct installer resolution.
 - A native release gate that initializes a clean AOS home, verifies the exact
-  19-capsule CE lock, grants, and ready set, repeats initialization without
+  20-capsule CE lock, grants, and ready set, repeats initialization without
   changing runtime state, and proves clean daemon shutdown before publication.
 - Native `aos status` output for authenticated running state and verified
   stopped state without invoking the runtime CLI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aos-meta-harness"
+version = "0.1.0"
+dependencies = [
+ "astrid-sdk",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "aos-openai"
 version = "0.2.0"
 dependencies = [
@@ -1565,6 +1574,7 @@ name = "unicity-aos-bootstrap"
 version = "2026.1.3"
 dependencies = [
  "astrid-core",
+ "astrid-types 0.10.4",
  "astrid-uplink",
  "axum",
  "blake3",
@@ -1575,6 +1585,7 @@ dependencies = [
  "tokio",
  "toml",
  "tower",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "capsules/capsule-forge",
     "capsules/capsule-fs",
     "capsules/capsule-hook-bridge",
+    "capsules/capsule-meta-harness",
     "capsules/capsule-http",
     "capsules/capsule-identity",
     "capsules/capsule-memory",
@@ -27,6 +28,7 @@ resolver = "3"
 [workspace.dependencies]
 astrid-sdk = { version = "=0.7.1", features = ["derive"] }
 astrid-core = "=0.10.4"
+astrid-types = { version = "=0.10.4", features = ["clock"] }
 astrid-uplink = "=0.10.4"
 axum = "0.8"
 blake3 = "1.8.5"

--- a/capsules/capsule-hook-bridge/Capsule.toml
+++ b/capsules/capsule-hook-bridge/Capsule.toml
@@ -15,8 +15,13 @@ type = "executable"
 
 [publish]
 "hook.v1.event.*" = { wit = "@unicity-astrid/wit/hook/hook-event-request" }
+"oracle.v1.hook.response.*" = { wit = "opaque" }
 
 [subscribe]
+"oracle.v1.hook.validated.codex" = { wit = "opaque", handler = "on_codex_hook" }
+"oracle.v1.hook.validated.claude" = { wit = "opaque", handler = "on_claude_hook" }
+"oracle.v1.hook.validated.grok" = { wit = "opaque", handler = "on_grok_hook" }
+"hook.v1.response.message_received.*" = "opaque"
 "astrid.v1.lifecycle.session_created" = { wit = "@unicity-astrid/wit/hook/lifecycle-event", handler = "on_session_created" }
 "astrid.v1.lifecycle.session_ended" = { wit = "@unicity-astrid/wit/hook/lifecycle-event", handler = "on_session_ended" }
 "astrid.v1.lifecycle.tool_call_started" = { wit = "@unicity-astrid/wit/hook/lifecycle-event", handler = "on_tool_call_started" }

--- a/capsules/capsule-hook-bridge/Capsule.toml
+++ b/capsules/capsule-hook-bridge/Capsule.toml
@@ -21,7 +21,7 @@ type = "executable"
 "oracle.v1.hook.validated.codex" = { wit = "opaque", handler = "on_codex_hook" }
 "oracle.v1.hook.validated.claude" = { wit = "opaque", handler = "on_claude_hook" }
 "oracle.v1.hook.validated.grok" = { wit = "opaque", handler = "on_grok_hook" }
-"hook.v1.response.message_received.*" = "opaque"
+"hook.v1.response.message_received.*" = { wit = "opaque" }
 "astrid.v1.lifecycle.session_created" = { wit = "@unicity-astrid/wit/hook/lifecycle-event", handler = "on_session_created" }
 "astrid.v1.lifecycle.session_ended" = { wit = "@unicity-astrid/wit/hook/lifecycle-event", handler = "on_session_ended" }
 "astrid.v1.lifecycle.tool_call_started" = { wit = "@unicity-astrid/wit/hook/lifecycle-event", handler = "on_tool_call_started" }

--- a/capsules/capsule-hook-bridge/src/lib.rs
+++ b/capsules/capsule-hook-bridge/src/lib.rs
@@ -34,7 +34,7 @@
 
 use astrid_sdk::contracts::hook::HookEventRequest;
 use astrid_sdk::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Hard deadline for collecting hook responses, per dispatch.
 ///
@@ -44,6 +44,18 @@ use serde::Serialize;
 /// in this window, we return the merge of whatever did arrive (which
 /// may be the `MergeSemantics::None` result).
 const HOOK_COLLECT_DEADLINE_MS: u64 = 5_000;
+
+/// Once one responder has answered, allow a short window for peers in the
+/// same fan-out before returning. This avoids paying the full deadline after
+/// the common single-responder case.
+const HOOK_QUIESCENCE_MS: u64 = 25;
+
+/// Host prompt hooks are latency-sensitive and all expected responders are
+/// already-loaded local capsules.
+const HOST_HOOK_COLLECT_DEADLINE_MS: u64 = 1_000;
+
+const MAX_HOST_PAYLOAD_BYTES: usize = 1024 * 1024;
+const MAX_HOST_CONTEXT_BYTES: usize = 64 * 1024;
 
 /// Merged result from hook fan-out.
 ///
@@ -58,6 +70,50 @@ pub struct HookResult {
     skip: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     data: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OracleHookEvent {
+    schema_version: u8,
+    principal_id: String,
+    host: String,
+    session_id: String,
+    event: String,
+    correlation_id: String,
+    route_id: String,
+    delivery_id: String,
+    #[serde(default)]
+    turn_id: Option<String>,
+    #[serde(default)]
+    workspace_id: Option<String>,
+    payload: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+struct OracleHookResponse<'a> {
+    schema_version: u8,
+    principal_id: &'a str,
+    host: &'a str,
+    session_id: &'a str,
+    event: &'a str,
+    correlation_id: &'a str,
+    route_id: &'a str,
+    delivery_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CanonicalOraclePayload<'a> {
+    principal_id: &'a str,
+    host: &'a str,
+    session_id: &'a str,
+    source_event: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    turn_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<&'a str>,
+    payload: &'a serde_json::Value,
 }
 
 // ── Merge Semantics ────────────────────────────────────────────────────────────────
@@ -306,7 +362,11 @@ fn dispatch_hook(
         if elapsed_ms >= HOOK_COLLECT_DEADLINE_MS {
             break;
         }
-        let remaining = HOOK_COLLECT_DEADLINE_MS - elapsed_ms;
+        let remaining = if responses.is_empty() {
+            HOOK_COLLECT_DEADLINE_MS - elapsed_ms
+        } else {
+            HOOK_QUIESCENCE_MS.min(HOOK_COLLECT_DEADLINE_MS - elapsed_ms)
+        };
 
         match sub.recv(remaining) {
             Ok(poll) => {
@@ -337,6 +397,224 @@ fn dispatch_hook(
     Ok(Some(apply_merge(&mapping.merge, &responses)))
 }
 
+fn canonical_hook_for_host_event(event: &str) -> Option<(&'static str, bool)> {
+    match event {
+        "session_start" => Some(("session_start", false)),
+        "user_prompt_submit" => Some(("message_received", true)),
+        "pre_tool_use" | "permission_request" => Some(("before_tool_call", false)),
+        "post_tool_use" => Some(("after_tool_call", false)),
+        "pre_compact" => Some(("on_compaction_started", false)),
+        "post_compact" => Some(("on_compaction_completed", false)),
+        "subagent_start" => Some(("subagent_start", false)),
+        "subagent_stop" => Some(("subagent_stop", false)),
+        "stop" | "session_end" => Some(("session_end", false)),
+        _ => None,
+    }
+}
+
+fn is_clean_segment(value: &str, max: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+fn is_lower_hex(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn validate_oracle_hook(event: &OracleHookEvent) -> Result<(), &'static str> {
+    if event.schema_version != 1 {
+        return Err("unsupported schema version");
+    }
+    if !matches!(event.host.as_str(), "codex" | "claude" | "grok") {
+        return Err("unsupported host");
+    }
+    if canonical_hook_for_host_event(&event.event).is_none() {
+        return Err("unsupported host event");
+    }
+    if !is_clean_segment(&event.session_id, 128)
+        || !is_clean_segment(&event.event, 128)
+        || !is_clean_segment(&event.delivery_id, 128)
+    {
+        return Err("invalid routed segment");
+    }
+    if !is_lower_hex(&event.route_id, 64) || !is_lower_hex(&event.correlation_id, 32) {
+        return Err("invalid route identifier");
+    }
+    if event.delivery_id != format!("{}-{}", event.route_id, event.correlation_id) {
+        return Err("delivery identifier does not bind route and correlation");
+    }
+    if event
+        .turn_id
+        .as_deref()
+        .is_some_and(|value| value.is_empty() || value.len() > 256)
+        || event
+            .workspace_id
+            .as_deref()
+            .is_some_and(|value| !is_clean_segment(value, 128))
+    {
+        return Err("invalid optional routing metadata");
+    }
+    if serde_json::to_vec(&event.payload)
+        .map_or(true, |payload| payload.len() > MAX_HOST_PAYLOAD_BYTES)
+    {
+        return Err("host payload exceeds limit");
+    }
+    Ok(())
+}
+
+fn collect_additional_context(
+    subscription: &ipc::Subscription,
+    reply_topic: &str,
+) -> Result<Option<String>, SysError> {
+    let mut contexts = Vec::new();
+    let mut context_bytes = 0;
+    let start = time::monotonic();
+    loop {
+        let elapsed_ms = u64::try_from((time::monotonic().saturating_sub(start)).as_millis())
+            .unwrap_or(HOST_HOOK_COLLECT_DEADLINE_MS);
+        if elapsed_ms >= HOST_HOOK_COLLECT_DEADLINE_MS {
+            break;
+        }
+        let remaining = if contexts.is_empty() {
+            HOST_HOOK_COLLECT_DEADLINE_MS - elapsed_ms
+        } else {
+            HOOK_QUIESCENCE_MS.min(HOST_HOOK_COLLECT_DEADLINE_MS - elapsed_ms)
+        };
+        match subscription.recv(remaining) {
+            Ok(poll) if poll.messages.is_empty() => break,
+            Ok(poll) => {
+                for message in poll.messages {
+                    match serde_json::from_str::<serde_json::Value>(&message.payload) {
+                        Ok(value) => {
+                            if let Some(context) = value
+                                .get("additional_context")
+                                .and_then(serde_json::Value::as_str)
+                                .filter(|context| !context.trim().is_empty())
+                                && !push_context(&mut contexts, &mut context_bytes, context)
+                            {
+                                log::warn(format!(
+                                    "hook-bridge: dropping host-hook context that exceeds the {MAX_HOST_CONTEXT_BYTES}-byte response limit"
+                                ));
+                            }
+                        }
+                        Err(error) => log::warn(format!(
+                            "hook-bridge: dropping malformed host-hook reply on {reply_topic}: {error}"
+                        )),
+                    }
+                }
+            }
+            Err(SysError::HostError(message)) if message.contains("Timeout") => break,
+            Err(error) => return Err(error),
+        }
+    }
+    if contexts.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(contexts.join("\n\n")))
+    }
+}
+
+fn push_context(contexts: &mut Vec<String>, total: &mut usize, context: &str) -> bool {
+    let separator = usize::from(!contexts.is_empty()) * 2;
+    let Some(next_total) = total
+        .checked_add(separator)
+        .and_then(|value| value.checked_add(context.len()))
+    else {
+        return false;
+    };
+    if next_total > MAX_HOST_CONTEXT_BYTES {
+        return false;
+    }
+    contexts.push(context.to_owned());
+    *total = next_total;
+    true
+}
+
+fn dispatch_oracle_hook(event: &OracleHookEvent) -> Result<Option<String>, SysError> {
+    let Some((hook, expects_context)) = canonical_hook_for_host_event(&event.event) else {
+        return Ok(None);
+    };
+    let canonical_payload = CanonicalOraclePayload {
+        principal_id: &event.principal_id,
+        host: &event.host,
+        session_id: &event.session_id,
+        source_event: &event.event,
+        turn_id: event.turn_id.as_deref(),
+        workspace_id: event.workspace_id.as_deref(),
+        payload: &event.payload,
+    };
+    let event_topic = format!("hook.v1.event.{hook}");
+    if !expects_context {
+        let request = HookEventRequest {
+            hook: hook.to_owned(),
+            payload: serde_json::to_string(&canonical_payload)?,
+            correlation_id: None,
+        };
+        ipc::publish_json(&event_topic, &request)?;
+        return Ok(None);
+    }
+
+    let reply_topic = format!("hook.v1.response.{hook}.{}", event.correlation_id);
+    let subscription = ipc::subscribe(&reply_topic)?;
+    let request = HookEventRequest {
+        hook: hook.to_owned(),
+        payload: serde_json::to_string(&canonical_payload)?,
+        correlation_id: Some(event.correlation_id.clone()),
+    };
+    ipc::publish_json(&event_topic, &request)?;
+    collect_additional_context(&subscription, &reply_topic)
+}
+
+fn handle_oracle_hook(payload: serde_json::Value) -> Result<(), SysError> {
+    let event: OracleHookEvent = match serde_json::from_value(payload) {
+        Ok(event) => event,
+        Err(error) => {
+            log::warn(format!(
+                "hook-bridge: dropping malformed oracle hook: {error}"
+            ));
+            return Ok(());
+        }
+    };
+    if let Err(reason) = validate_oracle_hook(&event) {
+        log::warn(format!(
+            "hook-bridge: dropping invalid {} hook '{}': {reason}",
+            event.host, event.event
+        ));
+        return Ok(());
+    }
+    let caller = runtime::caller()?;
+    if caller.principal.as_deref() != Some(event.principal_id.as_str()) {
+        log::warn(format!(
+            "hook-bridge: dropping hook with principal mismatch for host {}",
+            event.host
+        ));
+        return Ok(());
+    }
+
+    let context = dispatch_oracle_hook(&event)?;
+    let response_topic = format!("oracle.v1.hook.response.{}", event.delivery_id);
+    ipc::publish_json(
+        &response_topic,
+        &OracleHookResponse {
+            schema_version: 1,
+            principal_id: &event.principal_id,
+            host: &event.host,
+            session_id: &event.session_id,
+            event: &event.event,
+            correlation_id: &event.correlation_id,
+            route_id: &event.route_id,
+            delivery_id: &event.delivery_id,
+            context,
+        },
+    )
+}
+
 // ── Capsule Implementation ─────────────────────────────────────────────────────────
 
 /// Hook Bridge capsule.
@@ -356,6 +634,24 @@ fn handle_lifecycle(
 
 #[capsule]
 impl HookBridge {
+    /// Normalize a token-validated Codex host hook onto the canonical hook bus.
+    #[astrid::interceptor("on_codex_hook")]
+    pub fn on_codex_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        handle_oracle_hook(payload)
+    }
+
+    /// Normalize a token-validated Claude host hook onto the canonical hook bus.
+    #[astrid::interceptor("on_claude_hook")]
+    pub fn on_claude_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        handle_oracle_hook(payload)
+    }
+
+    /// Normalize a token-validated Grok host hook onto the canonical hook bus.
+    #[astrid::interceptor("on_grok_hook")]
+    pub fn on_grok_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        handle_oracle_hook(payload)
+    }
+
     // ── Session lifecycle ──
 
     /// Handle `session_created` lifecycle event.
@@ -488,5 +784,72 @@ impl HookBridge {
     pub fn on_kernel_shutdown(&self, payload: serde_json::Value) -> Result<(), SysError> {
         let _ = handle_lifecycle("astrid.v1.lifecycle.kernel_shutdown", payload)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host_event() -> OracleHookEvent {
+        let route_id = "a".repeat(64);
+        let correlation_id = "b".repeat(32);
+        OracleHookEvent {
+            schema_version: 1,
+            principal_id: "codex-code".to_owned(),
+            host: "codex".to_owned(),
+            session_id: "codex-session".to_owned(),
+            event: "user_prompt_submit".to_owned(),
+            delivery_id: format!("{route_id}-{correlation_id}"),
+            correlation_id,
+            route_id,
+            turn_id: Some("turn-one".to_owned()),
+            workspace_id: Some("workspace-one".to_owned()),
+            payload: serde_json::json!({"prompt": "hello"}),
+        }
+    }
+
+    #[test]
+    fn prompt_event_maps_to_context_bearing_message_hook() {
+        assert_eq!(
+            canonical_hook_for_host_event("user_prompt_submit"),
+            Some(("message_received", true))
+        );
+        assert_eq!(
+            canonical_hook_for_host_event("stop"),
+            Some(("session_end", false))
+        );
+    }
+
+    #[test]
+    fn exact_delivery_binding_is_required() {
+        let mut event = host_event();
+        assert!(validate_oracle_hook(&event).is_ok());
+        event.delivery_id = format!("{}-{}", "c".repeat(64), event.correlation_id);
+        assert_eq!(
+            validate_oracle_hook(&event),
+            Err("delivery identifier does not bind route and correlation")
+        );
+    }
+
+    #[test]
+    fn event_and_session_cannot_add_topic_segments() {
+        let mut event = host_event();
+        event.session_id = "codex.other".to_owned();
+        assert_eq!(validate_oracle_hook(&event), Err("invalid routed segment"));
+    }
+
+    #[test]
+    fn combined_host_context_stays_inside_relay_limit() {
+        let mut contexts = Vec::new();
+        let mut total = 0;
+        assert!(push_context(
+            &mut contexts,
+            &mut total,
+            &"a".repeat(MAX_HOST_CONTEXT_BYTES - 3)
+        ));
+        assert!(push_context(&mut contexts, &mut total, "b"));
+        assert_eq!(contexts.join("\n\n").len(), MAX_HOST_CONTEXT_BYTES);
+        assert!(!push_context(&mut contexts, &mut total, "c"));
     }
 }

--- a/capsules/capsule-meta-harness/.cargo/config.toml
+++ b/capsules/capsule-meta-harness/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "wasm32-unknown-unknown"
+
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg=getrandom_backend=\"custom\""]

--- a/capsules/capsule-meta-harness/Capsule.toml
+++ b/capsules/capsule-meta-harness/Capsule.toml
@@ -1,0 +1,20 @@
+[package]
+name = "aos-meta-harness"
+version = "0.1.0"
+description = "Prompts agents to notice and improve reusable capability gaps inside their own AOS world"
+authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
+astrid-version = ">=0.10.1"
+
+[[component]]
+id = "meta-harness"
+file = "aos_meta_harness.wasm"
+type = "executable"
+
+[publish]
+"hook.v1.response.message_received.*" = { wit = "opaque" }
+
+[subscribe]
+"hook.v1.event.message_received" = { wit = "@unicity-astrid/wit/hook/hook-event-request", handler = "on_message_received" }
+
+[env]
+activation = { type = "string", default = "adaptive", request = "Meta Harness activation: adaptive, propose, automatic, or off" }

--- a/capsules/capsule-meta-harness/Cargo.toml
+++ b/capsules/capsule-meta-harness/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "aos-meta-harness"
+version = "0.1.0"
+edition = "2024"
+description = "Proactive user-space capability reflection for Unicity AOS agents"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+astrid-sdk = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/capsules/capsule-meta-harness/README.md
+++ b/capsules/capsule-meta-harness/README.md
@@ -1,0 +1,10 @@
+# aos-meta-harness
+
+`aos-meta-harness` gives host agents a private, same-turn reminder to notice
+reusable capability gaps in their own Unicity AOS user-space world. It answers
+only correlated `user_prompt_submit` events, so it cannot create a second turn
+or broadcast context to every session owned by the same principal.
+
+The default `adaptive` activation leaves the reuse/build/propose decision to
+the agent. Operators may select `propose`, `automatic`, or `off` through the
+per-principal capsule configuration.

--- a/capsules/capsule-meta-harness/rust-toolchain.toml
+++ b/capsules/capsule-meta-harness/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"
 targets = ["wasm32-unknown-unknown"]
 components = ["rustfmt", "clippy"]

--- a/capsules/capsule-meta-harness/rust-toolchain.toml
+++ b/capsules/capsule-meta-harness/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.94.0"
+targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]

--- a/capsules/capsule-meta-harness/src/lib.rs
+++ b/capsules/capsule-meta-harness/src/lib.rs
@@ -1,0 +1,119 @@
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+#![deny(unreachable_pub)]
+#![warn(missing_docs)]
+
+//! Meta Harness activation for host-agent prompt turns.
+
+use astrid_sdk::prelude::*;
+use serde::Deserialize;
+
+const ADAPTIVE_CONTEXT: &str = "Work on the user's request normally. Privately, within this same turn, notice whether the work reveals a missing ability, recurring friction, or reusable leverage in your Unicity AOS user-space world. If useful, proactively use the Meta Harness skill and decide whether to reuse, remember, compose, improve the harness, or Forge-build within the user's intent and your existing authority. Do not add a second response, announce this check, or report that nothing was found.";
+
+const PROPOSE_CONTEXT: &str = "Work on the user's request normally. Privately, within this same turn, notice whether the work reveals a missing ability, recurring friction, or reusable leverage in your Unicity AOS user-space world. If useful, use the Meta Harness skill to form a concrete capability proposal and surface it only when it materially helps the user. Do not make durable changes without the approval or authority the work normally requires. Do not add a second response, announce this check, or report that nothing was found.";
+
+const AUTOMATIC_CONTEXT: &str = "Work on the user's request normally. Privately, within this same turn, notice whether the work reveals a missing ability, recurring friction, or reusable leverage in your Unicity AOS user-space world. If useful, proactively use the Meta Harness skill and directly reuse, remember, compose, improve the harness, or Forge-build when that action is already inside the user's intent and your existing authority. Ask only when the action normally needs new authority. Do not add a second response, announce this check, or report that nothing was found.";
+
+#[derive(Debug, Deserialize)]
+struct HookRequest {
+    payload: String,
+    #[serde(default)]
+    correlation_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CanonicalHostPayload {
+    host: String,
+    session_id: String,
+    source_event: String,
+}
+
+/// Proactive reflection responder for host prompt turns.
+#[derive(Default)]
+pub struct MetaHarness;
+
+fn is_correlation(value: &str) -> bool {
+    value.len() == 32
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn activation_context() -> Result<Option<&'static str>, SysError> {
+    match env::var("activation")?.trim().to_ascii_lowercase().as_str() {
+        "" | "adaptive" => Ok(Some(ADAPTIVE_CONTEXT)),
+        "propose" => Ok(Some(PROPOSE_CONTEXT)),
+        "automatic" => Ok(Some(AUTOMATIC_CONTEXT)),
+        "off" => Ok(None),
+        other => {
+            log::warn(format!(
+                "meta-harness: unknown activation mode '{other}', using adaptive"
+            ));
+            Ok(Some(ADAPTIVE_CONTEXT))
+        }
+    }
+}
+
+#[capsule]
+impl MetaHarness {
+    /// Add private same-turn reflection context to an exact host prompt turn.
+    #[astrid::interceptor("on_message_received")]
+    pub fn on_message_received(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        let request: HookRequest = match serde_json::from_value(payload) {
+            Ok(request) => request,
+            Err(error) => {
+                log::warn(format!("meta-harness: malformed hook request: {error}"));
+                return Ok(());
+            }
+        };
+        let Some(correlation_id) = request.correlation_id else {
+            return Ok(());
+        };
+        if !is_correlation(&correlation_id) {
+            log::warn("meta-harness: ignored unroutable hook correlation");
+            return Ok(());
+        }
+        let canonical: CanonicalHostPayload = match serde_json::from_str(&request.payload) {
+            Ok(canonical) => canonical,
+            Err(error) => {
+                log::warn(format!(
+                    "meta-harness: malformed canonical payload: {error}"
+                ));
+                return Ok(());
+            }
+        };
+        if canonical.source_event != "user_prompt_submit"
+            || !matches!(canonical.host.as_str(), "codex" | "claude" | "grok")
+            || canonical.session_id.is_empty()
+        {
+            return Ok(());
+        }
+        let Some(context) = activation_context()? else {
+            return Ok(());
+        };
+        ipc::publish_json(
+            &format!("hook.v1.response.message_received.{correlation_id}"),
+            &serde_json::json!({ "additional_context": context }),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn correlation_is_one_lower_hex_segment() {
+        assert!(is_correlation(&"a".repeat(32)));
+        assert!(!is_correlation("a.b"));
+        assert!(!is_correlation(&"A".repeat(32)));
+        assert!(!is_correlation(&"a".repeat(31)));
+    }
+
+    #[test]
+    fn context_is_same_turn_and_non_reporting() {
+        assert!(ADAPTIVE_CONTEXT.contains("within this same turn"));
+        assert!(ADAPTIVE_CONTEXT.contains("Do not add a second response"));
+        assert!(ADAPTIVE_CONTEXT.contains("report that nothing was found"));
+    }
+}

--- a/crates/unicity-aos-bootstrap/Cargo.toml
+++ b/crates/unicity-aos-bootstrap/Cargo.toml
@@ -7,6 +7,7 @@ description = "Product-owned runtime layout and launcher for Unicity AOS."
 
 [dependencies]
 astrid-core.workspace = true
+astrid-types.workspace = true
 astrid-uplink.workspace = true
 axum.workspace = true
 blake3.workspace = true
@@ -16,6 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 toml.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/unicity-aos-bootstrap/src/hook.rs
+++ b/crates/unicity-aos-bootstrap/src/hook.rs
@@ -1,0 +1,343 @@
+//! Authenticated host-hook ingress for AOS plugins.
+
+use std::io::Read;
+use std::time::Duration;
+
+use astrid_core::{PrincipalId, SessionId};
+use astrid_types::Topic;
+use astrid_types::ipc::{IpcMessage, IpcPayload};
+use astrid_uplink::SocketClient;
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use uuid::Uuid;
+
+const MAX_PAYLOAD_BYTES: u64 = 1024 * 1024;
+const MAX_TIMEOUT_MS: u64 = 30_000;
+const DEFAULT_TIMEOUT_MS: u64 = 5_000;
+
+/// A private, session-targeted hook delivery from a host plugin.
+#[derive(Debug, Args)]
+pub struct HookArgs {
+    /// Host adapter producing this event: codex, claude, or grok.
+    #[arg(long, value_parser = parse_host)]
+    host: String,
+    /// Exact host session receiving any returned context.
+    #[arg(long, value_parser = parse_segment)]
+    session: String,
+    /// Normalized host event name.
+    #[arg(long, value_parser = parse_segment)]
+    event: String,
+    /// Optional workspace identifier for observability and future routing.
+    #[arg(long, value_parser = parse_segment)]
+    workspace: Option<String>,
+    /// Maximum time to wait for a targeted hook response.
+    #[arg(long, default_value_t = DEFAULT_TIMEOUT_MS, value_parser = parse_timeout)]
+    timeout_ms: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct HostHookRequest {
+    schema_version: u8,
+    principal_id: String,
+    host: String,
+    session_id: String,
+    event: String,
+    correlation_id: String,
+    route_id: String,
+    delivery_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    turn_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<String>,
+    payload: Value,
+    token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct HostHookResponse {
+    schema_version: u8,
+    principal_id: String,
+    host: String,
+    session_id: String,
+    #[serde(default)]
+    event: Option<String>,
+    correlation_id: String,
+    route_id: String,
+    delivery_id: String,
+    #[serde(default)]
+    context: Option<String>,
+}
+
+pub(crate) fn handle(principal: String, args: HookArgs) -> Result<Option<String>, String> {
+    let token = std::env::var("ASTRID_HOOK_TOKEN")
+        .map_err(|_| "ASTRID_HOOK_TOKEN is required for `aos hook`".to_owned())?;
+    validate_token(&token)?;
+
+    let mut input = Vec::new();
+    std::io::stdin()
+        .take(MAX_PAYLOAD_BYTES + 1)
+        .read_to_end(&mut input)
+        .map_err(|error| format!("could not read hook payload: {error}"))?;
+    if input.len() as u64 > MAX_PAYLOAD_BYTES {
+        return Err(format!(
+            "hook payload exceeds the {MAX_PAYLOAD_BYTES}-byte limit"
+        ));
+    }
+    let payload = if input.iter().all(u8::is_ascii_whitespace) {
+        Value::Object(serde_json::Map::new())
+    } else {
+        serde_json::from_slice(&input)
+            .map_err(|error| format!("hook payload is not valid JSON: {error}"))?
+    };
+
+    let principal = PrincipalId::new(principal.clone())
+        .map_err(|error| format!("invalid hook principal: {error}"))?;
+    let correlation_id = Uuid::new_v4().simple().to_string();
+    let route_id = derive_route_id(&args.host, &args.session, &token);
+    let delivery_id = delivery_id(&route_id, &correlation_id);
+    let turn_id = payload
+        .get("turn_id")
+        .or_else(|| payload.get("turnId"))
+        .and_then(value_as_identifier);
+
+    let request = HostHookRequest {
+        schema_version: 1,
+        principal_id: principal.to_string(),
+        host: args.host.clone(),
+        session_id: args.session.clone(),
+        event: args.event,
+        correlation_id,
+        route_id,
+        delivery_id,
+        turn_id,
+        workspace_id: args.workspace,
+        payload,
+        token,
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("could not start hook client: {error}"))?;
+    runtime.block_on(deliver(
+        principal,
+        request,
+        Duration::from_millis(args.timeout_ms),
+    ))
+}
+
+async fn deliver(
+    principal: PrincipalId,
+    request: HostHookRequest,
+    timeout: Duration,
+) -> Result<Option<String>, String> {
+    let connection_id = Uuid::new_v4();
+    let mut client = SocketClient::connect(SessionId::from_uuid(connection_id), principal.clone())
+        .await
+        .map_err(|error| format!("could not connect to the AOS runtime: {error}"))?;
+    if !client.is_authenticated() {
+        return Err(format!(
+            "the AOS runtime did not authenticate principal {principal}"
+        ));
+    }
+
+    let ingress_topic = format!("astrid.v1.request.mcp.hook.{}", request.host);
+    let response_topic = format!("astrid.v1.response.{}", request.delivery_id);
+    let message = IpcMessage::new(
+        Topic::from_raw(ingress_topic),
+        IpcPayload::RawJson(
+            serde_json::to_value(&request)
+                .map_err(|error| format!("could not encode hook request: {error}"))?,
+        ),
+        connection_id,
+    );
+    client
+        .send_message(message)
+        .await
+        .map_err(|error| format!("could not publish hook request: {error}"))?;
+
+    let raw = client
+        .read_until_topic(&response_topic, timeout)
+        .await
+        .map_err(|error| format!("hook response unavailable: {error}"))?;
+    let response: HostHookResponse = serde_json::from_value(extract_raw_payload(&raw)?)
+        .map_err(|error| format!("hook response is malformed: {error}"))?;
+    validate_response(&request, &response)?;
+    Ok(response
+        .context
+        .filter(|context| !context.trim().is_empty()))
+}
+
+fn extract_raw_payload(raw: &Value) -> Result<Value, String> {
+    let payload = raw
+        .get("payload")
+        .ok_or_else(|| "hook response has no payload".to_owned())?;
+    if payload.get("type").and_then(Value::as_str) == Some("raw_json") {
+        payload
+            .get("value")
+            .cloned()
+            .ok_or_else(|| "hook response raw payload has no value".to_owned())
+    } else {
+        Ok(payload.clone())
+    }
+}
+
+fn validate_response(request: &HostHookRequest, response: &HostHookResponse) -> Result<(), String> {
+    let matches = response.schema_version == request.schema_version
+        && response.principal_id == request.principal_id
+        && response.host == request.host
+        && response.session_id == request.session_id
+        && response
+            .event
+            .as_deref()
+            .is_none_or(|event| event == request.event)
+        && response.correlation_id == request.correlation_id
+        && response.route_id == request.route_id
+        && response.delivery_id == request.delivery_id;
+    if matches {
+        Ok(())
+    } else {
+        Err("hook response did not match the exact host session route".to_owned())
+    }
+}
+
+fn derive_route_id(host: &str, session: &str, token: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"unicity-aos-hook-route-v1\0");
+    hasher.update(host.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(session.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(token.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+fn delivery_id(route_id: &str, correlation_id: &str) -> String {
+    format!("{route_id}-{correlation_id}")
+}
+
+fn value_as_identifier(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) if !value.is_empty() => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn parse_host(value: &str) -> Result<String, String> {
+    match value {
+        "codex" | "claude" | "grok" => Ok(value.to_owned()),
+        _ => Err("host must be codex, claude, or grok".to_owned()),
+    }
+}
+
+fn parse_segment(value: &str) -> Result<String, String> {
+    if is_segment(value) {
+        Ok(value.to_owned())
+    } else {
+        Err("expected 1-128 ASCII letters, digits, underscores, or hyphens".to_owned())
+    }
+}
+
+fn is_segment(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+fn validate_token(token: &str) -> Result<(), String> {
+    if token.len() < 32
+        || token.len() > 128
+        || !token.bytes().all(|byte| byte.is_ascii_alphanumeric())
+    {
+        return Err(
+            "ASTRID_HOOK_TOKEN must be 32-128 ASCII letters or digits with no whitespace"
+                .to_owned(),
+        );
+    }
+    Ok(())
+}
+
+fn parse_timeout(value: &str) -> Result<u64, String> {
+    let timeout = value
+        .parse::<u64>()
+        .map_err(|_| "timeout must be an integer number of milliseconds".to_owned())?;
+    if timeout == 0 || timeout > MAX_TIMEOUT_MS {
+        return Err(format!("timeout must be between 1 and {MAX_TIMEOUT_MS} ms"));
+    }
+    Ok(timeout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn route_is_stable_and_secret_bound() {
+        let first = derive_route_id("codex", "codex-session", &"a".repeat(64));
+        assert_eq!(
+            first,
+            derive_route_id("codex", "codex-session", &"a".repeat(64))
+        );
+        assert_ne!(
+            first,
+            derive_route_id("codex", "codex-session", &"b".repeat(64))
+        );
+        assert_ne!(
+            first,
+            derive_route_id("codex", "other-session", &"a".repeat(64))
+        );
+    }
+
+    #[test]
+    fn delivery_topic_has_one_dynamic_segment() {
+        let delivery = delivery_id(&"a".repeat(64), &"b".repeat(32));
+        assert!(is_segment(&delivery));
+        assert_eq!(delivery.split('.').count(), 1);
+    }
+
+    #[test]
+    fn response_must_match_every_routing_dimension() {
+        let request = HostHookRequest {
+            schema_version: 1,
+            principal_id: "codex-code".to_owned(),
+            host: "codex".to_owned(),
+            session_id: "codex-one".to_owned(),
+            event: "user_prompt_submit".to_owned(),
+            correlation_id: "correlation".to_owned(),
+            route_id: "route".to_owned(),
+            delivery_id: "delivery".to_owned(),
+            turn_id: None,
+            workspace_id: None,
+            payload: serde_json::json!({}),
+            token: "a".repeat(64),
+        };
+        let mut response = HostHookResponse {
+            schema_version: 1,
+            principal_id: request.principal_id.clone(),
+            host: request.host.clone(),
+            session_id: request.session_id.clone(),
+            event: Some(request.event.clone()),
+            correlation_id: request.correlation_id.clone(),
+            route_id: request.route_id.clone(),
+            delivery_id: request.delivery_id.clone(),
+            context: Some("context".to_owned()),
+        };
+        assert!(validate_response(&request, &response).is_ok());
+        response.event = None;
+        assert!(validate_response(&request, &response).is_ok());
+        response.session_id = "codex-two".to_owned();
+        assert!(validate_response(&request, &response).is_err());
+    }
+
+    #[test]
+    fn topic_segments_reject_smuggling() {
+        assert!(parse_segment("codex-session_1").is_ok());
+        assert!(parse_segment("codex.session").is_err());
+        assert!(parse_segment("../session").is_err());
+        assert!(parse_segment("").is_err());
+    }
+}

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -1023,7 +1023,7 @@ mod tests {
         let encoded = materialize_manifest(&capsule_dir).expect("materialize manifest");
         let decoded: toml::Value = encoded.parse().expect("parse materialized TOML");
         let capsules = decoded["capsule"].as_array().expect("capsule array");
-        assert_eq!(capsules.len(), 19);
+        assert_eq!(capsules.len(), 20);
         assert!(capsules.iter().all(|capsule| {
             PathBuf::from(capsule["source"].as_str().expect("absolute source")).parent()
                 == Some(capsule_dir.as_path())

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -14,6 +14,8 @@ use std::time::Duration;
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use unicity_aos_bootstrap::{AOS_WORKSPACE_STATE_DIR, AosHome};
 
+mod hook;
+
 // Product-owned commands are parsed here. Unknown roots bypass this parser and
 // are delegated byte-for-byte to the bundled runtime by `main`.
 #[derive(Parser)]
@@ -52,6 +54,8 @@ enum ProductCommand {
     Update(UpdateArgs),
     /// Distribution state is fixed to Unicity CE in this AOS release.
     Distro(DistroArgs),
+    /// Deliver a host hook through the authenticated AOS event bus.
+    Hook(hook::HookArgs),
     /// Serve the loopback-only product health endpoint.
     ServeHealth,
 }
@@ -276,11 +280,11 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
     if cli.principal.is_some()
         && !matches!(
             &cli.command,
-            Some(ProductCommand::Init(_) | ProductCommand::Distro(_))
+            Some(ProductCommand::Init(_) | ProductCommand::Distro(_) | ProductCommand::Hook(_))
         )
     {
         eprintln!(
-            "aos: '--principal' is supported for `aos init`; this AOS-owned command does not accept an operator principal"
+            "aos: '--principal' is supported for `aos init` and `aos hook`; this AOS-owned command does not accept an operator principal"
         );
         return Some(ExitCode::from(2));
     }
@@ -293,6 +297,7 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
         }) => Some(handle_migrate_runtime(&from)),
         Some(ProductCommand::Update(args)) => Some(handle_self_update(&args)),
         Some(ProductCommand::Distro(args)) => Some(refuse_distro_command(&args.arguments)),
+        Some(ProductCommand::Hook(args)) => Some(handle_hook(cli.principal, args)),
         Some(ProductCommand::ServeHealth) => Some(handle_health_service()),
         None => Some(print_product_help()),
     }
@@ -509,6 +514,7 @@ fn is_owned_root(value: &str) -> bool {
             | "self-update"
             | "self_update"
             | "distro"
+            | "hook"
             | "serve-health"
     )
 }
@@ -712,6 +718,31 @@ fn handle_health_service() -> ExitCode {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("aos: health service failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn handle_hook(principal: Option<String>, args: hook::HookArgs) -> ExitCode {
+    let home = match resolve_home() {
+        Ok(home) => home,
+        Err(code) => return code,
+    };
+    set_runtime_environment(&home);
+    let principal = principal.unwrap_or_else(|| "default".to_owned());
+    match hook::handle(principal, args) {
+        Ok(Some(context)) => {
+            print!("{context}");
+            if let Err(error) = io::stdout().flush() {
+                eprintln!("aos: failed to write hook response: {error}");
+                ExitCode::FAILURE
+            } else {
+                ExitCode::SUCCESS
+            }
+        }
+        Ok(None) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("aos: hook delivery failed: {error}");
             ExitCode::FAILURE
         }
     }

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -440,7 +440,7 @@ fn offline_init_keeps_the_runtime_offline_flag_and_uses_only_local_capsules() {
         .parse()
         .expect("parse materialized manifest");
     let capsules = manifest["capsule"].as_array().expect("capsule entries");
-    assert_eq!(capsules.len(), 19);
+    assert_eq!(capsules.len(), 20);
     let expected_root = fixture
         .home
         .join("releases")

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -101,6 +101,11 @@ name = "aos-hook-bridge"
 source = "capsules/aos-hook-bridge.capsule"
 version = "0.2.0"
 
+[[capsule]]
+name = "aos-meta-harness"
+source = "capsules/aos-meta-harness.capsule"
+version = "0.1.0"
+
 # ---------------------------------------------------------------------------
 # Tools
 # ---------------------------------------------------------------------------

--- a/release/community-capsules.txt
+++ b/release/community-capsules.txt
@@ -13,6 +13,7 @@ capsule-router
 capsule-prompt-builder
 capsule-context-engine
 capsule-hook-bridge
+capsule-meta-harness
 capsule-shell
 capsule-http
 capsule-fs

--- a/scripts/test-clean-home-init.sh
+++ b/scripts/test-clean-home-init.sh
@@ -94,8 +94,8 @@ expected = sorted(
     for line in assets_path.read_text(encoding="utf-8").splitlines()
     if line
 )
-if len(expected) != 19 or len(set(expected)) != 19:
-    raise SystemExit("release capsule inventory is not the exact 19-capsule CE set")
+if len(expected) != 20 or len(set(expected)) != 20:
+    raise SystemExit("release capsule inventory is not the exact 20-capsule CE set")
 with lock_path.open("rb") as file:
     lock = tomllib.load(file)
 with profile_path.open("rb") as file:

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -251,7 +251,7 @@ release_dir="$work/home/.aos/releases/2026.1.3"
 test -f "$release_dir/release-manifest.json"
 test -f "$release_dir/Distro.toml"
 test -f "$release_dir/capsule-assets.txt"
-test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 19
+test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 20
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"
@@ -608,7 +608,7 @@ for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
   test "$("$destination")" = "old-$binary"
 done
 test "$(cat "$release_dir/release-manifest.json")" = old-release-manifest
-test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 19
+test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 20
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -69,7 +69,7 @@ tar -tzf "$archive" > "$work/files"
 grep -q '/bin/aos$' "$work/files"
 grep -q '/libexec/install.sh$' "$work/files"
 grep -q '/runtime/bin/astrid-daemon$' "$work/files"
-test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 19
+test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 20
 grep -q '/capsule-assets.txt$' "$work/files"
 grep -q '/Distro.toml$' "$work/files"
 grep -q '/release-manifest.json$' "$work/files"
@@ -77,7 +77,7 @@ grep -q '/release-manifest.json$' "$work/files"
 tar -xzf "$archive" -C "$work"
 manifest=$(find "$work" -path '*/release-manifest.json' -print -quit)
 bundle_root=$(dirname "$manifest")
-test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 19
+test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 20
 if grep -F '@unicity-aos/capsule-' "$bundle_root/Distro.toml" >/dev/null; then
   echo "release archive retained a legacy capsule repository source" >&2
   exit 1
@@ -99,9 +99,9 @@ assert manifest["contracts"]["repository"] == "astrid-runtime/wit"
 assert manifest["contracts"]["commit"] == "278dbca3e32f327d0f2358644fc86559779ba0fd"
 assert manifest["contracts"]["sdk_rust_version"] == "0.7.1"
 assert manifest["contracts"]["sdk_rust_commit"] == "bbbc61c8821d6c536fb25d2068b6b646e759ad35"
-assert manifest["capsules"]["count"] == 19
-assert len(manifest["capsules"]["assets"]) == 19
-assert len(set(manifest["capsules"]["assets"])) == 19
+assert manifest["capsules"]["count"] == 20
+assert len(manifest["capsules"]["assets"]) == 20
+assert len(set(manifest["capsules"]["assets"])) == 20
 PY
 
 unsafe_root="$work/unsafe-runtime"

--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -85,15 +85,15 @@ class CapsuleReleaseTests(unittest.TestCase):
             write_fixture(directory / spec.asset, spec)
 
     def test_source_contract_has_exact_community_set(self) -> None:
-        self.assertEqual(len(self.specs), 19)
-        self.assertEqual(len({spec.asset for spec in self.specs}), 19)
+        self.assertEqual(len(self.specs), 20)
+        self.assertEqual(len({spec.asset for spec in self.specs}), 20)
         assets = {spec.asset for spec in self.specs}
         self.assertIn("aos-forge.capsule", assets)
         self.assertNotIn("aos-telegram.capsule", assets)
         distro = Path(__file__).resolve().parent.parent / "distros/community/unicity-ce/Distro.toml"
         text = distro.read_text(encoding="utf-8")
         self.assertNotIn("@unicity-aos/", text)
-        self.assertEqual(text.count('source = "capsules/'), 19)
+        self.assertEqual(text.count('source = "capsules/'), 20)
         for spec in self.specs:
             self.assertIn(f'source = "capsules/{spec.asset}"', text)
 

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -113,7 +113,7 @@ class ReleasePublicationTests(unittest.TestCase):
             artifacts, compatibility = self.fixture(Path(temp))
             payloads = self.validate(artifacts, compatibility)
             self.assertIn(f"unicity-aos-{VERSION}-release.toml", payloads)
-            self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 19)
+            self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 20)
 
     def test_rejects_missing_asset(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## What changed

- add a product-owned `aos hook` command for authenticated Codex, Claude, and Grok host events
- normalize validated host events through the existing hook bridge
- add the Community Edition `aos-meta-harness` capsule with adaptive, propose, automatic, and off activation modes
- return private prompt context only to the exact originating host session through a secret-bound route and correlation ID
- bound ingress payloads and combined response context, preserve additive response compatibility, and update the CE inventory to 20 capsules

## Why

The Meta Harness skill teaches agents how to extend their AOS user-space world, but a skill alone does not create the proactive moment. This activates that reflection at `UserPromptSubmit`, before the agent's response loop, without adding a second response or broadcasting context to every session under a principal.

The kernel remains policy-neutral: authenticated ingress, normalization, activation policy, and prompt context stay in product and capsule space.

## Validation

- `cargo test -p unicity-aos-bootstrap -p aos-hook-bridge -p aos-meta-harness --offline`
- `cargo clippy -p unicity-aos-bootstrap -p aos-hook-bridge -p aos-meta-harness --offline -- -D warnings`
- release inventory and packaging test suites
- fresh `astrid-build` packages for the hook bridge and Meta Harness capsules
- live throwaway-principal proof that the intended Codex session receives same-turn context while a wrong token and a different session cannot receive it

No version bump or public release is included.
