### PR TITLE
Own MCP interaction and broker edge in AOS CE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           toolchain: "1.95.0"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo install b3sum --locked --version "$B3SUM_VERSION"
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - run: sh -n install.sh
       - run: python3 scripts/validate-release-contract.py
       - run: python3 scripts/test_validate_release_contract.py
@@ -50,6 +51,8 @@ jobs:
       - run: python3 scripts/test_channel_transaction.py
       - run: python3 scripts/test_channel_publication.py
       - run: python3 scripts/test_release_publication.py
+      - run: python3 scripts/test_runtime_command_surface.py
+      - run: bash scripts/test-pinned-runtime-command-surface.sh
       - run: bash scripts/test-channel-workflow-contract.sh
       - run: python3 scripts/test_create_astrid_094_fixture.py
       - run: bash scripts/test-package-release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,9 @@ jobs:
           key: aos-release-identity
       - name: Install pinned BLAKE3 checksum tool
         run: cargo install b3sum --locked --version "$B3SUM_VERSION"
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Verify the pinned runtime command surface
+        run: bash scripts/test-pinned-runtime-command-surface.sh
       - name: Refuse a nightly after its canonical base is tagged
         if: needs.classify.outputs.nightly == 'true'
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@
   form elicitation continue to render their own approvals; hosts such as Grok
   fall back to AppKit on macOS, native confirmation on Windows, or Pinentry on
   Linux. Free-form and secret-shaped fields are refused by this bridge.
+- Pin the exact public root-command inventory of the bundled runtime and fail
+  validation when a runtime update adds or removes a verb before AOS classifies
+  it as inherited, product-owned, or shared. Runtime verbs remain direct
+  `aos <verb>` commands without a nested runtime namespace.
 
 - Keep agent Skills out of `Capsule.toml` and the generic capsule release
   contract. Host plugins may vendor trigger Skills, the AOS Skills service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Runtime import holds the standalone daemon's existing singleton lock without
   changing the source, and interrupted unreceipted cutovers always roll back
   before recopying the current locked source.
-- A signed release path for the 20 installable `aos-*` artifacts
+- A signed release path for the 21 installable `aos-*` artifacts
   built from this source tree and selected locally by Community Edition, with
   exact source/manifest identity checks, product-archive inclusion, offline
   provisioning, archive safety validation, BLAKE3 checksums, SHA-256
@@ -42,7 +42,7 @@
   contracts with exact workflow identities, expiry, replay-resistant generation
   state, and fail-closed direct installer resolution.
 - A native release gate that initializes a clean AOS home, verifies the exact
-  20-capsule CE lock, grants, and ready set, repeats initialization without
+  21-capsule CE lock, grants, and ready set, repeats initialization without
   changing runtime state, and proves clean daemon shutdown before publication.
 - Native `aos status` output for authenticated running state and verified
   stopped state without invoking the runtime CLI.
@@ -52,6 +52,12 @@
   disabled by default; merging `main` never publishes a release.
 
 ### Changed
+
+- Own the host-facing `aos mcp serve` command, MCP server identity, constrained
+  interaction fallback, and `aos-mcp` broker capsule in AOS CE. Hosts with MCP
+  form elicitation continue to render their own approvals; hosts such as Grok
+  fall back to AppKit on macOS, native confirmation on Windows, or Pinentry on
+  Linux. Free-form and secret-shaped fields are refused by this bridge.
 
 - Keep agent Skills out of `Capsule.toml` and the generic capsule release
   contract. Host plugins may vendor trigger Skills, the AOS Skills service

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aos-mcp"
+version = "0.1.0"
+dependencies = [
+ "aos-mcp-broker",
+ "astrid-sdk",
+ "blake3",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "aos-mcp-broker"
+version = "0.1.0"
+dependencies = [
+ "astrid-sdk",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "aos-memory"
 version = "0.2.0"
 dependencies = [
@@ -714,6 +735,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +781,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1073,6 +1114,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1416,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1515,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",
@@ -1580,12 +1680,16 @@ dependencies = [
  "blake3",
  "clap",
  "fs2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "serde",
  "serde_json",
  "tokio",
  "toml",
  "tower",
  "uuid",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/unicity-aos-bootstrap",
+    "crates/aos-mcp-broker",
     "capsules/capsule-agents",
     "capsules/capsule-cli",
     "capsules/capsule-context-engine",
@@ -11,6 +12,7 @@ members = [
     "capsules/capsule-http",
     "capsules/capsule-identity",
     "capsules/capsule-memory",
+    "capsules/capsule-mcp",
     "capsules/capsule-openai",
     "capsules/capsule-openai-compat",
     "capsules/capsule-prompt-builder",
@@ -36,7 +38,7 @@ clap = { version = "4.6", features = ["derive"] }
 fs2 = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1", features = ["net", "rt", "time"] }
+tokio = { version = "1", features = ["io-std", "io-util", "macros", "net", "process", "rt", "time"] }
 toml = "0.8"
 uuid = { version = "1.22", features = ["rng-getrandom", "serde", "v4"] }
 

--- a/README.md
+++ b/README.md
@@ -49,21 +49,18 @@ aos status --json
 aos --principal codex-code mcp serve
 ```
 
-Every other root inherits the bundled Astrid CLI transparently. Arguments, exit
-codes, and signals pass through unchanged:
+Every other runtime root is part of the AOS CLI directly. Arguments, exit
+codes, and signals pass through unchanged; there is no nested `aos astrid` or
+`aos runtime` namespace:
 
 ```sh
 aos doctor
 aos capsule build
 ```
 
-An AOS-owned root intentionally shadows the runtime root with the same name.
-Use the standalone runtime CLI when the raw command is required:
-
-```sh
-astrid status
-astrid init --help
-```
+When AOS owns a root such as `status`, `init`, `update`, or `mcp`, its product
+implementation replaces the lower-level command at that same location. The
+complete supported surface therefore remains `aos <verb>`.
 
 `aos mcp serve` is the product edge shared by Codex, Claude, and Grok. A client
 that supports MCP form elicitation keeps presenting its own constrained

--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ aos capsule build
 
 When AOS owns a root such as `status`, `init`, `update`, or `mcp`, its product
 implementation replaces the lower-level command at that same location. The
-complete supported surface therefore remains `aos <verb>`.
+complete supported surface therefore remains `aos <verb>`. Release validation
+compares the exact pinned runtime's public command inventory with AOS's
+classified root contract, so a new runtime verb cannot enter a product release
+without an explicit inherit-or-own decision.
 
 `aos mcp serve` is the product edge shared by Codex, Claude, and Grok. A client
 that supports MCP form elicitation keeps presenting its own constrained

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ docs/         Product and operator documentation
 ## Install
 
 The supported installer installs the `aos` product command, its pinned runtime,
-and the exact 19 Community Edition capsules built from this source tree under
+and the exact 21 Community Edition capsules built from this source tree under
 the product-owned `~/.aos` root:
 
 ```sh
@@ -41,11 +41,12 @@ generated runtime coordination state.
 ## Command boundary
 
 AOS owns its product roots, including `init`, `status`, `migrate`, `update`,
-`distro`, and `serve-health`:
+`distro`, `mcp`, and `serve-health`:
 
 ```sh
 aos status
 aos status --json
+aos --principal codex-code mcp serve
 ```
 
 Every other root inherits the bundled Astrid CLI transparently. Arguments, exit
@@ -63,6 +64,15 @@ Use the standalone runtime CLI when the raw command is required:
 astrid status
 astrid init --help
 ```
+
+`aos mcp serve` is the product edge shared by Codex, Claude, and Grok. A client
+that supports MCP form elicitation keeps presenting its own constrained
+approval forms. When a client does not, the default `--interaction auto` mode
+uses a local AOS decision surface: AppKit on macOS, a native Windows dialog, or
+Pinentry on Linux. `--interaction client`, `native`, and `deny` make the policy
+explicit. The local bridge accepts only a single boolean or the fixed AOS
+approval enum; arbitrary strings, password-shaped fields, and URL
+elicitations are never collected through it.
 
 ## Build on AOS
 

--- a/capsules/capsule-mcp/.cargo/config.toml
+++ b/capsules/capsule-mcp/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "wasm32-unknown-unknown"
+
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg=getrandom_backend=\"custom\""]

--- a/capsules/capsule-mcp/Capsule.toml
+++ b/capsules/capsule-mcp/Capsule.toml
@@ -1,0 +1,175 @@
+[package]
+name = "aos-mcp"
+version = "0.1.0"
+description = "Unicity AOS MCP broker bridging Astrid capsule tools to host agents"
+authors = [
+    "Joshua J. Bouw <dev@joshuajbouw.com>",
+    "Unicity Labs <info@unicity-labs.com>",
+]
+astrid-version = ">=0.7.0"
+
+[[component]]
+id = "aos-mcp"
+file = "aos_mcp.wasm"
+type = "executable"
+
+[capabilities]
+kv = []
+
+# The confused-deputy gate for the state-mutating broker front door
+# (`astrid.v1.request.mcp.tool.call`) no longer reads an operator-maintained
+# allow-set. An ingress `source_id` (the kernel-set originating-capsule UUID)
+# is trusted iff the user has interactively consented to it — recorded under
+# the per-(principal, source_id) KV key `mcp.ingress.trust.<source_id>` by
+# `approval::handle_mcp_ingress_respond` after an elicit prompt. The `kv`
+# capability above backs that read/write.
+#
+# Per-principal argument-level policy rules — a JSON array of
+# { id, effect:"deny"|"allow", tool:"<glob>", when:[{pointer,op,value}] }.
+# Evaluated IN-PROCESS at the broker chokepoint (`policy::evaluate`,
+# read via `env::var_opt("policy_rules")`, so it resolves the invoking
+# principal's overlay — per-principal with no cross-capsule KV write). The
+# PDP only NARROWS: unset / empty /
+# malformed → no policy → the host's exec-time capability enforcement
+# remains the boundary (degrade-to-PEP + a loud `astrid.v1.audit.policy_*`
+# audit). DENY rules over free-form strings are best-effort (the kernel
+# resolves `home://` host-side; a raw-literal path/command deny is
+# evadable) — the robust shapes are allowlist-style eq/prefix. See
+# `crate::policy`.
+[env]
+policy_rules = { type = "string", default = "", request = "Per-principal policy rules as a JSON array (leave blank for none); see aos-mcp policy docs" }
+
+# aos-mcp describes the tool surface the host agent sees by querying the tool
+# registry and reshaping into MCP tool descriptors, and brokers tool
+# execution over the `astrid.v1.*` MCP surface (dispatched via the
+# tool.v1 bus protocol). Tool calls arrive ONLY through that broker front
+# door — `aos mcp serve` is the registered MCP server the supervised
+# host agent calls directly; there is no `astrid.v1.tool.call.*`
+# agent-runner leg (it would double-execute against the broker).
+[subscribe]
+# Authenticated host shims enter through the same kernel-recognized request
+# plane as MCP. aos-mcp validates the kernel-stamped principal plus the
+# session token before releasing a token-free event onto the internal bus.
+"astrid.v1.request.mcp.hook.codex" = { wit = "opaque", handler = "handle_codex_hook" }
+"astrid.v1.request.mcp.hook.claude" = { wit = "opaque", handler = "handle_claude_hook" }
+"astrid.v1.request.mcp.hook.grok" = { wit = "opaque", handler = "handle_grok_hook" }
+# The hook bridge answers on an internal delivery topic. aos-mcp revalidates
+# its principal/session/secret-derived route, then relays it to the exact
+# `astrid.v1.response.<delivery>` topic awaited by the originating uplink.
+"oracle.v1.hook.response.*" = { wit = "opaque", handler = "relay_host_hook_response" }
+"astrid.v1.tools.describe" = { wit = "opaque", handler = "describe_tools" }
+"tool.v1.response.describe.*" = { wit = "@unicity-astrid/wit/tool/describe-response", handler = "collect_tool_descriptors" }
+# Capsule-set change signal. The kernel publishes `astrid.v1.capsules_loaded`
+# whenever the loaded-capsule set changes (install / live upgrade / live
+# remove). The descriptor-cache merge path above only ADDS, so a removed or
+# upgraded capsule's tools would linger until the TTL; `handle_capsules_changed`
+# invalidates the cache so the next `tools/list` re-discovers the live surface.
+# Exact (segment-arity-fixed) topic; the payload is a bare ready-signal.
+"astrid.v1.capsules_loaded" = { wit = "opaque", handler = "handle_capsules_changed" }
+# Broker front door: the sanitized `astrid.v1.*` MCP surface for an MCP
+# client behind a shim/proxy (`aos mcp serve`). The shim never sees
+# `tool.v1.*`. Both are exact (segment-arity-fixed) topics — the proxy
+# carries the correlation token in the body, not the topic, so no
+# wildcard suffix is needed here.
+"astrid.v1.request.mcp.tools.list" = { wit = "broker/list-request", handler = "handle_mcp_list" }
+"astrid.v1.request.mcp.tool.call" = { wit = "broker/call-request", handler = "handle_mcp_call" }
+# Elicitation/approval bridge (broker side). The shim forwards the host agent's
+# elicited approval choice here; `handle_mcp_approval` maps it onto
+# `astrid.v1.approval.response.<id>` to unblock the parked tool. Exact
+# (segment-arity-fixed) topic — the proxy carries the correlation token in
+# the body. State-mutating (it can grant a capability), so the handler is
+# confused-deputy gated on the kernel-set `source_id` (a trusted ingress),
+# the same gate the tool-call front door uses.
+"astrid.v1.request.mcp.approval.respond" = { wit = "broker/approval-respond", handler = "handle_mcp_approval" }
+# Ingress consent bridge (broker side). When a `tool.call` arrives from an
+# untrusted `source_id`, the broker replies an `ingress_approval_required`
+# signal; the shim elicits the user's consent and forwards the decision here
+# as `{ req_id, accept }`. On accept, `handle_mcp_ingress_respond` records
+# trust under `mcp.ingress.trust.<source_id>` (the SECURITY-CRITICAL
+# `source_id` is the kernel-stamped `runtime::caller().source_id` of this
+# message — never a body field) and acks on `astrid.v1.response.<req_id>`.
+# Exact (segment-arity-fixed) topic.
+"astrid.v1.request.mcp.ingress.respond" = { wit = "opaque", handler = "handle_mcp_ingress_respond" }
+# Capsule-grant consent bridge (broker side). When a `tool.call` is refused by
+# the kernel access gate (the principal has not granted the target capsule),
+# the broker replies a `grant_required` flag; the shim elicits the user's
+# Grant/Deny and forwards it here as `{ req_id, request_id, decision,
+# capsule_id }`. `handle_mcp_grant_respond` maps the choice onto
+# `astrid.v1.approval.response.<request_id>` (the SAME envelope the approval
+# flow uses, consumed verbatim by the kernel grant handler) and acks on
+# `astrid.v1.response.<req_id>`. PUBLISH-THEN-ACK, no result drain — the kernel
+# dropped the call (grant-on-use mirrors INGRESS: gate → consent → re-send).
+# State-mutating (an approve persists a grant), so it is confused-deputy gated
+# on the kernel-set `source_id`. Exact (segment-arity-fixed) topic. No new
+# publish ACL needed: the `astrid.v1.approval.response.*` decision channel and
+# the `astrid.v1.response.*` ack channel are already declared.
+"astrid.v1.request.mcp.grant.respond" = { wit = "opaque", handler = "handle_mcp_grant_respond" }
+# Dynamic-subscribe pattern: `execute::dispatch_with_approval` calls
+# `ipc::subscribe("astrid.v1.approval")` per broker tool call to observe a
+# capability-approval request published by the host while a gated tool is
+# blocked. The kernel gates runtime subscribes against this list, so the
+# fixed topic must be declared here even though there is no static handler
+# — the subscription is drained inline inside `dispatch_with_approval`.
+"astrid.v1.approval" = "@unicity-astrid/wit/approval/required"
+# Dynamic-subscribe pattern: `execute::dispatch_with_approval` calls
+# `ipc::subscribe("tool.v1.execute.<bare>.result")` per broker call. The
+# kernel gates runtime subscribes against this list, so the pattern must
+# be declared here even though there is no static handler — the
+# subscription is drained inline inside `dispatch_with_approval`.
+#
+# Kernel `topic_matches` treats `*` as a single-segment wildcard, so a
+# one-pattern declaration cannot cover both flat names ("read_file") and
+# MCP-style dot-namespaced names ("fs.read"). `is_valid_tool_name`
+# permits `.` in the bare name, so both shapes are legitimate and the
+# subscribe surface must enumerate both arities.
+"tool.v1.execute.*.result" = "@unicity-astrid/wit/types/tool-call-result"
+"tool.v1.execute.*.*.result" = "@unicity-astrid/wit/types/tool-call-result"
+# Native-tool verdict responder (the second PDP plane). aos-mcp joins the
+# hook-bridge `ToolCallBefore` merge: a `before_tool_call` fan-out — from the
+# kernel bridge (a bus-mediated tool) or an external `astrid-gate` PreToolUse
+# hook (a native tool) — carrying a correlation id gets a `{ skip }` verdict.
+# Exact (segment-arity-fixed) topic. See `crate::hook_gate`.
+"hook.v1.event.before_tool_call" = { wit = "opaque", handler = "handle_before_tool_call" }
+
+[publish]
+"oracle.v1.hook.validated.*" = "opaque"
+"astrid.v1.tools.list" = "opaque"
+# Policy-gate audits emitted at the broker. The in-process `mcp__aos__*`
+# gate emits `astrid.v1.audit.policy_deny` (a tool call refused by a rule) and
+# `astrid.v1.audit.policy_load_failed` (rules unset/unparseable/over-cap →
+# policy degraded to the exec-time capability PEP); the native-tool
+# PreToolUse gate emits `astrid.v1.audit.pretooluse_deny` (a native tool call
+# the hook blocked by policy). Single `*` covers the 4-segment
+# `astrid.v1.audit.<name>` topics; all share the `{ tool, rule }` shape.
+"astrid.v1.audit.*" = "broker/policy-audit"
+# `before_tool_call` verdict replies. `handle_before_tool_call` replies on
+# `hook.v1.response.before_tool_call.<correlation_id>`; the id is a single
+# clean segment (charset-gated in `hook_gate::reply_topic`), so the egress
+# topic is exactly 5 segments — one trailing `*` (subtree) covers every
+# routable reply and a multi-segment id is rejected before the wire.
+"hook.v1.response.before_tool_call.*" = "opaque"
+# Broker reply channel. Both broker handlers reply on
+# `astrid.v1.response.<req_id>`; the `req_id` is a single clean segment
+# (UUID-ish, validated in `broker::reply_topic`) so the egress topic is
+# exactly 4 segments — the kernel `*` is single-segment, so this
+# one-pattern declaration covers every routable reply and a multi-segment
+# req_id is rejected before it can reach the wire.
+"astrid.v1.response.*" = "opaque"
+# Elicitation/approval bridge decision channel. `handle_mcp_approval` maps
+# the shim's elicited choice onto `astrid.v1.approval.response.<request_id>`,
+# which the host's blocked `request_approval` is subscribed to. The
+# `request_id` is a single clean segment (host-minted UUID, charset-gated in
+# `approval::response_topic`) so the egress topic is exactly 4 segments — the
+# kernel `*` is single-segment, so this one-pattern declaration covers every
+# routable decision and a multi-segment id is rejected before the wire.
+"astrid.v1.approval.response.*" = "@unicity-astrid/wit/approval/response"
+"tool.v1.request.describe" = { wit = "@unicity-astrid/wit/tool/describe-request" }
+# Execute fan-out from `dispatch_with_approval` — the broker strips the
+# `mcp__aos__` MCP prefix and forwards to the bare tool topic.
+# Two patterns because the kernel `*` is single-segment: the first
+# matches one-segment tool names ("read_file"), the second matches
+# MCP-style dot-namespaced names ("fs.read"). Tool-name charset is
+# already gated by `is_valid_tool_name` to ASCII alnum + `_.-`, so the
+# wildcards cannot be widened beyond the legitimate name surface.
+"tool.v1.execute.*" = { wit = "@unicity-astrid/wit/types/tool-call" }
+"tool.v1.execute.*.*" = { wit = "@unicity-astrid/wit/types/tool-call" }

--- a/capsules/capsule-mcp/Cargo.toml
+++ b/capsules/capsule-mcp/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "aos-mcp"
+version = "0.1.0"
+edition = "2024"
+description = "Unicity AOS MCP broker capsule over the neutral Astrid event bus"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+aos-mcp-broker = { path = "../../crates/aos-mcp-broker" }
+astrid-sdk.workspace = true
+blake3.workspace = true
+serde.workspace = true
+serde_json.workspace = true

--- a/capsules/capsule-mcp/src/host_hooks.rs
+++ b/capsules/capsule-mcp/src/host_hooks.rs
@@ -1,0 +1,497 @@
+//! Authenticated host-hook ingress shared by every Oracle plugin.
+
+use astrid_sdk::prelude::*;
+use serde::{Deserialize, Serialize};
+
+const MAX_PAYLOAD_BYTES: usize = 1024 * 1024;
+const MAX_CONTEXT_BYTES: usize = 64 * 1024;
+const TOKEN_MIN_BYTES: usize = 32;
+const TOKEN_MAX_BYTES: usize = 128;
+
+#[derive(Debug, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
+struct HostHookRequest {
+    schema_version: u8,
+    principal_id: String,
+    host: String,
+    session_id: String,
+    event: String,
+    correlation_id: String,
+    route_id: String,
+    delivery_id: String,
+    #[serde(default)]
+    turn_id: Option<String>,
+    #[serde(default)]
+    workspace_id: Option<String>,
+    payload: serde_json::Value,
+    token: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ValidatedHostHook<'a> {
+    schema_version: u8,
+    principal_id: &'a str,
+    host: &'a str,
+    session_id: &'a str,
+    event: &'a str,
+    correlation_id: &'a str,
+    route_id: &'a str,
+    delivery_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    turn_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<&'a str>,
+    payload: &'a serde_json::Value,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct HostHookResponse {
+    schema_version: u8,
+    principal_id: String,
+    host: String,
+    session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    event: Option<String>,
+    correlation_id: String,
+    route_id: String,
+    delivery_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    context: Option<String>,
+}
+
+pub(crate) fn handle(expected_host: &str, payload: serde_json::Value) -> Result<(), SysError> {
+    let request: HostHookRequest = match serde_json::from_value(payload) {
+        Ok(request) => request,
+        Err(error) => {
+            reject(expected_host, "unknown", "malformed_payload");
+            log::warn(format!(
+                "aos-mcp: malformed {expected_host} hook ingress: {error}"
+            ));
+            return Ok(());
+        }
+    };
+    if let Err(reason) = validate_request(expected_host, &request) {
+        reject(expected_host, &request.event, reason);
+        return Ok(());
+    }
+
+    let caller = match runtime::caller() {
+        Ok(caller) => caller,
+        Err(error) => {
+            reject(expected_host, &request.event, "caller_unavailable");
+            log::warn(format!(
+                "aos-mcp: caller unavailable for {expected_host} hook: {error}"
+            ));
+            return Ok(());
+        }
+    };
+    if caller.principal.as_deref() != Some(request.principal_id.as_str()) {
+        reject(expected_host, &request.event, "principal_mismatch");
+        return Ok(());
+    }
+
+    let token_key = token_key(expected_host, &request.session_id);
+    if !authenticate_token(&token_key, &request)? {
+        reject(expected_host, &request.event, "token_mismatch");
+        return Ok(());
+    }
+
+    ipc::publish_json(
+        &format!("oracle.v1.hook.validated.{expected_host}"),
+        &ValidatedHostHook {
+            schema_version: 1,
+            principal_id: &request.principal_id,
+            host: &request.host,
+            session_id: &request.session_id,
+            event: &request.event,
+            correlation_id: &request.correlation_id,
+            route_id: &request.route_id,
+            delivery_id: &request.delivery_id,
+            turn_id: request.turn_id.as_deref(),
+            workspace_id: request.workspace_id.as_deref(),
+            payload: &request.payload,
+        },
+    )
+}
+
+pub(crate) fn relay_response(payload: serde_json::Value) -> Result<(), SysError> {
+    let response: HostHookResponse = match serde_json::from_value(payload) {
+        Ok(response) => response,
+        Err(error) => {
+            reject("unknown", "unknown", "malformed_response");
+            log::warn(format!(
+                "aos-mcp: malformed host-hook bridge response: {error}"
+            ));
+            return Ok(());
+        }
+    };
+    let event = response.event.as_deref().unwrap_or("unknown");
+    if let Err(reason) = validate_response_shape(&response) {
+        reject(&response.host, event, reason);
+        return Ok(());
+    }
+
+    let caller = match runtime::caller() {
+        Ok(caller) => caller,
+        Err(error) => {
+            reject(&response.host, event, "caller_unavailable");
+            log::warn(format!(
+                "aos-mcp: caller unavailable for host-hook response: {error}"
+            ));
+            return Ok(());
+        }
+    };
+    if caller.principal.as_deref() != Some(response.principal_id.as_str()) {
+        reject(&response.host, event, "principal_mismatch");
+        return Ok(());
+    }
+
+    let token_key = token_key(&response.host, &response.session_id);
+    let Some(token) = kv::get_bytes_opt(&token_key)? else {
+        reject(&response.host, event, "unknown_session_route");
+        return Ok(());
+    };
+    let Ok(token) = std::str::from_utf8(&token) else {
+        reject(&response.host, event, "invalid_stored_route");
+        return Ok(());
+    };
+    if derive_route_id(&response.host, &response.session_id, token) != response.route_id {
+        reject(&response.host, event, "route_mismatch");
+        return Ok(());
+    }
+
+    ipc::publish_json(
+        &format!("astrid.v1.response.{}", response.delivery_id),
+        &response,
+    )?;
+
+    if matches!(response.event.as_deref(), Some("stop" | "session_end"))
+        && let Err(error) = kv::delete(&token_key)
+    {
+        log::warn(format!(
+            "aos-mcp: could not retire {} hook route: {error}",
+            response.host
+        ));
+    }
+    Ok(())
+}
+
+fn authenticate_token(key: &str, request: &HostHookRequest) -> Result<bool, SysError> {
+    match kv::get_bytes_opt(key)? {
+        Some(expected) => Ok(tokens_match(request.token.as_bytes(), &expected)),
+        None if can_register(&request.event) => {
+            if kv::cas(key, None, request.token.as_bytes())? {
+                Ok(true)
+            } else {
+                Ok(kv::get_bytes_opt(key)?
+                    .as_deref()
+                    .is_some_and(|expected| tokens_match(request.token.as_bytes(), expected)))
+            }
+        }
+        None => Ok(false),
+    }
+}
+
+fn can_register(event: &str) -> bool {
+    matches!(event, "session_start" | "user_prompt_submit")
+}
+
+fn token_key(host: &str, session: &str) -> String {
+    format!("oracle.hook_token.{host}.{session}")
+}
+
+fn validate_request(expected_host: &str, request: &HostHookRequest) -> Result<(), &'static str> {
+    if request.schema_version != 1 {
+        return Err("unsupported_schema");
+    }
+    if request.host != expected_host || !is_host(&request.host) {
+        return Err("host_mismatch");
+    }
+    validate_route_fields(
+        &request.session_id,
+        &request.event,
+        &request.correlation_id,
+        &request.route_id,
+        &request.delivery_id,
+    )?;
+    if request.token.len() < TOKEN_MIN_BYTES
+        || request.token.len() > TOKEN_MAX_BYTES
+        || !request
+            .token
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric())
+    {
+        return Err("invalid_token_shape");
+    }
+    if derive_route_id(&request.host, &request.session_id, &request.token) != request.route_id {
+        return Err("route_mismatch");
+    }
+    if request
+        .workspace_id
+        .as_deref()
+        .is_some_and(|workspace| !is_segment(workspace, 128))
+        || request
+            .turn_id
+            .as_deref()
+            .is_some_and(|turn| turn.is_empty() || turn.len() > 256)
+    {
+        return Err("invalid_metadata");
+    }
+    if serde_json::to_vec(&request.payload)
+        .map_or(true, |payload| payload.len() > MAX_PAYLOAD_BYTES)
+    {
+        return Err("payload_too_large");
+    }
+    Ok(())
+}
+
+fn validate_response_shape(response: &HostHookResponse) -> Result<(), &'static str> {
+    if response.schema_version != 1 {
+        return Err("unsupported_schema");
+    }
+    if !is_host(&response.host) {
+        return Err("unsupported_host");
+    }
+    if response
+        .event
+        .as_deref()
+        .is_some_and(|event| !is_segment(event, 128))
+    {
+        return Err("invalid_event");
+    }
+    validate_delivery_fields(
+        &response.session_id,
+        &response.correlation_id,
+        &response.route_id,
+        &response.delivery_id,
+    )?;
+    if response
+        .context
+        .as_ref()
+        .is_some_and(|context| context.len() > MAX_CONTEXT_BYTES)
+    {
+        return Err("context_too_large");
+    }
+    Ok(())
+}
+
+fn validate_route_fields(
+    session_id: &str,
+    event: &str,
+    correlation_id: &str,
+    route_id: &str,
+    delivery_id: &str,
+) -> Result<(), &'static str> {
+    if !is_segment(event, 128) {
+        return Err("invalid_segment");
+    }
+    validate_delivery_fields(session_id, correlation_id, route_id, delivery_id)
+}
+
+fn validate_delivery_fields(
+    session_id: &str,
+    correlation_id: &str,
+    route_id: &str,
+    delivery_id: &str,
+) -> Result<(), &'static str> {
+    if !is_segment(session_id, 128) || !is_segment(delivery_id, 128) {
+        return Err("invalid_segment");
+    }
+    if !is_lower_hex(correlation_id, 32) || !is_lower_hex(route_id, 64) {
+        return Err("invalid_route");
+    }
+    if delivery_id != format!("{route_id}-{correlation_id}") {
+        return Err("delivery_mismatch");
+    }
+    Ok(())
+}
+
+fn is_host(host: &str) -> bool {
+    matches!(host, "codex" | "claude" | "grok")
+}
+
+fn derive_route_id(host: &str, session: &str, token: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"unicity-aos-hook-route-v1\0");
+    hasher.update(host.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(session.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(token.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+fn tokens_match(claimed: &[u8], expected: &[u8]) -> bool {
+    if claimed.len() != expected.len() {
+        return false;
+    }
+    let mut difference = 0_u8;
+    for (left, right) in claimed.iter().zip(expected) {
+        difference |= left ^ right;
+    }
+    difference == 0
+}
+
+fn is_segment(value: &str, max: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+fn is_lower_hex(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn reject(host: &str, event: &str, reason: &str) {
+    if let Err(error) = ipc::publish_json(
+        "astrid.v1.audit.hook_ingress_rejected",
+        &serde_json::json!({
+            "host": bounded_audit(host),
+            "event": bounded_audit(event),
+            "reason": reason,
+        }),
+    ) {
+        log::warn(format!(
+            "aos-mcp: could not audit rejected hook message: {error}"
+        ));
+    }
+}
+
+fn bounded_audit(value: &str) -> &str {
+    let end = value.floor_char_boundary(value.len().min(128));
+    &value[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request() -> HostHookRequest {
+        let token = "a".repeat(64);
+        let route_id = derive_route_id("codex", "codex-session", &token);
+        let correlation_id = "b".repeat(32);
+        HostHookRequest {
+            schema_version: 1,
+            principal_id: "codex-code".to_owned(),
+            host: "codex".to_owned(),
+            session_id: "codex-session".to_owned(),
+            event: "user_prompt_submit".to_owned(),
+            delivery_id: format!("{route_id}-{correlation_id}"),
+            correlation_id,
+            route_id,
+            turn_id: Some("turn-one".to_owned()),
+            workspace_id: Some("workspace-one".to_owned()),
+            payload: serde_json::json!({"prompt": "hello"}),
+            token,
+        }
+    }
+
+    fn response(request: &HostHookRequest) -> HostHookResponse {
+        HostHookResponse {
+            schema_version: 1,
+            principal_id: request.principal_id.clone(),
+            host: request.host.clone(),
+            session_id: request.session_id.clone(),
+            event: Some(request.event.clone()),
+            correlation_id: request.correlation_id.clone(),
+            route_id: request.route_id.clone(),
+            delivery_id: request.delivery_id.clone(),
+            context: Some("same-turn context".to_owned()),
+        }
+    }
+
+    #[test]
+    fn validates_exact_request_route_binding() {
+        let mut value = request();
+        assert!(validate_request("codex", &value).is_ok());
+        value.route_id = "c".repeat(64);
+        assert_eq!(validate_request("codex", &value), Err("delivery_mismatch"));
+    }
+
+    #[test]
+    fn validates_exact_response_route_binding() {
+        let request = request();
+        let mut value = response(&request);
+        assert!(validate_response_shape(&value).is_ok());
+        assert_eq!(
+            derive_route_id(&value.host, &value.session_id, &request.token),
+            value.route_id
+        );
+        value.delivery_id = format!("{}-{}", "c".repeat(64), value.correlation_id);
+        assert_eq!(validate_response_shape(&value), Err("delivery_mismatch"));
+    }
+
+    #[test]
+    fn response_event_is_additive_for_staggered_upgrades() {
+        let request = request();
+        let mut value = response(&request);
+        value.event = None;
+        assert!(validate_response_shape(&value).is_ok());
+    }
+
+    #[test]
+    fn response_accepts_future_additive_fields() {
+        let request = request();
+        let mut value = serde_json::to_value(response(&request)).expect("serialize response");
+        value["future_metadata"] = serde_json::json!({"revision": 2});
+        let decoded: HostHookResponse =
+            serde_json::from_value(value).expect("deserialize additive response");
+        assert!(validate_response_shape(&decoded).is_ok());
+    }
+
+    #[test]
+    fn request_accepts_future_additive_fields() {
+        let mut value = serde_json::to_value(request()).expect("serialize request");
+        value["future_metadata"] = serde_json::json!({"revision": 2});
+        let decoded: HostHookRequest =
+            serde_json::from_value(value).expect("deserialize additive request");
+        assert!(validate_request("codex", &decoded).is_ok());
+    }
+
+    #[test]
+    fn token_comparison_is_exact() {
+        assert!(tokens_match(b"same", b"same"));
+        assert!(!tokens_match(b"same", b"sand"));
+        assert!(!tokens_match(b"short", b"longer"));
+    }
+
+    #[test]
+    fn only_session_entry_events_register_routes() {
+        assert!(can_register("session_start"));
+        assert!(can_register("user_prompt_submit"));
+        assert!(!can_register("pre_tool_use"));
+        assert!(!can_register("stop"));
+    }
+
+    #[test]
+    fn segments_reject_topic_smuggling() {
+        assert!(is_segment("codex-session_1", 128));
+        assert!(!is_segment("codex.session", 128));
+        assert!(!is_segment("../session", 128));
+    }
+
+    #[test]
+    fn validated_shape_does_not_contain_token() {
+        let request = request();
+        let value = serde_json::to_value(ValidatedHostHook {
+            schema_version: 1,
+            principal_id: &request.principal_id,
+            host: &request.host,
+            session_id: &request.session_id,
+            event: &request.event,
+            correlation_id: &request.correlation_id,
+            route_id: &request.route_id,
+            delivery_id: &request.delivery_id,
+            turn_id: request.turn_id.as_deref(),
+            workspace_id: request.workspace_id.as_deref(),
+            payload: &request.payload,
+        })
+        .expect("serialize validated hook");
+        assert!(value.get("token").is_none());
+    }
+}

--- a/capsules/capsule-mcp/src/lib.rs
+++ b/capsules/capsule-mcp/src/lib.rs
@@ -1,0 +1,111 @@
+//! AOS MCP broker capsule shared by Codex, Claude, and Grok host adapters.
+
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+
+use aos_mcp_broker::handlers;
+use astrid_sdk::prelude::*;
+
+mod host_hooks;
+
+/// Unicity AOS MCP broker capsule over the neutral runtime wire.
+#[derive(Default)]
+pub struct AosMcp;
+
+fn ensure_identity() {
+    aos_mcp_broker::install_aos();
+}
+
+#[capsule]
+impl AosMcp {
+    /// Token-validated hook ingress from the Codex plugin.
+    #[astrid::interceptor("handle_codex_hook")]
+    pub fn handle_codex_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        host_hooks::handle("codex", payload)
+    }
+
+    /// Token-validated hook ingress from the Claude plugin.
+    #[astrid::interceptor("handle_claude_hook")]
+    pub fn handle_claude_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        host_hooks::handle("claude", payload)
+    }
+
+    /// Token-validated hook ingress from the Grok plugin.
+    #[astrid::interceptor("handle_grok_hook")]
+    pub fn handle_grok_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        host_hooks::handle("grok", payload)
+    }
+
+    /// Relay a validated bridge response to the authenticated host call.
+    #[astrid::interceptor("relay_host_hook_response")]
+    pub fn relay_host_hook_response(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        host_hooks::relay_response(payload)
+    }
+
+    /// Handle tool discovery requests.
+    #[astrid::interceptor("describe_tools")]
+    pub fn describe_tools(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        handlers::describe_tools(payload)
+    }
+
+    /// Merge a tool descriptor response.
+    #[astrid::interceptor("collect_tool_descriptors")]
+    pub fn collect_tool_descriptors(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        handlers::collect_tool_descriptors(payload)
+    }
+
+    /// Invalidate discovery after the capsule set changes.
+    #[astrid::interceptor("handle_capsules_changed")]
+    pub fn handle_capsules_changed(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        handlers::handle_capsules_changed(payload)
+    }
+
+    /// Serve a sanitized MCP tool list.
+    #[astrid::interceptor("handle_mcp_list")]
+    pub fn handle_mcp_list(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        handlers::handle_mcp_list(payload)
+    }
+
+    /// Broker one MCP tool call.
+    #[astrid::interceptor("handle_mcp_call")]
+    pub fn handle_mcp_call(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        handlers::handle_mcp_call(payload)
+    }
+
+    /// Apply an elicited capability approval decision.
+    #[astrid::interceptor("handle_mcp_approval")]
+    pub fn handle_mcp_approval(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        handlers::handle_mcp_approval(payload)
+    }
+
+    /// Apply an elicited ingress-consent decision.
+    #[astrid::interceptor("handle_mcp_ingress_respond")]
+    pub fn handle_mcp_ingress_respond(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        handlers::handle_mcp_ingress_respond(payload)
+    }
+
+    /// Apply an elicited capsule-grant decision.
+    #[astrid::interceptor("handle_mcp_grant_respond")]
+    pub fn handle_mcp_grant_respond(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        handlers::handle_mcp_grant_respond(payload)
+    }
+
+    /// Answer native host policy hooks.
+    #[astrid::interceptor("handle_before_tool_call")]
+    pub fn handle_before_tool_call(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        ensure_identity();
+        handlers::handle_before_tool_call(payload)
+    }
+}

--- a/crates/aos-mcp-broker/Cargo.toml
+++ b/crates/aos-mcp-broker/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aos-mcp-broker"
+version = "0.1.0"
+edition = "2024"
+description = "AOS-owned MCP tool broker for the neutral Astrid event bus"
+publish = false
+
+[dependencies]
+astrid-sdk.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+uuid.workspace = true
+
+[lib]
+path = "src/lib.rs"

--- a/crates/aos-mcp-broker/src/approval.rs
+++ b/crates/aos-mcp-broker/src/approval.rs
@@ -1,0 +1,1461 @@
+//! Broker-side elicitation/approval bridge.
+//!
+//! ROLE: this is the **Claude-front-door renderer** of Astrid's existing
+//! runtime approval flow — NOT a new elicitation mechanism or channel. The
+//! consent prompt is *originated* by the host `astrid:approval` syscall
+//! (`request_approval`, ungated at runtime); the TUI renders it inline; this
+//! bridge renders the same `astrid.v1.approval` envelope into Claude's UI via
+//! the shim's `ctx.peer.elicit`. It invents no origination primitive, reuses
+//! the host's response topic + verb set verbatim, and never round-trips a
+//! secret. Runtime user-prompting already exists in Astrid (`request_approval`
+//! for consent, `SelectionRequired` for choice); see the runtime-value-elicit
+//! RFC for the one gap these do NOT cover (typed value / out-of-band secret).
+//!
+//! When a broker `tool.call` ([`crate::broker::handle_mcp_call`]) routes a
+//! capability-gated tool, the tool's host-side `request_approval` syscall
+//! publishes an `astrid.v1.approval` envelope and BLOCKS the tool's WASM
+//! thread until a decision lands on
+//! `astrid.v1.approval.response.<request-id>`. The broker can't call the
+//! host `astrid:elicit` syscall (it is hard-gated to install/upgrade), so
+//! it relays the bus-level envelopes instead: it surfaces an
+//! `approval-required` flag in the `tool.call` reply so the shim can elicit
+//! the choice from Claude, then maps the returned choice back onto the
+//! `astrid.v1.approval.response.<request-id>` decision topic to unblock the
+//! tool.
+//!
+//! ## Topic contract (meets the core elicit-shim slice)
+//!
+//! * **inbound (observed during dispatch)** `astrid.v1.approval` —
+//!   `IpcPayload::ApprovalRequired` = `{ type:"approval_required",
+//!   request_id, action, resource, reason }`. Published by the host
+//!   `request_approval` path ([`core` `host/approval.rs`]).
+//! * **inbound (shim's elicited choice)**
+//!   `astrid.v1.request.mcp.approval.respond` -> [`handle_mcp_approval`] —
+//!   `{ req_id, request_id, decision, tool_name, call_id }`. The shim
+//!   collected the choice from Claude and forwards it through the same broker
+//!   front door it uses for tool calls; `req_id` is the proxy correlation
+//!   token (echoed into the reply), `request_id` is the approval correlation
+//!   id from the `approval_required` envelope, and `tool_name` / `call_id`
+//!   are echoed back from the `approval_required` reply flag so this handler
+//!   can re-establish the result drain the original dispatch dropped.
+//! * **outbound (decision → unblock tool)**
+//!   `astrid.v1.approval.response.<request_id>` —
+//!   `IpcPayload::ApprovalResponse` = `{ type:"approval_response",
+//!   request_id, decision, reason? }`. The blocked host `request_approval`
+//!   wakes on this and returns the typed decision to the tool.
+//! * **outbound (resumed result → shim)** `astrid.v1.response.<req_id>` —
+//!   `{ kind:"tool.call", req_id, content:[...], isError:bool }`. After
+//!   publishing the decision this handler re-subscribes to the tool's result
+//!   topic and drains the resumed (approve) or `isError` (deny) result,
+//!   delivering it to the shim as a terminal `tool.call` reply — the same
+//!   shape [`crate::broker::handle_mcp_call`] would have produced had the
+//!   tool not parked on approval. THIS is the leg that completes the
+//!   round-trip: the original dispatch could not keep its result
+//!   subscription alive across the synchronous interceptor return, so
+//!   ownership of result delivery moves here.
+//!
+//! ## Why the result drain lives here, not in the original dispatch
+//!
+//! A WASM interceptor is synchronous and returns exactly once. When
+//! [`crate::execute::dispatch_with_approval`] observes the `approval_required`
+//! envelope it must return so the broker can surface the elicit flag — at
+//! which point its `tool.v1.execute.<name>.result` subscription is dropped.
+//! The tool only publishes its result AFTER a decision lands, so by the time
+//! the result exists no subscriber remains. This handler therefore re-opens
+//! that subscription (subscribe BEFORE publishing the decision to avoid the
+//! resume race) and owns delivering the single terminal result back to the
+//! shim. The `tool_name` + `call_id` it needs are echoed by the shim from
+//! the reply flag.
+//!
+//! ## Concurrency / correlation
+//!
+//! `astrid.v1.approval` is a single global broadcast topic and the host
+//! envelope carries NO `call_id` / `tool_name` — only an opaque host-minted
+//! `request_id`. The concern is whether one tool's approval could be surfaced
+//! to a *different* tool's `tool.call` reply.
+//!
+//! This is prevented at the engine level: the kernel serialises guest calls
+//! per capsule instance behind the store mutex
+//! (`core` `engine/wasm/mod.rs`: *"The mutex still serialises one guest call
+//! at a time per capsule"*). A broker dispatch
+//! ([`crate::execute::dispatch_with_approval`]) holds that lock for the whole
+//! synchronous drain and returns the instant it observes ANY approval, so a
+//! second aos-mcp `handle_mcp_call` cannot run — and cannot be watching the
+//! approval topic — while another is in flight. There is therefore at most
+//! ONE aos-mcp approval-watcher at a time: the only `astrid.v1.approval`
+//! envelope it can observe during its window is the one ITS OWN routed tool
+//! raised (it published that tool's execute request and nothing else of
+//! aos-mcp's is running). Intra-capsule cross-talk is structurally
+//! impossible — no claim registry is needed.
+//!
+//! The decision is independently routed correctly regardless: it targets
+//! `astrid.v1.approval.response.<request_id>`, the exact per-request topic the
+//! blocked host `request_approval` subscribed to, so the shim round-trip
+//! carrying a given `request_id` unblocks exactly the tool that raised it.
+//!
+//! Residual (documented, not fixed here): a DIFFERENT capsule's tool that
+//! calls `request_approval` during this dispatch's drain window also lands on
+//! the global topic, and nothing on the wire distinguishes it from this
+//! tool's approval — the host stamps a nil source and omits any `call_id` /
+//! `tool_name`. Attributing such a foreign approval correctly needs a kernel
+//! correlation field on `IpcPayload::ApprovalRequired`; that is a kernel
+//! contract change, out of scope for this capsule-only slice.
+//!
+//! ## Decision surface — approvals/confirms/selects ONLY
+//!
+//! The decision string is constrained to the host's recognised approval
+//! verbs ([`MAP` in core `host/approval.rs::decision_from_str`]):
+//! `approve`, `approve_session`, `approve_always`, `deny`. Anything else
+//! (including unknown / empty) is normalised to `deny` — fail secure. A
+//! `deny` decision results in the tool call returning `isError` upstream
+//! (the host returns `ApprovalDecision::Denied`, the gated tool publishes
+//! an error result, and the broker's drain reshapes it). **This bridge
+//! NEVER relays a secret through elicitation** — it carries only the
+//! action/resource/reason display fields (already host-sanitized) and a
+//! constrained decision verb. No free-form text is round-tripped into the
+//! tool.
+
+use astrid_sdk::prelude::*;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+/// Bus topic the host publishes capability-approval requests on. A single
+/// fixed (segment-arity-stable) topic — the correlation id lives in the
+/// body (`request_id`), not the topic, so a wildcard suffix is not needed
+/// to observe it.
+pub(crate) const APPROVAL_REQUEST_TOPIC: &str = "astrid.v1.approval";
+
+/// Egress topic PREFIX for the decision. The host's blocked
+/// `request_approval` subscribed to `astrid.v1.approval.response.<id>`
+/// before publishing the request, so the decision lands on the exact
+/// per-request topic. `<id>` is charset-gated by [`response_topic`].
+const APPROVAL_RESPONSE_PREFIX: &str = "astrid.v1.approval.response.";
+
+/// `request_id` charset cap. The approval correlation id is a host-minted
+/// UUID; anything longer is rejected before it can be stamped into an
+/// egress topic.
+const MAX_REQUEST_ID_LEN: usize = 128;
+
+/// Display-field cap mirrored from the host sanitizer
+/// (`MAX_RESOURCE_LEN`). The host already trims/strips/truncates these
+/// before publishing `astrid.v1.approval`; we re-cap defensively so a
+/// future producer that skips sanitization cannot inflate the reply body
+/// the shim renders to Claude.
+const MAX_DISPLAY_LEN: usize = 1024;
+
+/// The four approval verbs the host's `decision_from_str` recognises.
+/// `approve` / `approve_session` / `approve_always` grant; everything
+/// else (including `deny`) is treated as a deny by the host. We normalise
+/// the shim's choice to exactly one of these so no free-form string is
+/// ever round-tripped onto the decision topic.
+const APPROVE: &str = "approve";
+const APPROVE_SESSION: &str = "approve_session";
+const APPROVE_ALWAYS: &str = "approve_always";
+const DENY: &str = "deny";
+
+/// Bound on the post-decision result drain in [`handle_mcp_approval`].
+/// The tool resumes (or denies) the instant the decision lands; its result
+/// is one bus hop away, so this only needs to cover scheduling latency, not
+/// a fresh tool runtime. Kept well under the host's 60 s approval window and
+/// the proxy's own request deadline so the shim gets a terminal reply
+/// promptly rather than hanging.
+const RESUME_TIMEOUT_MS: u64 = 50_000;
+
+/// Poll slice for the resume drain. Mirrors the execute-path slice cadence
+/// so a result published the instant the tool resumes is picked up within
+/// one short slice rather than blocking the whole budget on the first
+/// `recv`.
+const RESUME_SLICE_MS: u64 = 250;
+
+/// Parsed `astrid.v1.approval` envelope (`IpcPayload::ApprovalRequired`).
+///
+/// Only the display + correlation fields are deserialized. The `type`
+/// discriminator tag is ignored by the struct-deserialize (serde drops
+/// unknown fields), and `is_approval_required` gates on it explicitly so
+/// a sibling `IpcPayload` variant published on the shared topic is not
+/// mistaken for an approval.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ApprovalRequired {
+    /// Host-minted correlation id; echoed onto the response topic suffix.
+    pub(crate) request_id: String,
+    /// The action being requested (e.g. `"git push"`). Display only.
+    #[serde(default)]
+    pub(crate) action: String,
+    /// The resource target (e.g. full command string). Display only.
+    #[serde(default)]
+    pub(crate) resource: String,
+    /// Justification shown to the user. Display only.
+    #[serde(default)]
+    pub(crate) reason: String,
+}
+
+impl ApprovalRequired {
+    /// Shape the `approval_required` flag embedded in the broker
+    /// `tool.call` reply.
+    ///
+    /// Carries the host-sanitized display fields plus the correlation id
+    /// (never any tool argument or secret), AND the dispatch's `tool_name` +
+    /// `call_id`. The latter two are NOT secrets — they are the same routing
+    /// tokens the shim already used to make the `tool.call` — and the shim
+    /// MUST echo them back on `astrid.v1.request.mcp.approval.respond` so
+    /// [`handle_mcp_approval`] can re-subscribe to the tool's result topic
+    /// and deliver the resumed/denied outcome the original dispatch could not
+    /// keep a subscription alive for.
+    pub(crate) fn to_reply_flag(&self, tool_name: &str, call_id: &str) -> Value {
+        json!({
+            "request_id": self.request_id,
+            "action": clamp(&self.action),
+            "resource": clamp(&self.resource),
+            "reason": clamp(&self.reason),
+            "tool_name": tool_name,
+            "call_id": call_id,
+        })
+    }
+}
+
+/// Decide whether a JSON value parsed from the `astrid.v1.approval` topic
+/// is actually an `ApprovalRequired` envelope.
+///
+/// The `IpcPayload` enum is `#[serde(tag = "type", rename_all =
+/// "snake_case")]`, so a genuine approval carries `"type":
+/// "approval_required"`. Gate on the tag AND a non-empty `request_id` (a
+/// blank id can't be routed back). Other payloads sharing the topic are
+/// skipped.
+pub(crate) fn is_approval_required(value: &Value) -> bool {
+    value.get("type").and_then(Value::as_str) == Some("approval_required")
+        && value
+            .get("request_id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.is_empty())
+}
+
+/// Parsed `astrid.v1.approval` grant-gate-miss envelope
+/// (`IpcPayload::GrantRequired`, published by the kernel #1001 producer when
+/// the principal has not granted the target capsule).
+///
+/// `grant-on-use` mirrors the INGRESS flow (gate → consent → re-send), NOT
+/// capability-approval (park → resume): the kernel DROPPED the original
+/// `tool.call` at the access gate, so there is nothing parked and nothing to
+/// drain. The kernel grants the capsule when an APPROVE `approval_response`
+/// lands on `astrid.v1.approval.response.<request_id>` — the exact same
+/// response topic + envelope the approval flow uses, reused verbatim.
+///
+/// Only the correlation + display fields are deserialized. The `type`
+/// discriminator tag is dropped by struct-deserialize; [`is_grant_required`]
+/// gates on it explicitly so a sibling `IpcPayload` variant on the shared topic
+/// is not mistaken for a grant request.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct GrantRequired {
+    /// Host-minted correlation id; echoed onto the response topic suffix
+    /// (`astrid.v1.approval.response.<request_id>`) so the kernel grant handler
+    /// resumes the exact gate miss.
+    pub(crate) request_id: String,
+    /// The principal the grant would be recorded for. Display only — the
+    /// kernel resolves the real principal from the approve it consumes; this is
+    /// never trusted as an identity.
+    #[serde(default)]
+    pub(crate) principal: String,
+    /// The capsule id the access gate refused. Carried to the shim for display
+    /// and used as the dedup key `(principal, capsule_id)`.
+    #[serde(default)]
+    pub(crate) capsule_id: String,
+}
+
+impl GrantRequired {
+    /// Shape the `grant_required` flag embedded in the broker `tool.call`
+    /// reply.
+    ///
+    /// Carries the correlation id, the (display-only) principal, the capsule id
+    /// the gate refused, plus the dispatch's `tool_name` + `call_id` — the same
+    /// routing tokens the shim already used for the `tool.call`, so it can
+    /// RE-SEND the original call on approve (grant-on-use re-sends; it does not
+    /// resume). No tool argument or secret is carried.
+    pub(crate) fn to_reply_flag(&self, tool_name: &str, call_id: &str) -> Value {
+        json!({
+            "request_id": self.request_id,
+            "capsule_id": clamp(&self.capsule_id),
+            "principal": clamp(&self.principal),
+            "tool_name": tool_name,
+            "call_id": call_id,
+        })
+    }
+}
+
+/// Decide whether a JSON value parsed from the `astrid.v1.approval` topic is a
+/// `GrantRequired` envelope.
+///
+/// The `IpcPayload` enum is `#[serde(tag = "type", rename_all = "snake_case")]`,
+/// so a genuine grant request carries `"type": "grant_required"`. Gate on the
+/// tag AND a non-empty `request_id` (a blank id can't be routed back). Other
+/// payloads sharing the topic — including the sibling `approval_required` — are
+/// skipped.
+pub(crate) fn is_grant_required(value: &Value) -> bool {
+    value.get("type").and_then(Value::as_str) == Some("grant_required")
+        && value
+            .get("request_id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.is_empty())
+}
+
+/// Inbound `astrid.v1.request.mcp.approval.respond` payload — the shim's
+/// elicited choice for an outstanding approval.
+///
+/// `req_id` is the proxy correlation token (echoed into the terminal reply);
+/// `request_id` is the approval correlation id from the `approval_required`
+/// envelope; `decision` is the shim's choice, normalised to a host verb by
+/// [`normalize_decision`]. `tool_name` + `call_id` are echoed back from the
+/// reply flag and identify which `tool.v1.execute.<name>.result` to drain for
+/// the resumed/denied outcome. An optional `reason` is carried as a display /
+/// audit string only — it is NOT a tool argument and never substitutes into
+/// the tool call.
+#[derive(Debug, Deserialize)]
+struct ApprovalRespond {
+    req_id: String,
+    request_id: String,
+    decision: String,
+    tool_name: String,
+    call_id: String,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+/// Handle `astrid.v1.request.mcp.approval.respond`.
+///
+/// Maps the shim's elicited choice onto an
+/// `astrid.v1.approval.response.<request_id>` decision so the blocked host
+/// `request_approval` resumes, then DRAINS the resumed (approve) or `isError`
+/// (deny) tool result and delivers it to the shim on
+/// `astrid.v1.response.<req_id>` as a terminal `tool.call` reply — completing
+/// the round-trip the original [`crate::execute::dispatch_with_approval`]
+/// could not (its result subscription died when the interceptor returned).
+///
+/// Ordering is load-bearing: we subscribe to the tool's result topic BEFORE
+/// publishing the decision, otherwise the tool could resume and publish its
+/// result before we are listening.
+///
+/// State-mutating (it can grant a capability), so it is confused-deputy
+/// gated identically to [`crate::broker::handle_mcp_call`]: the inbound
+/// message's kernel-set `source_id` must already be a trusted ingress
+/// ([`crate::execute::is_ingress_trusted`]) before any decision is published.
+/// A rejected or malformed request publishes a `deny` so an outstanding tool
+/// can never hang waiting on a decision that will not come — fail secure —
+/// and (when routable) delivers the resulting `isError` reply to the shim.
+pub(crate) fn handle_mcp_approval(payload: Value) -> Result<(), SysError> {
+    let req: ApprovalRespond = match serde_json::from_value(payload) {
+        Ok(v) => v,
+        Err(e) => {
+            // No recoverable req_id — there is no channel to reply on, and no
+            // request_id to deny. The host's approval times out (60 s) on
+            // its own schedule. Log and drop.
+            log::warn(format!(
+                "{}: broker approval.respond: malformed payload: {e}",
+                crate::profile::log_tag()
+            ));
+            return Ok(());
+        }
+    };
+
+    log::info(format!(
+        "{}: broker ingress method=approval.respond req_id={} request_id={} tool={}",
+        crate::profile::log_tag(),
+        req.req_id,
+        req.request_id,
+        req.tool_name
+    ));
+
+    let reply_topic = crate::broker::reply_topic(&req.req_id);
+    let Some(response_topic) = response_topic(&req.request_id) else {
+        log::warn(format!(
+            "{}: broker approval.respond: rejecting unroutable request_id '{}'",
+            crate::profile::log_tag(),
+            req.request_id
+        ));
+        // Reply to the shim if we at least have a clean req_id so it doesn't
+        // hang; the decision was never published (bad request_id).
+        if let Some(reply) = &reply_topic {
+            deliver_error(reply, &req.req_id, "approval request_id was not routable");
+        }
+        return Ok(());
+    };
+
+    // Confused-deputy gate. Granting a capability is the most sensitive
+    // action this capsule performs — require the kernel-set `source_id`
+    // (NOT a body field) to be in the operator-pinned trusted-ingress
+    // allow-set. On any failure (no caller context, untrusted ingress) we
+    // publish a `deny` decision so the blocked tool retires cleanly, then
+    // deliver the resulting denied outcome to the shim.
+    let source_id = match runtime::caller() {
+        Ok(ctx) => ctx.source_id,
+        Err(e) => {
+            log::warn(format!(
+                "{}: broker approval.respond: no caller context, denying request_id '{}': {e}",
+                crate::profile::log_tag(),
+                req.request_id
+            ));
+            resolve_with_decision(&req, &response_topic, DENY, None);
+            return Ok(());
+        }
+    };
+    if !crate::execute::is_ingress_trusted(&source_id) {
+        log::warn(format!(
+            "{}: broker approval.respond: untrusted ingress source_id '{source_id}', \
+             denying request_id '{}'",
+            crate::profile::log_tag(),
+            req.request_id
+        ));
+        resolve_with_decision(&req, &response_topic, DENY, None);
+        return Ok(());
+    }
+
+    // Normalise the shim's choice to exactly one host verb. Unknown /
+    // empty collapses to `deny` — fail secure. The optional `reason` is a
+    // display/audit string only; it is forwarded verbatim into the
+    // `ApprovalResponse.reason` field and is NEVER treated as a tool
+    // argument (the host's approval path discards it after logging).
+    let decision = normalize_decision(&req.decision);
+    resolve_with_decision(&req, &response_topic, decision, req.reason.as_deref());
+    Ok(())
+}
+
+/// Inbound `astrid.v1.request.mcp.ingress.respond` payload — the user's
+/// consent decision for an untrusted ingress, collected by the shim's
+/// elicit prompt.
+///
+/// `req_id` is the proxy correlation token (the ack lands on
+/// `astrid.v1.response.<req_id>`); `accept` is the user's decision. There is
+/// DELIBERATELY no `source_id` field — the ingress to trust is the
+/// kernel-stamped `runtime::caller().source_id` of whoever sent THIS message
+/// (the cli proxy), never a value the body could forge. Any other fields are
+/// ignored.
+#[derive(Debug, Deserialize)]
+struct IngressRespond {
+    req_id: String,
+    accept: bool,
+}
+
+/// Inbound `astrid.v1.request.mcp.grant.respond` payload — the shim's elicited
+/// Grant/Deny decision for an outstanding capsule-grant prompt.
+///
+/// `req_id` is the proxy correlation token (the ack lands on
+/// `astrid.v1.response.<req_id>`); `request_id` is the kernel grant correlation
+/// id from the `grant_required` envelope (echoed onto
+/// `astrid.v1.approval.response.<request_id>`); `decision` is the user's choice,
+/// normalised to a host verb by [`normalize_decision`]. `capsule_id` is the
+/// grant target, used to clear the dedup marker on respond. There is
+/// DELIBERATELY no `tool_name` / `call_id`: grant-on-use does NOT drain a result
+/// (the kernel dropped the call), so there is no result topic to re-establish —
+/// unlike [`ApprovalRespond`]. Any other fields are ignored.
+#[derive(Debug, Deserialize)]
+struct GrantRespond {
+    req_id: String,
+    request_id: String,
+    decision: String,
+    #[serde(default)]
+    capsule_id: String,
+}
+
+/// Handle `astrid.v1.request.mcp.ingress.respond`.
+///
+/// The shim elicited the user's consent for an untrusted ingress (in response
+/// to an `ingress_approval_required` reply a prior
+/// [`crate::broker::handle_mcp_call`] produced) and forwards the decision
+/// here as `{ req_id, accept }`. On `accept:true` we record trust for the
+/// ingress under `mcp.ingress.trust.<source_id>` so a re-sent `tool.call`
+/// passes the confused-deputy gate; on `accept:false` we record nothing.
+/// Either way we ack on `astrid.v1.response.<req_id>` so the shim does not
+/// hang.
+///
+/// **SECURITY-CRITICAL**: the `source_id` trust is recorded against is the
+/// kernel-stamped `runtime::caller().source_id` of THIS message — the
+/// identity of whoever actually forwarded the `ingress.respond` (the cli
+/// proxy). It is NEVER taken from the payload body. A capsule cannot smuggle
+/// a trust grant for some OTHER ingress by putting a foreign source_id in the
+/// body, because the body carries none and we read only the kernel-stamped
+/// caller. An empty / unattributed caller is refused
+/// ([`crate::execute::ingress_trust_key`] returns `None`).
+///
+/// **Correlation gate**: trust is recorded only when this respond consumes an
+/// outstanding consent-prompt marker the broker wrote for `source_id` when it
+/// replied `ingress_approval_required`
+/// ([`crate::execute::take_ingress_pending`]). An accept with no marker —
+/// unsolicited, replayed, or for an ingress the broker never prompted on — is
+/// refused. The shim mints a FRESH `req_id` per respond and the broker hands
+/// it no prompt id to echo, so `source_id` (identical on the gated call and
+/// its respond, since the same proxy forwards both) is the only correlation
+/// token available without a wire change. The marker is single-use (consumed
+/// on accept and decline). This does NOT by itself prove a human (vs a
+/// capsule) drove the accept — that remains the publish-ACL on
+/// `astrid.v1.request.mcp.ingress.respond`; it removes the unsolicited /
+/// replayed-respond residual.
+pub(crate) fn handle_mcp_ingress_respond(payload: Value) -> Result<(), SysError> {
+    let req: IngressRespond = match serde_json::from_value(payload) {
+        Ok(v) => v,
+        Err(e) => {
+            // No recoverable req_id — there is no channel to ack on. Log
+            // and drop; the shim times out its own request.
+            log::warn(format!(
+                "{}: broker ingress.respond: malformed payload: {e}",
+                crate::profile::log_tag()
+            ));
+            return Ok(());
+        }
+    };
+
+    log::info(format!(
+        "{}: broker ingress method=ingress.respond req_id={} accept={}",
+        crate::profile::log_tag(),
+        req.req_id,
+        req.accept
+    ));
+
+    let reply_topic = crate::broker::reply_topic(&req.req_id);
+
+    // The kernel-stamped caller is the ONLY source of the ingress identity.
+    let source_id = match runtime::caller() {
+        Ok(ctx) => ctx.source_id,
+        Err(e) => {
+            log::warn(format!(
+                "{}: broker ingress.respond: no caller context, recording no trust: {e}",
+                crate::profile::log_tag()
+            ));
+            if let Some(reply) = &reply_topic {
+                ingress_ack(reply, &req.req_id, false);
+            }
+            return Ok(());
+        }
+    };
+
+    // Correlation gate: only honour a respond that consumes a prompt the
+    // broker actually issued for THIS ingress. Consumed on accept AND decline
+    // so a declined prompt cannot leave a stale marker a later unsolicited
+    // accept could ride. Fail-closed (missing marker / read error → false).
+    let had_prompt = crate::execute::take_ingress_pending(&source_id);
+
+    if req.accept {
+        if !had_prompt {
+            // Unsolicited or replayed accept: no consent prompt is outstanding
+            // for this ingress, so the broker never asked. Refuse to record
+            // trust and ack as not-granted — the shim will not re-send.
+            log::warn(format!(
+                "{}: broker ingress.respond: accept with no outstanding prompt for \
+                 source_id '{source_id}'; recording no trust",
+                crate::profile::log_tag()
+            ));
+            if let Some(reply) = &reply_topic {
+                ingress_ack(reply, &req.req_id, false);
+            }
+            return Ok(());
+        }
+        match crate::execute::ingress_trust_key(&source_id) {
+            Some(key) => {
+                if let Err(e) = kv::set_bytes(&key, b"1") {
+                    log::warn(format!(
+                        "{}: broker ingress.respond: failed to record trust for \
+                         source_id '{source_id}': {e}",
+                        crate::profile::log_tag()
+                    ));
+                    // Could not persist — ack as not-granted so the shim does
+                    // not falsely believe trust was recorded.
+                    if let Some(reply) = &reply_topic {
+                        ingress_ack(reply, &req.req_id, false);
+                    }
+                    return Ok(());
+                }
+                log::info(format!(
+                    "{}: broker ingress.respond: recorded trust for ingress source_id \
+                     '{source_id}'",
+                    crate::profile::log_tag()
+                ));
+                // Best-effort audit on the same `astrid.v1.audit.*` family the
+                // policy gate uses. source_id is kernel-stamped, not a
+                // reflected argument.
+                let _ = ipc::publish_json(
+                    &crate::profile::audit_topic("ingress_trusted"),
+                    &json!({ "source_id": source_id }),
+                );
+                if let Some(reply) = &reply_topic {
+                    ingress_ack(reply, &req.req_id, true);
+                }
+            }
+            None => {
+                // Empty / unattributed caller — refuse to record a routable
+                // trust key. Ack as not-granted.
+                log::warn(format!(
+                    "{}: broker ingress.respond: empty caller source_id; no trust recorded",
+                    crate::profile::log_tag()
+                ));
+                if let Some(reply) = &reply_topic {
+                    ingress_ack(reply, &req.req_id, false);
+                }
+            }
+        }
+    } else {
+        log::info(format!(
+            "{}: broker ingress.respond: user declined trust for ingress source_id \
+             '{source_id}'",
+            crate::profile::log_tag()
+        ));
+        if let Some(reply) = &reply_topic {
+            ingress_ack(reply, &req.req_id, false);
+        }
+    }
+    Ok(())
+}
+
+/// Ack an `ingress.respond` to the shim on `astrid.v1.response.<req_id>`.
+///
+/// `granted` reports whether trust was actually persisted, so the shim only
+/// re-sends the parked `tool.call` when the gate will now pass. Best-effort:
+/// a publish failure is logged, not retried (the shim times out otherwise).
+fn ingress_ack(reply_topic: &str, req_id: &str, granted: bool) {
+    let reply = json!({
+        "kind": "ingress.respond",
+        "req_id": req_id,
+        "granted": granted,
+    });
+    if let Err(e) = ipc::publish_json(reply_topic, &reply) {
+        log::warn(format!(
+            "{}: broker ingress.respond: failed to ack {reply_topic}: {e}",
+            crate::profile::log_tag()
+        ));
+    }
+}
+
+/// Handle `astrid.v1.request.mcp.grant.respond`.
+///
+/// The shim elicited the user's Grant/Deny choice for a capsule the kernel
+/// access gate refused (in response to a `grant_required` flag a prior
+/// [`crate::broker::handle_mcp_call`] reply carried) and forwards it here as
+/// `{ req_id, request_id, decision, capsule_id }`. This maps the choice onto
+/// `astrid.v1.approval.response.<request_id>` — the SAME response topic and
+/// `approval_response` envelope the approval flow uses, consumed VERBATIM by
+/// the kernel grant handler (#1001), which persists the capsule grant on an
+/// APPROVE — then acks the shim on `astrid.v1.response.<req_id>` with
+/// `{ kind:"grant.respond", req_id, granted }`.
+///
+/// An APPROVE is additionally recorded durably
+/// ([`crate::grant_decision::record_grant_decision`]) before the decision is
+/// published, so the flow converges from the record even when the kernel
+/// awaiter that prompted it has expired. A DENY is deliberately NOT recorded:
+/// the shim publishes `deny` on every non-accept path (decline, elicit
+/// error/timeout, no elicitation capability) with no provenance, so it stays
+/// ephemeral — see [`crate::grant_decision::respond_decision_to_record`].
+///
+/// ## Publish-then-ack, NO result drain (the key divergence)
+///
+/// Unlike [`handle_mcp_approval`], this handler MUST NOT subscribe to
+/// `tool.v1.execute.*.result` and MUST NOT drain a result. grant-on-use mirrors
+/// the INGRESS flow: the kernel DROPPED the original `tool.call` at the access
+/// gate, so nothing is parked and no result will ever be published. Draining
+/// would block the full window then emit a spurious error. The shim RE-SENDS
+/// the original `tool.call` itself once it sees `granted:true`. Structurally
+/// this matches [`handle_mcp_ingress_respond`] (publish/record then ack), NOT
+/// [`handle_mcp_approval`] (publish then drain).
+///
+/// State-mutating (an APPROVE causes the kernel to persist a capsule grant), so
+/// it is confused-deputy gated identically to [`crate::broker::handle_mcp_call`]:
+/// the inbound message's kernel-set `source_id` must already be a trusted
+/// ingress ([`crate::execute::is_ingress_trusted`]) before any decision is
+/// published. A rejected request publishes a `deny` (when a `request_id` is
+/// routable) so the kernel gate miss retires cleanly and clears the dedup
+/// marker — fail secure.
+///
+/// The dedup marker for `(principal, capsule_id)` is consumed on BOTH approve
+/// and deny ([`crate::execute::take_grant_pending`]) so a declined prompt can
+/// never leave a marker that suppresses every future grant prompt for the pair.
+/// A payload so malformed it carries no `request_id` (and so no routable deny)
+/// — or no `capsule_id` to clear by — is logged and dropped; the kernel gate
+/// miss times out on its own schedule and any pending marker self-heals at
+/// [`crate::execute::GRANT_PENDING_TTL_MS`], so even that path cannot wedge the
+/// pair.
+pub(crate) fn handle_mcp_grant_respond(payload: Value) -> Result<(), SysError> {
+    let req: GrantRespond = match serde_json::from_value(payload) {
+        Ok(v) => v,
+        Err(e) => {
+            // No recoverable req_id — no channel to ack on, and no request_id
+            // to deny. The kernel grant gate retires on its own schedule, and a
+            // pending marker self-heals at GRANT_PENDING_TTL_MS, so dropping
+            // here cannot wedge the pair. Log and drop.
+            log::warn(format!(
+                "{}: broker grant.respond: malformed payload: {e}",
+                crate::profile::log_tag()
+            ));
+            return Ok(());
+        }
+    };
+
+    log::info(format!(
+        "{}: broker ingress method=grant.respond req_id={} request_id={} capsule_id={}",
+        crate::profile::log_tag(),
+        req.req_id,
+        req.request_id,
+        req.capsule_id
+    ));
+
+    let reply_topic = crate::broker::reply_topic(&req.req_id);
+    let Some(response_topic) = response_topic(&req.request_id) else {
+        log::warn(format!(
+            "{}: broker grant.respond: rejecting unroutable request_id '{}'",
+            crate::profile::log_tag(),
+            req.request_id
+        ));
+        // Clear any dedup marker so the next ungranted call can re-prompt — the
+        // decision was never published (bad request_id), so leaving the marker
+        // would wedge the pair. The caller principal scopes the KV; the suffix
+        // is the capsule id.
+        clear_grant_marker(&req.capsule_id);
+        // Ack the shim (when routable) so it does not hang; not granted.
+        if let Some(reply) = &reply_topic {
+            grant_ack(reply, &req.req_id, false);
+        }
+        return Ok(());
+    };
+
+    // Confused-deputy gate. An APPROVE here causes the kernel to persist a
+    // capsule grant — the most sensitive action on this path — so require the
+    // kernel-set `source_id` (NOT a body field) to be a trusted ingress. On any
+    // failure (no caller context, untrusted ingress) publish a `deny` so the
+    // kernel gate miss retires, clear the marker, and ack not-granted.
+    let source_id = match runtime::caller() {
+        Ok(ctx) => ctx.source_id,
+        Err(e) => {
+            log::warn(format!(
+                "{}: broker grant.respond: no caller context, denying request_id '{}': {e}",
+                crate::profile::log_tag(),
+                req.request_id
+            ));
+            publish_decision(&response_topic, &req.request_id, DENY, None);
+            clear_grant_marker(&req.capsule_id);
+            if let Some(reply) = &reply_topic {
+                grant_ack(reply, &req.req_id, false);
+            }
+            return Ok(());
+        }
+    };
+    if !crate::execute::is_ingress_trusted(&source_id) {
+        log::warn(format!(
+            "{}: broker grant.respond: untrusted ingress source_id '{source_id}', \
+             denying request_id '{}'",
+            crate::profile::log_tag(),
+            req.request_id
+        ));
+        publish_decision(&response_topic, &req.request_id, DENY, None);
+        clear_grant_marker(&req.capsule_id);
+        if let Some(reply) = &reply_topic {
+            grant_ack(reply, &req.req_id, false);
+        }
+        return Ok(());
+    }
+
+    // Normalise the shim's choice to exactly one host verb. Unknown / empty
+    // collapses to `deny` — fail secure: no string the shim sends grants a
+    // capsule unless it is exactly an approve verb.
+    let decision = normalize_decision(&req.decision);
+    let granted = is_approve_verb(decision);
+
+    // Record a DURABLE decision BEFORE forwarding it to the kernel, so it
+    // survives even if the kernel awaiter that raised this grant has already
+    // expired fail-closed (its 60 s window vs. a slow or re-asked human answer):
+    // the next call for this capsule then converges from the record without
+    // re-prompting (see [`crate::grant_decision`] and the broker's auto-respond
+    // path). APPROVE-ONLY: the shim publishes `deny` on every non-accept path —
+    // user decline, elicit error, elicit timeout, or a client with no
+    // elicitation support — with no provenance in the respond body to tell them
+    // apart, so durably recording a deny would make a transport glitch a
+    // permanent auto-deny the user never chose. A deny keeps its ephemeral
+    // semantics (marker consumed below, next call re-prompts: "not now", never
+    // "never") until the respond carries provenance
+    // (astrid-runtime/astrid#1114). The approve/skip choice lives in the pure
+    // [`crate::grant_decision::respond_decision_to_record`] chokepoint. This
+    // runs only AFTER the confused-deputy gate above has passed, so a
+    // security-refusal deny (no caller context / untrusted ingress, handled
+    // earlier) records nothing either way — it is not the user's decision.
+    if let Some(record) = crate::grant_decision::respond_decision_to_record(granted) {
+        crate::grant_decision::record_grant_decision(&req.capsule_id, record);
+    }
+
+    // Publish the decision on the per-request response topic. The kernel grant
+    // handler consumes this `approval_response` verbatim and, on an approve,
+    // persists the capsule grant. NO result drain follows — the call was
+    // dropped at the gate; the shim re-sends it on `granted:true`.
+    publish_decision(&response_topic, &req.request_id, decision, None);
+
+    // Consume the dedup marker on BOTH approve and deny so it is single-use and
+    // can never stick. The grant itself is driven by the published decision, not
+    // this marker; clearing it here is what lets the next call re-prompt (and a
+    // TTL self-heal backstops the clear if this respond never arrives).
+    clear_grant_marker(&req.capsule_id);
+
+    if let Some(reply) = &reply_topic {
+        grant_ack(reply, &req.req_id, granted);
+    } else {
+        log::warn(format!(
+            "{}: broker grant.respond: decision published but req_id '{}' unroutable; \
+             no ack delivered",
+            crate::profile::log_tag(),
+            req.req_id
+        ));
+    }
+    Ok(())
+}
+
+/// Whether a normalised host decision verb is one of the three APPROVE verbs
+/// (i.e. the kernel will GRANT). Anything else — `deny` — is not a grant. Used
+/// to report `granted` in the grant ack so the shim only re-sends the dropped
+/// `tool.call` when the capsule will now be granted.
+fn is_approve_verb(decision: &str) -> bool {
+    matches!(decision, APPROVE | APPROVE_SESSION | APPROVE_ALWAYS)
+}
+
+/// Consume the `(principal, capsule_id)` grant-pending dedup marker. The KV
+/// scope is per-principal (the caller's principal), so the capsule id is the
+/// key suffix; the principal argument is passed for intent only. Best-effort —
+/// a failure to clear just risks one extra suppressed prompt, never a spurious
+/// grant. Called on every respond outcome so the marker is single-use.
+///
+/// An empty `capsule_id` (a respond that omitted the field) makes this a no-op —
+/// there is no key to clear. That does not wedge the pair: the marker carries a
+/// write timestamp and self-heals at [`crate::execute::GRANT_PENDING_TTL_MS`],
+/// so a missing-`capsule_id` respond degrades to a slightly delayed re-prompt,
+/// never permanent suppression.
+fn clear_grant_marker(capsule_id: &str) {
+    let principal = runtime::caller()
+        .ok()
+        .and_then(|ctx| ctx.principal)
+        .unwrap_or_default();
+    let _ = crate::execute::take_grant_pending(&principal, capsule_id);
+}
+
+/// Ack a `grant.respond` to the shim on `astrid.v1.response.<req_id>`.
+///
+/// `granted` reports whether the kernel will grant the capsule (an approve
+/// verb), so the shim only RE-SENDS the dropped `tool.call` when the access
+/// gate will now pass. Mirrors [`ingress_ack`]'s shape with a `grant.respond`
+/// kind. Best-effort: a publish failure is logged, not retried.
+fn grant_ack(reply_topic: &str, req_id: &str, granted: bool) {
+    let reply = json!({
+        "kind": "grant.respond",
+        "req_id": req_id,
+        "granted": granted,
+    });
+    if let Err(e) = ipc::publish_json(reply_topic, &reply) {
+        log::warn(format!(
+            "{}: broker grant.respond: failed to ack {reply_topic}: {e}",
+            crate::profile::log_tag()
+        ));
+    }
+}
+
+/// Publish `decision` on the per-request response topic to unblock the host,
+/// then drain the resumed/denied tool result and deliver it to the shim.
+///
+/// Subscribe-before-publish: the result subscription on
+/// `tool.v1.execute.<tool_name>.result` is established BEFORE the decision is
+/// published so the tool cannot resume and publish ahead of us. Then we drain
+/// for `call_id` and reply on `astrid.v1.response.<req_id>` with the same
+/// terminal `tool.call` shape the broker's non-parked path produces.
+///
+/// `tool_name` is charset-validated (it must form the result topic). A
+/// non-routable `tool_name`, a subscribe failure, or a drain timeout still
+/// publishes the decision (so the host-blocked tool is never left hanging)
+/// and delivers a best-effort `isError` reply to the shim.
+fn resolve_with_decision(
+    req: &ApprovalRespond,
+    response_topic: &str,
+    decision: &'static str,
+    reason: Option<&str>,
+) {
+    let reply_topic = crate::broker::reply_topic(&req.req_id);
+
+    // Validate the tool name BEFORE building the result topic — the same
+    // charset gate the execute path applies, so a hostile / buggy echo
+    // cannot smuggle topic segments into our subscription.
+    if !crate::execute::is_valid_tool_name(&req.tool_name) {
+        log::warn(format!(
+            "{}: broker approval.respond: invalid tool_name '{}' for request_id '{}'; \
+             publishing decision without result drain",
+            crate::profile::log_tag(),
+            req.tool_name,
+            req.request_id
+        ));
+        // Still unblock the host so the tool retires, then surface an error.
+        publish_decision(response_topic, &req.request_id, decision, reason);
+        if let Some(reply) = &reply_topic {
+            deliver_error(reply, &req.req_id, "approval echoed an invalid tool name");
+        }
+        return;
+    }
+
+    let result_topic = format!("tool.v1.execute.{}.result", req.tool_name);
+
+    // Subscribe BEFORE publishing the decision so the resumed tool's result
+    // cannot race ahead of our subscription. A subscribe failure is
+    // non-fatal: we still publish the decision (the host must not be left
+    // blocked) and fall back to a best-effort error reply.
+    let result_sub = match ipc::subscribe(&result_topic) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            log::warn(format!(
+                "{}: broker approval.respond: failed to subscribe {result_topic}: {e}",
+                crate::profile::log_tag()
+            ));
+            None
+        }
+    };
+
+    publish_decision(response_topic, &req.request_id, decision, reason);
+
+    let Some(reply) = &reply_topic else {
+        // Decision is published (tool unblocked) but we have no channel to
+        // deliver the terminal result on. The shim will time out its own
+        // request; nothing more we can do.
+        log::warn(format!(
+            "{}: broker approval.respond: decision published but req_id '{}' unroutable; \
+             no terminal reply delivered",
+            crate::profile::log_tag(),
+            req.req_id
+        ));
+        return;
+    };
+
+    // Drain the resumed/denied result and deliver it as the terminal reply.
+    match result_sub.and_then(|sub| drain_result(&sub, &req.call_id)) {
+        Some((content, is_error)) => deliver_result(reply, &req.req_id, content, is_error),
+        None => deliver_error(
+            reply,
+            &req.req_id,
+            "tool did not return a result after the approval decision",
+        ),
+    }
+}
+
+/// Drain `tool.v1.execute.<name>.result` for `call_id` after a decision,
+/// returning `(content, is_error)` for the first matching result or `None` on
+/// timeout. Bounded by [`RESUME_TIMEOUT_MS`]; polled in [`RESUME_SLICE_MS`]
+/// slices so a result published the instant the tool resumes is picked up
+/// promptly. Reuses the execute path's result-envelope parser so both legs
+/// agree on the wire shape.
+fn drain_result(sub: &ipc::Subscription, call_id: &str) -> Option<(Value, bool)> {
+    let mut remaining = RESUME_TIMEOUT_MS;
+    while remaining > 0 {
+        let step = remaining.min(RESUME_SLICE_MS);
+        match sub.recv(step) {
+            Ok(poll) => {
+                for msg in poll.messages {
+                    if let Some(found) = crate::execute::match_result(&msg.payload, call_id) {
+                        return Some(found);
+                    }
+                }
+            }
+            Err(_) => {
+                // Slice timeout — keep draining until the budget closes.
+            }
+        }
+        remaining = remaining.saturating_sub(step);
+    }
+    None
+}
+
+/// Deliver a terminal `tool.call` reply to the shim carrying the resumed/
+/// denied tool result, mirroring [`crate::broker::handle_mcp_call`]'s
+/// non-parked reply shape so the shim needs no special-casing.
+fn deliver_result(reply_topic: &str, req_id: &str, content: Value, is_error: bool) {
+    let reply = json!({
+        "kind": "tool.call",
+        "req_id": req_id,
+        "content": crate::broker::mcp_content(content),
+        "isError": is_error,
+    });
+    if let Err(e) = ipc::publish_json(reply_topic, &reply) {
+        log::warn(format!(
+            "{}: broker approval.respond: failed to deliver result {reply_topic}: {e}",
+            crate::profile::log_tag()
+        ));
+    }
+}
+
+/// Deliver a terminal `isError` `tool.call` reply to the shim with `text` as
+/// the body. Used for every failure path so the shim always gets exactly one
+/// terminal reply and never hangs.
+fn deliver_error(reply_topic: &str, req_id: &str, text: &str) {
+    deliver_result(
+        reply_topic,
+        req_id,
+        Value::String(format!("{}: {text}", crate::profile::log_tag())),
+        true,
+    );
+}
+
+/// Normalise an arbitrary decision string to one of the host's recognised
+/// approval verbs. Trims and lowercases first so `"Approve"` / `" deny "`
+/// behave intuitively, then maps; anything unrecognised → `deny`.
+fn normalize_decision(decision: &str) -> &'static str {
+    match decision.trim().to_ascii_lowercase().as_str() {
+        APPROVE => APPROVE,
+        APPROVE_SESSION => APPROVE_SESSION,
+        APPROVE_ALWAYS => APPROVE_ALWAYS,
+        // `deny` and EVERYTHING else (unknown verbs, empty, free-form) →
+        // deny. Fail secure: no string the shim can send grants a
+        // capability unless it is exactly one of the three approve verbs.
+        _ => DENY,
+    }
+}
+
+/// Publish the `IpcPayload::ApprovalResponse` decision on the per-request
+/// response topic so the blocked host `request_approval` wakes. The `type`
+/// tag matches the host's `#[serde(tag = "type", rename_all =
+/// "snake_case")]` discriminator for `ApprovalResponse`.
+fn publish_decision(topic: &str, request_id: &str, decision: &str, reason: Option<&str>) {
+    let mut envelope = json!({
+        "type": "approval_response",
+        "request_id": request_id,
+        "decision": decision,
+    });
+    if let Some(r) = reason
+        && let Some(obj) = envelope.as_object_mut()
+    {
+        // `reason` is a display/audit field on the host side — clamp it
+        // like the other display strings so a hostile shim can't inflate
+        // it. Empty after clamping is omitted.
+        let clamped = clamp(r);
+        if !clamped.is_empty() {
+            obj.insert("reason".to_string(), Value::String(clamped));
+        }
+    }
+    if let Err(e) = ipc::publish_json(topic, &envelope) {
+        log::warn(format!(
+            "{}: failed to publish approval decision {topic}: {e}",
+            crate::profile::log_tag()
+        ));
+    }
+}
+
+/// Publish an auto-decision for an observed grant-gate miss WITHOUT eliciting —
+/// the broker's realization of a DURABLE recorded decision
+/// ([`crate::grant_decision::recorded_grant_decision`]). Maps the choice onto the
+/// SAME `astrid.v1.approval.response.<request_id>` envelope a human
+/// `grant.respond` would produce, so the kernel grant handler consumes it
+/// verbatim: an approve persists the grant against the (fresh, live) awaiter that
+/// raised this signal, a deny retires that awaiter cleanly instead of letting it
+/// fail-closed at 60 s. NO result drain — grant-on-use dropped the original call;
+/// the caller re-sends. Returns whether the `request_id` was routable (an
+/// unroutable id publishes nothing and the kernel awaiter times out on its own).
+///
+/// SECURITY: this only ever answers a KERNEL-CORRELATED `GrantRequired` whose
+/// `request_id` the kernel access gate minted. The broker never grants anything
+/// itself — it replays a decision the user already recorded onto the kernel's own
+/// response topic; the kernel remains the sole grantor, and the
+/// response-never-carries-a-target invariant is untouched.
+pub(crate) fn publish_grant_auto_decision(request_id: &str, approve: bool) -> bool {
+    let Some(topic) = response_topic(request_id) else {
+        log::warn(format!(
+            "{}: broker grant auto-decision: unroutable request_id '{request_id}'; \
+             not publishing (kernel awaiter will time out on its own)",
+            crate::profile::log_tag()
+        ));
+        return false;
+    };
+    let decision = if approve { APPROVE } else { DENY };
+    publish_decision(&topic, request_id, decision, None);
+    true
+}
+
+/// Build the single-segment decision topic for `request_id`, or `None` if
+/// the id cannot form a clean topic segment.
+///
+/// Same charset family as [`crate::broker::reply_topic`]: a `.` would turn
+/// the egress topic into one the host's exact
+/// `astrid.v1.approval.response.<id>` subscription can't match, and
+/// whitespace / control / wildcard bytes could forge or shadow topics.
+fn response_topic(request_id: &str) -> Option<String> {
+    if request_id.is_empty() || request_id.len() > MAX_REQUEST_ID_LEN {
+        return None;
+    }
+    let clean = request_id
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-'));
+    if !clean {
+        return None;
+    }
+    Some(format!("{APPROVAL_RESPONSE_PREFIX}{request_id}"))
+}
+
+/// Trim + length-clamp a host display string defensively. The host
+/// already sanitizes these; this is belt-and-suspenders against a future
+/// producer that skips it.
+fn clamp(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.chars().count() <= MAX_DISPLAY_LEN {
+        return trimmed.to_string();
+    }
+    trimmed.chars().take(MAX_DISPLAY_LEN).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    fn install_test_profile() {
+        crate::profile::install_aos();
+    }
+
+    use super::*;
+
+    #[test]
+    fn approval_required_parses_canonical_envelope() {
+        install_test_profile();
+        let v = json!({
+            "type": "approval_required",
+            "request_id": "0191f3a2b4c74d8e9f01234567890abc",
+            "action": "git push",
+            "resource": "git push origin main",
+            "reason": "Capsule 'shell' requests approval",
+        });
+        assert!(is_approval_required(&v));
+        let req: ApprovalRequired = serde_json::from_value(v).unwrap();
+        assert_eq!(req.request_id, "0191f3a2b4c74d8e9f01234567890abc");
+        assert_eq!(req.action, "git push");
+    }
+
+    #[test]
+    fn is_approval_required_rejects_other_payloads() {
+        install_test_profile();
+        // Wrong tag.
+        assert!(!is_approval_required(&json!({
+            "type": "approval_response",
+            "request_id": "x",
+            "decision": "approve"
+        })));
+        // Right tag, empty request_id.
+        assert!(!is_approval_required(&json!({
+            "type": "approval_required",
+            "request_id": ""
+        })));
+        // No tag at all.
+        assert!(!is_approval_required(&json!({ "request_id": "x" })));
+    }
+
+    #[test]
+    fn normalize_decision_maps_approve_verbs() {
+        install_test_profile();
+        assert_eq!(normalize_decision("approve"), APPROVE);
+        assert_eq!(normalize_decision("approve_session"), APPROVE_SESSION);
+        assert_eq!(normalize_decision("approve_always"), APPROVE_ALWAYS);
+    }
+
+    #[test]
+    fn normalize_decision_is_case_and_whitespace_insensitive() {
+        install_test_profile();
+        assert_eq!(normalize_decision("  Approve "), APPROVE);
+        assert_eq!(normalize_decision("APPROVE_ALWAYS"), APPROVE_ALWAYS);
+    }
+
+    #[test]
+    fn normalize_decision_fails_secure_on_unknown() {
+        install_test_profile();
+        // Anything not exactly an approve verb denies — no string the shim
+        // sends can smuggle a grant.
+        assert_eq!(normalize_decision("deny"), DENY);
+        assert_eq!(normalize_decision(""), DENY);
+        assert_eq!(normalize_decision("yes"), DENY);
+        assert_eq!(normalize_decision("approve; rm -rf /"), DENY);
+        assert_eq!(normalize_decision("allow"), DENY);
+    }
+
+    #[test]
+    fn response_topic_accepts_uuid() {
+        install_test_profile();
+        assert_eq!(
+            response_topic("0191f3a2b4c74d8e9f01234567890abc").as_deref(),
+            Some("astrid.v1.approval.response.0191f3a2b4c74d8e9f01234567890abc")
+        );
+        assert!(response_topic("0191f3a2-b4c7-4d8e-9f01-234567890abc").is_some());
+    }
+
+    #[test]
+    fn response_topic_rejects_topic_smuggling() {
+        install_test_profile();
+        assert!(response_topic("").is_none());
+        assert!(response_topic("a.b").is_none());
+        assert!(response_topic("a b").is_none());
+        assert!(response_topic("a*b").is_none());
+        assert!(response_topic("a/b").is_none());
+        assert!(response_topic("a\nb").is_none());
+        let too_long = "a".repeat(MAX_REQUEST_ID_LEN + 1);
+        assert!(response_topic(&too_long).is_none());
+    }
+
+    #[test]
+    fn reply_flag_carries_display_and_routing_fields_only() {
+        install_test_profile();
+        let req = ApprovalRequired {
+            request_id: "rid".to_string(),
+            action: "  git push  ".to_string(),
+            resource: "git push origin main".to_string(),
+            reason: "needs consent".to_string(),
+        };
+        let flag = req.to_reply_flag("shell.exec", "call-7");
+        assert_eq!(flag["request_id"], "rid");
+        // Trimmed.
+        assert_eq!(flag["action"], "git push");
+        assert_eq!(flag["resource"], "git push origin main");
+        assert_eq!(flag["reason"], "needs consent");
+        // Routing tokens the shim must echo back so the resume path can
+        // re-establish the result drain. These are not secrets — they are the
+        // same tokens the shim used to make the original tool.call.
+        assert_eq!(flag["tool_name"], "shell.exec");
+        assert_eq!(flag["call_id"], "call-7");
+        // No arguments / secret fields leak in.
+        assert!(flag.get("arguments").is_none());
+    }
+
+    #[test]
+    fn clamp_truncates_oversize_display() {
+        install_test_profile();
+        let long = "a".repeat(MAX_DISPLAY_LEN + 50);
+        assert_eq!(clamp(&long).chars().count(), MAX_DISPLAY_LEN);
+        assert_eq!(clamp("  hi  "), "hi");
+    }
+
+    #[test]
+    fn approval_respond_parses_minimum_shape() {
+        install_test_profile();
+        let v = json!({
+            "req_id": "r1",
+            "request_id": "rid",
+            "decision": "approve",
+            "tool_name": "shell.exec",
+            "call_id": "r1",
+        });
+        let parsed: ApprovalRespond = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed.req_id, "r1");
+        assert_eq!(parsed.request_id, "rid");
+        assert_eq!(parsed.decision, "approve");
+        assert_eq!(parsed.tool_name, "shell.exec");
+        assert_eq!(parsed.call_id, "r1");
+        assert!(parsed.reason.is_none());
+    }
+
+    #[test]
+    fn approval_respond_requires_routing_fields() {
+        install_test_profile();
+        // `tool_name` / `call_id` are mandatory — without them the resume
+        // path cannot re-establish the result drain, so the wire shape must
+        // reject a payload missing them rather than silently default.
+        assert!(
+            serde_json::from_value::<ApprovalRespond>(json!({
+                "req_id": "r1",
+                "request_id": "rid",
+                "decision": "approve",
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn ingress_respond_parses_minimum_shape() {
+        install_test_profile();
+        let v = json!({ "req_id": "r1", "accept": true });
+        let parsed: IngressRespond = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed.req_id, "r1");
+        assert!(parsed.accept);
+    }
+
+    #[test]
+    fn ingress_respond_requires_accept_and_req_id() {
+        install_test_profile();
+        // `req_id` is the only ack channel; `accept` is the decision. Both
+        // are mandatory — a payload missing either is rejected rather than
+        // silently defaulting (a defaulted `accept` could mean a silent
+        // grant or a silent deny, both wrong).
+        assert!(serde_json::from_value::<IngressRespond>(json!({ "accept": true })).is_err());
+        assert!(serde_json::from_value::<IngressRespond>(json!({ "req_id": "r1" })).is_err());
+    }
+
+    #[test]
+    fn ingress_respond_ignores_body_source_id() {
+        install_test_profile();
+        // SECURITY: a `source_id` in the body must be inert — the trust write
+        // keys on the kernel-stamped caller, never this field. The struct does
+        // not deserialize it, so a hostile body cannot smuggle a foreign
+        // ingress identity through the wire shape.
+        let v = json!({
+            "req_id": "r1",
+            "accept": true,
+            "source_id": "attacker-controlled-uuid",
+        });
+        let parsed: IngressRespond = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed.req_id, "r1");
+        assert!(parsed.accept);
+        // No field on the struct carries the body source_id — it is dropped.
+    }
+
+    #[test]
+    fn approval_respond_carries_optional_reason() {
+        install_test_profile();
+        let v = json!({
+            "req_id": "r1",
+            "request_id": "rid",
+            "decision": "deny",
+            "tool_name": "shell.exec",
+            "call_id": "r1",
+            "reason": "user declined",
+        });
+        let parsed: ApprovalRespond = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed.reason.as_deref(), Some("user declined"));
+    }
+
+    // ------------------------------------------------------------------
+    // grant-on-use (grant_required signal + grant.respond bridge).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn grant_required_parses_canonical_envelope() {
+        install_test_profile();
+        let v = json!({
+            "type": "grant_required",
+            "request_id": "0191f3a2b4c74d8e9f01234567890abc",
+            "principal": "alice",
+            "capsule_id": "fs",
+        });
+        assert!(is_grant_required(&v));
+        let req: GrantRequired = serde_json::from_value(v).unwrap();
+        assert_eq!(req.request_id, "0191f3a2b4c74d8e9f01234567890abc");
+        assert_eq!(req.principal, "alice");
+        assert_eq!(req.capsule_id, "fs");
+    }
+
+    #[test]
+    fn is_grant_required_rejects_other_payloads() {
+        install_test_profile();
+        // Wrong tag — the sibling approval_required must NOT be read as a grant.
+        assert!(!is_grant_required(&json!({
+            "type": "approval_required",
+            "request_id": "x",
+        })));
+        // Right tag, empty request_id (can't be routed back).
+        assert!(!is_grant_required(&json!({
+            "type": "grant_required",
+            "request_id": ""
+        })));
+        // No tag at all.
+        assert!(!is_grant_required(&json!({ "request_id": "x" })));
+    }
+
+    #[test]
+    fn is_approval_required_rejects_grant_required() {
+        install_test_profile();
+        // Symmetry: the grant envelope must NOT be read as an approval, so the
+        // combined poll classifies each signal to exactly one outcome.
+        assert!(!is_approval_required(&json!({
+            "type": "grant_required",
+            "request_id": "x",
+            "capsule_id": "fs",
+        })));
+    }
+
+    #[test]
+    fn grant_reply_flag_carries_display_and_routing_fields_only() {
+        install_test_profile();
+        let req = GrantRequired {
+            request_id: "rid".to_string(),
+            principal: "  alice  ".to_string(),
+            capsule_id: "fs".to_string(),
+        };
+        let flag = req.to_reply_flag("fs.read", "call-7");
+        assert_eq!(flag["request_id"], "rid");
+        // Trimmed display fields.
+        assert_eq!(flag["principal"], "alice");
+        assert_eq!(flag["capsule_id"], "fs");
+        // Routing tokens the shim echoes / re-sends with.
+        assert_eq!(flag["tool_name"], "fs.read");
+        assert_eq!(flag["call_id"], "call-7");
+        // No arguments / secret fields leak in.
+        assert!(flag.get("arguments").is_none());
+    }
+
+    #[test]
+    fn grant_respond_parses_minimum_shape() {
+        install_test_profile();
+        let v = json!({
+            "req_id": "r1",
+            "request_id": "rid",
+            "decision": "approve",
+            "capsule_id": "fs",
+        });
+        let parsed: GrantRespond = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed.req_id, "r1");
+        assert_eq!(parsed.request_id, "rid");
+        assert_eq!(parsed.decision, "approve");
+        assert_eq!(parsed.capsule_id, "fs");
+    }
+
+    #[test]
+    fn grant_respond_requires_req_id_request_id_decision() {
+        install_test_profile();
+        // `req_id` (ack channel), `request_id` (decision topic), and `decision`
+        // are mandatory; only `capsule_id` defaults (used solely to clear the
+        // dedup marker — its absence degrades to a no-op clear, never a wrong
+        // decision). A payload missing any of the three is rejected.
+        assert!(
+            serde_json::from_value::<GrantRespond>(json!({
+                "request_id": "rid",
+                "decision": "approve",
+            }))
+            .is_err()
+        );
+        assert!(
+            serde_json::from_value::<GrantRespond>(json!({
+                "req_id": "r1",
+                "decision": "approve",
+            }))
+            .is_err()
+        );
+        assert!(
+            serde_json::from_value::<GrantRespond>(json!({
+                "req_id": "r1",
+                "request_id": "rid",
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn grant_respond_does_not_require_tool_name_or_call_id() {
+        install_test_profile();
+        // Divergence from ApprovalRespond: grant-on-use does NOT drain a result
+        // (the kernel dropped the call), so the wire shape carries no
+        // `tool_name` / `call_id`. A payload without them must still parse.
+        let v = json!({
+            "req_id": "r1",
+            "request_id": "rid",
+            "decision": "deny",
+        });
+        let parsed: GrantRespond = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed.capsule_id, "");
+    }
+
+    #[test]
+    fn is_approve_verb_only_true_for_approve_verbs() {
+        install_test_profile();
+        // The grant ack's `granted` flag — true only when the kernel will grant
+        // (an approve verb), so the shim re-sends only on a real grant.
+        assert!(is_approve_verb(APPROVE));
+        assert!(is_approve_verb(APPROVE_SESSION));
+        assert!(is_approve_verb(APPROVE_ALWAYS));
+        assert!(!is_approve_verb(DENY));
+    }
+
+    #[test]
+    fn grant_respond_decision_normalizes_to_grant_or_deny() {
+        install_test_profile();
+        // End-to-end of the verb spine the handler uses: an approve verb → the
+        // kernel grants (granted:true); anything else → deny (granted:false),
+        // fail secure. No string the shim sends grants unless it is exactly an
+        // approve verb.
+        assert!(is_approve_verb(normalize_decision("approve")));
+        assert!(is_approve_verb(normalize_decision("  Approve_Always ")));
+        assert!(!is_approve_verb(normalize_decision("deny")));
+        assert!(!is_approve_verb(normalize_decision("")));
+        assert!(!is_approve_verb(normalize_decision("grant")));
+        assert!(!is_approve_verb(normalize_decision("approve; rm -rf /")));
+    }
+}

--- a/crates/aos-mcp-broker/src/broker.rs
+++ b/crates/aos-mcp-broker/src/broker.rs
@@ -1,0 +1,1156 @@
+//! Broker front door — the sanitized `astrid.v1.*` MCP surface.
+//!
+//! This is aos-mcp's SECOND front door, sitting over the SAME
+//! discovery ([`crate::discovery`]) and execute ([`crate::execute`])
+//! internals as the agent-runner path. Where the agent path serves the
+//! `mcp__aos__*` namespace Claude consumes via `--allowed-tools`, the
+//! broker serves a generic, third-party MCP client through a
+//! shim/proxy.
+//!
+//! ## Topics
+//!
+//! * **inbound** `astrid.v1.request.mcp.tools.list`  -> [`handle_mcp_list`]
+//! * **inbound** `astrid.v1.request.mcp.tool.call`   -> [`handle_mcp_call`]
+//! * **outbound** `astrid.v1.response.<req_id>`        (both handlers)
+//!
+//! ## Wire contract
+//!
+//! The proxy/shim delivers the PAYLOAD only — the source topic is not
+//! visible to the handler, and the proxy that bridges the external MCP
+//! client subscribes to `astrid.v1.response.*` and forwards the body
+//! verbatim. So:
+//!
+//! * `req_id` is mirrored into the request body and echoed into the
+//!   reply body (the proxy correlates on the body, not the topic);
+//! * the egress topic `astrid.v1.response.<req_id>` MUST be a single
+//!   segment after the prefix. The kernel's `topic_matches` is
+//!   strict-arity (a 4-segment `astrid.v1.response.*` subscription
+//!   never matches a 5-segment topic), so a `req_id` carrying a `.`
+//!   would be silently dropped. We reject any `req_id` that is not a
+//!   single clean segment before publishing.
+//!
+//! ## Trust boundary
+//!
+//! The shim NEVER sees `tool.v1.*` — it only ever touches the
+//! sanitized `astrid.v1.*` surface. All `tool.v1.*` fan-out lives
+//! behind [`crate::execute::dispatch_with_approval`], which charset-gates
+//! the tool name before it can reach a routed topic. The list reply
+//! carries RAW MCP descriptors (no `mcp__aos__` prefix) because the
+//! broker is a standard MCP server, not the agent runner.
+//!
+//! ## Confused-deputy gate (state-mutating calls)
+//!
+//! [`handle_mcp_call`] is state-mutating and externally reachable, so it
+//! additionally requires the inbound message's kernel-set `source_id`
+//! (the originating capsule UUID, via [`astrid_sdk::runtime::caller`]) to
+//! be a TRUSTED ingress. Trust is recorded interactively: an untrusted
+//! source_id triggers an `ingress_approval_required` reply that the shim
+//! turns into a user consent prompt, and on accept the broker records trust
+//! under the per-(principal, source_id) KV key `mcp.ingress.trust.<source_id>`
+//! (see [`crate::execute::is_ingress_trusted`] and
+//! [`crate::approval::handle_mcp_ingress_respond`]). This stops a non-ingress
+//! capsule from puppeting aos-mcp into executing tools on a principal's
+//! behalf without a human ever consenting to it. [`handle_mcp_list`] is
+//! read-only (it returns the public tool surface the proxy already publishes)
+//! and is NOT gated as strictly. See [`crate::execute::is_ingress_trusted`]
+//! for why the trust marker (`verified()`) cannot substitute for the
+//! `source_id` identity check.
+
+use astrid_sdk::prelude::*;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::{approval, discovery, execute, grant_decision};
+
+/// Egress topic prefix. The reply lands on `<prefix><req_id>`; with a
+/// single-segment `req_id` that is exactly 4 segments, which the
+/// proxy's `astrid.v1.response.*` subscription matches.
+const RESPONSE_PREFIX: &str = "astrid.v1.response.";
+
+/// `req_id` length cap. A correlation id is a UUID-ish token; anything
+/// longer is rejected before it can be stamped into an egress topic.
+const MAX_REQ_ID_LEN: usize = 128;
+
+/// Reserved broker tool name for the NATIVE-tool PreToolUse permission
+/// gate. It is NOT a real capsule tool and deliberately never appears in
+/// `tools/list`: it exists only to service Claude's `type:"mcp_tool"`
+/// PreToolUse hook, which calls it OUT-OF-BAND (not through Claude's tool
+/// surface) to get a binding allow/deny decision for a native tool call
+/// (`Bash`, `Write`, `Edit`, …). VERIFIED against the shipped `claude`
+/// executor: a `mcp_tool` hook issues `tools/call` DIRECTLY and does NOT
+/// pre-validate the name against the server's `tools/list`, so an
+/// intentionally-unlisted tool the broker special-cases is invoked normally
+/// — no descriptor injection needed.
+///
+/// ## Why a hook, when the `mcp__aos__*` plane is gated in-process
+///
+/// Native tools execute INSIDE the `claude` process and reach no Astrid
+/// chokepoint — unlike the `mcp__aos__*` tools, which funnel through
+/// [`handle_mcp_call`] where the same [`crate::policy`] PDP refuses to
+/// dispatch a denied call un-bypassably. For native tools there is no such
+/// in-process point, so the PreToolUse hook is the ONLY per-call lever. The
+/// gate reuses the SAME PDP, so one operator rule set governs both planes.
+///
+/// ## Honest limit — advisory, fail-open
+///
+/// This path is best-effort, not a guarantee. The hook is read from a
+/// settings tier a capable session can edit, the gate call is one Claude
+/// could route around, and the platform FAILS OPEN: a disconnected server,
+/// an `isError` reply, or non-JSON text all let the tool run. The
+/// fail-CLOSED boundary for native tools stays the Astrid host sandbox plus
+/// the `--disallowedTools` deny-list; this gate adds dynamic, argument-level
+/// DENY on top, and only ever NARROWS (an `Allow` defers to Claude's
+/// existing permission flow rather than asserting an explicit allow).
+///
+/// Must equal `claude_install::layout::PRETOOLUSE_GATE_TOOL` — claude-install
+/// authors the hook with this exact `tool` name. The two
+/// crates share no dependency edge, so the constant is mirrored, not shared;
+/// a drift silently DISABLES the gate (the hook would call a name the broker
+/// does not special-case, so `dispatch_with_approval` treats it as an
+/// unknown tool, drains to `isError`, and the hook fails open). A presence
+/// test in each crate anchors the value.
+pub(crate) const PRETOOLUSE_GATE_TOOL: &str = "aos_pretooluse_gate";
+
+/// Inbound `astrid.v1.request.mcp.tools.list` payload.
+///
+/// `req_id` is the proxy's correlation token, mirrored into the body
+/// because the handler cannot see the source topic. Any other fields
+/// are ignored (forward-compat with future pagination cursors etc.).
+#[derive(Debug, Deserialize)]
+struct ListRequest {
+    req_id: String,
+}
+
+/// Inbound `astrid.v1.request.mcp.tool.call` payload.
+///
+/// Standard MCP `tools/call` shape (`name` + `arguments`) plus the
+/// proxy `req_id`. `name` is a RAW MCP tool name — the broker does not
+/// use the `mcp__aos__` prefix.
+#[derive(Debug, Deserialize)]
+struct CallRequest {
+    req_id: String,
+    name: String,
+    #[serde(default)]
+    arguments: Value,
+}
+
+/// Handle `astrid.v1.request.mcp.tools.list`.
+///
+/// Runs the shared describe-collect snapshot, converts to MCP
+/// descriptors, and replies on `astrid.v1.response.<req_id>` with
+/// `{ kind:"tools.list", req_id, tools:[...] }`. Exactly one reply per
+/// accepted request.
+pub(crate) fn handle_mcp_list(payload: Value) -> Result<(), SysError> {
+    let req: ListRequest = match serde_json::from_value(payload) {
+        Ok(v) => v,
+        Err(e) => {
+            // No recoverable req_id — there is no channel to reply on,
+            // so the proxy will time out its own request. Log and drop.
+            log::warn(format!(
+                "{}: broker tools.list: malformed payload (no req_id): {e}",
+                crate::profile::log_tag()
+            ));
+            return Ok(());
+        }
+    };
+
+    let Some(reply_topic) = reply_topic(&req.req_id) else {
+        log::warn(format!(
+            "{}: broker tools.list: rejecting unroutable req_id '{}'",
+            crate::profile::log_tag(),
+            req.req_id
+        ));
+        return Ok(());
+    };
+
+    let started = discovery::wall_ms();
+    let (source_id, principal) = caller_fields();
+    log::info(format!(
+        "{}: broker ingress method=tools.list req_id={} source_id={source_id} \
+         principal={principal}",
+        crate::profile::log_tag(),
+        req.req_id
+    ));
+
+    let snapshot = discovery::collect_snapshot(&req.req_id);
+    let tools = discovery::to_mcp_descriptors(&snapshot);
+    let tool_count = tools.len();
+
+    let reply = json!({
+        "kind": "tools.list",
+        "req_id": req.req_id,
+        "tools": tools,
+    });
+    publish_reply(&reply_topic, &reply);
+    log::info(format!(
+        "{}: broker response method=tools.list req_id={} outcome=ok tools={tool_count} \
+         elapsed_ms={}",
+        crate::profile::log_tag(),
+        req.req_id,
+        discovery::wall_ms().saturating_sub(started)
+    ));
+    Ok(())
+}
+
+/// Handle `astrid.v1.request.mcp.tool.call`.
+///
+/// Runs the shared execute-dispatch and replies on
+/// `astrid.v1.response.<req_id>` with
+/// `{ kind:"tool.call", req_id, content:[...], isError:bool }`. Every
+/// failure path (unknown/invalid name, subscribe/publish error, drain
+/// timeout) reshapes into an `isError:true` reply so the proxy never
+/// hangs. Exactly one reply per accepted request.
+pub(crate) fn handle_mcp_call(payload: Value) -> Result<(), SysError> {
+    let req: CallRequest = match serde_json::from_value(payload) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn(format!(
+                "{}: broker tool.call: malformed payload (no req_id): {e}",
+                crate::profile::log_tag()
+            ));
+            return Ok(());
+        }
+    };
+
+    let Some(reply_topic) = reply_topic(&req.req_id) else {
+        log::warn(format!(
+            "{}: broker tool.call: rejecting unroutable req_id '{}'",
+            crate::profile::log_tag(),
+            req.req_id
+        ));
+        return Ok(());
+    };
+
+    let started = discovery::wall_ms();
+
+    // Native-tool PreToolUse gate. A reserved, unlisted tool name Claude's
+    // PreToolUse `mcp_tool` hook calls to get a binding decision for a NATIVE
+    // tool (`Bash`/`Write`/…) that runs inside the claude process and so
+    // never reaches the dispatch gate below. It is READ-ONLY — it evaluates
+    // policy and replies a hook decision, never dispatching — so it sits
+    // ABOVE the confused-deputy mutation gate, exactly like the read-only
+    // `handle_mcp_list`. The reply is ALWAYS `isError:false`: an
+    // `isError:true` MCP result makes the hook fail OPEN, so a deny must ride
+    // in the reply `content`, never the error flag. See [`PRETOOLUSE_GATE_TOOL`].
+    if req.name == PRETOOLUSE_GATE_TOOL {
+        // Out-of-band native-tool permission gate (not a routed tool call); the
+        // gated NATIVE tool is named in the arguments, not `req.name`.
+        let native = req
+            .arguments
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        log::info(format!(
+            "{}: broker ingress method=pretooluse_gate req_id={} tool={native}",
+            crate::profile::log_tag(),
+            req.req_id
+        ));
+        publish_reply(&reply_topic, &pretooluse_gate_reply(&req));
+        log::info(format!(
+            "{}: broker response method=pretooluse_gate req_id={} outcome=ok elapsed_ms={}",
+            crate::profile::log_tag(),
+            req.req_id,
+            discovery::wall_ms().saturating_sub(started)
+        ));
+        return Ok(());
+    }
+
+    // Confused-deputy gate. `astrid.v1.request.mcp.tool.call` is
+    // state-mutating and externally reachable through the cli proxy, so
+    // before we dispatch we require the message's kernel-set `source_id`
+    // (the originating capsule UUID, NOT a guest-settable body field) to be
+    // a TRUSTED ingress. Trust is no longer an operator-maintained allow-list:
+    // an ingress is trusted iff the user has interactively consented to it
+    // (recorded under the per-(principal, source_id) KV key
+    // `mcp.ingress.trust.<source_id>` — see [`execute::is_ingress_trusted`]).
+    //
+    // When the source_id is NOT yet trusted we do NOT hard-deny: we reply a
+    // distinct `ingress_approval_required` signal (NOT `isError`, since it is
+    // a prompt-needed state, not a failure) so the shim can elicit consent
+    // from the user and, on accept, forward
+    // `astrid.v1.request.mcp.ingress.respond` ->
+    // [`crate::approval::handle_mcp_ingress_respond`], which records trust
+    // against the kernel-stamped caller source_id and lets a re-sent call
+    // pass this gate. We NEVER dispatch on this path. See
+    // [`execute::is_ingress_trusted`] for why `verified()` is insufficient.
+    let (source_id, principal) = match runtime::caller() {
+        Ok(ctx) => (ctx.source_id, ctx.principal.unwrap_or_default()),
+        Err(e) => {
+            // No caller context — cannot attribute the ingress. Fail
+            // closed rather than dispatch an unattributed mutation.
+            log::warn(format!(
+                "{}: broker tool.call: no caller context, rejecting req_id={} tool={}: {e}",
+                crate::profile::log_tag(),
+                req.req_id,
+                req.name
+            ));
+            let reply = json!({
+                "kind": "tool.call",
+                "req_id": req.req_id,
+                "content": mcp_content(Value::String(
+                    format!("{}: caller context unavailable; tool call rejected", crate::profile::log_tag()),
+                )),
+                "isError": true,
+            });
+            publish_reply(&reply_topic, &reply);
+            return Ok(());
+        }
+    };
+
+    // Ingress milestone — one concise line per accepted tool.call. Tool NAME
+    // only, never arguments (an argument may carry a secret; INFO must not
+    // leak it). `arg_count` is the cheap, non-sensitive shape signal.
+    log::info(format!(
+        "{}: broker ingress method=tool.call req_id={} source_id={source_id} \
+         principal={} tool={} arg_count={}",
+        crate::profile::log_tag(),
+        req.req_id,
+        display_principal(&principal),
+        req.name,
+        arg_count(&req.arguments)
+    ));
+
+    if !execute::is_ingress_trusted(&source_id) {
+        // Trust decision: untrusted ingress → consent-required (WARN: a
+        // mutation was withheld pending a human accept, security-relevant).
+        log::warn(format!(
+            "{}: broker trust=consent-required req_id={} source_id={source_id} tool={}; \
+             requesting interactive consent",
+            crate::profile::log_tag(),
+            req.req_id,
+            req.name
+        ));
+        // Record that a consent prompt is now outstanding for this ingress.
+        // The respond handler ([`crate::approval::handle_mcp_ingress_respond`])
+        // only honours an `accept` that consumes this marker, so an unsolicited
+        // or replayed `ingress.respond` cannot prime trust without a prompt the
+        // broker actually issued. Keyed on the kernel-stamped caller (the same
+        // identity the trust write uses) — best-effort; a write failure just
+        // re-prompts on the next call, never grants spuriously.
+        execute::mark_ingress_pending(&source_id);
+
+        // Prompt-needed signal — NOT an error. The shim elicits consent and,
+        // on accept, drives `ingress.respond` then re-sends this call. We
+        // echo `source_id` for display/diagnostics only; the trust write
+        // keys on the kernel-stamped caller of the `ingress.respond`, never
+        // this body field. No tool is dispatched.
+        //
+        // Carry actionable guidance as `message` + MCP `content` so the denial
+        // is never a dead end: an elicit-capable shim honours the
+        // `ingress_approval_required` signal and ignores this text, but a
+        // client that cannot render the prompt still surfaces WHICH session was
+        // withheld, WHY, and HOW to proceed instead of a bare "not authorized".
+        // Additive only — the trust model is unchanged; nothing here grants
+        // trust.
+        let guidance = ingress_consent_guidance(&source_id);
+        let reply = json!({
+            "kind": "tool.call",
+            "req_id": req.req_id,
+            "ingress_approval_required": true,
+            "source_id": source_id,
+            "tool_name": req.name,
+            "message": guidance,
+            "content": mcp_content(Value::String(guidance.clone())),
+            "isError": false,
+        });
+        publish_reply(&reply_topic, &reply);
+        log::info(format!(
+            "{}: broker response method=tool.call req_id={} outcome=consent_required \
+             tool={} elapsed_ms={}",
+            crate::profile::log_tag(),
+            req.req_id,
+            req.name,
+            discovery::wall_ms().saturating_sub(started)
+        ));
+        return Ok(());
+    }
+
+    // Trust decision: source_id is a trusted ingress → proceed to dispatch.
+    log::info(format!(
+        "{}: broker trust=trusted req_id={} source_id={source_id} tool={}",
+        crate::profile::log_tag(),
+        req.req_id,
+        req.name
+    ));
+
+    // Argument-level policy gate — the binding PDP. Evaluated in-process
+    // at THIS chokepoint (the one capsule-space point holding parsed
+    // `(name, arguments)` before fan-out), so a supervised Claude cannot
+    // route around it the way it could strip a settings-tier PreToolUse
+    // hook. DENY → reply `isError` + never dispatch. The gate only ever
+    // NARROWS: no matching rule, no policy configured, or a policy-load
+    // failure all return `Allow`, leaving the host's execution-time
+    // capability enforcement as the live boundary — degrade-to-PEP, never
+    // "anything goes". The reason surfaced back is the operator's static
+    // rule id, never a reflected argument. See [`crate::policy`].
+    if let crate::policy::Decision::Deny { reason } =
+        crate::policy::evaluate(&crate::policy::load_rules(), &req.name, &req.arguments)
+    {
+        // A received request that will NOT be dispatched → WARN (never silent).
+        // `rule` is the operator's static rule id, never a reflected argument.
+        log::warn(format!(
+            "{}: broker policy-deny req_id={} tool={} rule={reason}",
+            crate::profile::log_tag(),
+            req.req_id,
+            req.name
+        ));
+        let _ = ipc::publish_json(
+            &crate::profile::audit_topic("policy_deny"),
+            &serde_json::json!({ "tool": req.name, "rule": reason }),
+        );
+        let reply = json!({
+            "kind": "tool.call",
+            "req_id": req.req_id,
+                "content": mcp_content(Value::String(format!("{}: tool call denied by policy (rule: {reason})", crate::profile::log_tag()))),
+            "isError": true,
+        });
+        publish_reply(&reply_topic, &reply);
+        log::info(format!(
+            "{}: broker response method=tool.call req_id={} outcome=policy_denied \
+             tool={} elapsed_ms={}",
+            crate::profile::log_tag(),
+            req.req_id,
+            req.name,
+            discovery::wall_ms().saturating_sub(started)
+        ));
+        return Ok(());
+    }
+
+    // Routing milestone — the broker is about to dispatch the execute to the
+    // providing capsule via the routed `tool.v1.execute.<tool>` topic.
+    log::info(format!(
+        "{}: broker route req_id={} tool={} topic=tool.v1.execute.{}",
+        crate::profile::log_tag(),
+        req.req_id,
+        req.name,
+        req.name
+    ));
+
+    // The execute core wants a `call_id` for result correlation on the
+    // shared `tool.v1.execute.<bare>.result` topic. The broker's
+    // `req_id` doubles as that correlation token — it is already
+    // single-segment / charset-clean (validated by `reply_topic`), and
+    // it never leaves the `astrid.v1.*` surface beyond the inner
+    // `tool.v1.execute` request body.
+    //
+    // `dispatch_with_approval` additionally watches `astrid.v1.approval`
+    // for the drain window: if the routed tool blocks on a capability
+    // approval, we surface an `approval-required` flag in this reply so the
+    // shim can elicit the choice from Claude (the broker can't call the
+    // host `astrid:elicit` syscall — it is install/upgrade-gated — so it
+    // relays the bus envelope instead). The shim then drives
+    // `astrid.v1.request.mcp.approval.respond` -> [`approval::handle_mcp_approval`],
+    // which maps the choice onto `astrid.v1.approval.response.<id>` to
+    // unblock the tool. See [`crate::approval`].
+    let reply = match execute::dispatch_with_approval(&req.name, &req.req_id, &req.arguments) {
+        execute::DispatchOutcome::Result(content, is_error) => {
+            log::info(format!(
+                "{}: broker response method=tool.call req_id={} tool={} outcome={} \
+                 elapsed_ms={}",
+                crate::profile::log_tag(),
+                req.req_id,
+                req.name,
+                if is_error { "error" } else { "ok" },
+                discovery::wall_ms().saturating_sub(started)
+            ));
+            json!({
+                "kind": "tool.call",
+                "req_id": req.req_id,
+                "content": mcp_content(content),
+                "isError": is_error,
+            })
+        }
+        execute::DispatchOutcome::ApprovalRequired(required) => {
+            log::info(format!(
+                "{}: broker response method=tool.call req_id={} tool={} \
+                 outcome=approval_required elapsed_ms={}",
+                crate::profile::log_tag(),
+                req.req_id,
+                req.name,
+                discovery::wall_ms().saturating_sub(started)
+            ));
+            json!({
+                "kind": "tool.call",
+                "req_id": req.req_id,
+                // No tool result yet — the tool is parked on the approval. The
+                // shim MUST elicit the choice and respond on
+                // `astrid.v1.request.mcp.approval.respond` (echoing back the
+                // `tool_name` + `call_id` the flag carries) before a result can
+                // be produced. `content` is empty and `isError` false: this is
+                // a pending state, not a failure. The terminal result is
+                // delivered by `approval::handle_mcp_approval` once the decision
+                // lands — see [`crate::approval`]. `req.req_id` doubles as the
+                // dispatch `call_id` (it is the result-correlation token).
+                "content": mcp_content(Value::String(String::new())),
+                "isError": false,
+                "approval_required": required.to_reply_flag(&req.name, &req.req_id),
+            })
+        }
+        execute::DispatchOutcome::GrantRequired(grant) => {
+            // The kernel access gate refused the call and DROPPED it (grant-on-use
+            // mirrors INGRESS: gate → consent → re-send). What happens next is
+            // driven by the DURABLE recorded decision for this capsule
+            // ([`crate::grant_decision`]), so a consent the user already gave
+            // converges WITHOUT re-prompting even when the awaiter that raised
+            // THIS signal has expired fail-closed.
+            let outcome;
+            let reply = match grant_decision::grant_action(grant_decision::recorded_grant_decision(
+                &grant.capsule_id,
+            )) {
+                grant_decision::GrantAction::AutoApprove => {
+                    // Answer the fresh, live awaiter for THIS signal (raised ms
+                    // ago) without eliciting — the grant persists and the re-sent
+                    // call converges. An unroutable request_id can't be published,
+                    // so return an error, not a retry-hint that would spin.
+                    if approval::publish_grant_auto_decision(&grant.request_id, true) {
+                        let _ = ipc::publish_json(
+                            &crate::profile::audit_topic("grant_auto_approved"),
+                            &json!({ "capsule": grant.capsule_id }),
+                        );
+                        outcome = "grant_auto_approved";
+                        grant_decision::grant_auto_approve_reply(&req.req_id, &grant.capsule_id)
+                    } else {
+                        outcome = "grant_auto_approve_unroutable";
+                        grant_decision::grant_unroutable_reply(&req.req_id, &grant.capsule_id)
+                    }
+                }
+                grant_decision::GrantAction::AutoDeny => {
+                    // The user denied this capsule: retire the awaiter with a deny
+                    // (clean, vs. a 60 s fail-closed timeout), suppress
+                    // re-prompting, and return the operator escape hatch. Unlike
+                    // AutoApprove, an unroutable request_id changes only the
+                    // TELEMETRY, not the reply: no deny was published, but the
+                    // unretired awaiter fail-closes to denied on its own, so the
+                    // user-facing deny stands either way and there is no
+                    // retry-loop hazard. The audit event is emitted only for a
+                    // deny actually published — an unpublished one must not be
+                    // reported as published.
+                    if approval::publish_grant_auto_decision(&grant.request_id, false) {
+                        let _ = ipc::publish_json(
+                            &crate::profile::audit_topic("grant_auto_denied"),
+                            &json!({ "capsule": grant.capsule_id }),
+                        );
+                        outcome = "grant_auto_denied";
+                    } else {
+                        outcome = "grant_auto_deny_unroutable";
+                    }
+                    grant_decision::grant_auto_deny_reply(
+                        &req.req_id,
+                        &grant.capsule_id,
+                        &principal,
+                    )
+                }
+                grant_decision::GrantAction::Prompt => {
+                    // No durable decision yet. Dedup: if a grant prompt is already
+                    // pending for this `(principal, capsule)` pair, reply a benign,
+                    // actionable terminal result instead of a fresh elicit, so a
+                    // flurry of ungranted calls for the same capsule does not stack
+                    // duplicate prompts. The marker is non-consumingly peeked here
+                    // (it must survive to keep deduping) and consumed only on the
+                    // respond ([`crate::approval::handle_mcp_grant_respond`]).
+                    if execute::grant_pending(&principal, &grant.capsule_id) {
+                        outcome = "grant_pending_dedup";
+                        grant_decision::grant_dedup_reply(&req.req_id)
+                    } else {
+                        // First prompt for this pair — record it pending, then
+                        // surface the flag. `mark` is best-effort: a lost marker
+                        // only risks a duplicate prompt, never a spurious grant.
+                        execute::mark_grant_pending(&principal, &grant.capsule_id);
+                        outcome = "grant_required";
+                        json!({
+                            "kind": "tool.call",
+                            "req_id": req.req_id,
+                            // No tool result — the kernel dropped the call at the
+                            // access gate. The shim MUST elicit Grant/Deny and
+                            // respond on `astrid.v1.request.mcp.grant.respond`, then
+                            // re-send on Grant. `content` empty, `isError` false: a
+                            // prompt-needed state, not a failure.
+                            "content": mcp_content(Value::String(String::new())),
+                            "isError": false,
+                            "grant_required": grant.to_reply_flag(&req.name, &req.req_id),
+                        })
+                    }
+                }
+            };
+            log::info(format!(
+                "{}: broker response method=tool.call req_id={} tool={} outcome={outcome} \
+                 capsule={} elapsed_ms={}",
+                crate::profile::log_tag(),
+                req.req_id,
+                req.name,
+                grant.capsule_id,
+                discovery::wall_ms().saturating_sub(started)
+            ));
+            reply
+        }
+        execute::DispatchOutcome::Failed(message) => {
+            // A received request that could NOT be dispatched / drained (no
+            // provider, not-subscribed, dispatch error, or response timeout)
+            // → WARN, never silent. `dispatch_with_approval` collapses every
+            // such mode into a single human-readable `message`; it carries no
+            // tool arguments, only the tool name + failure reason, so it is
+            // safe to surface verbatim.
+            log::warn(format!(
+                "{}: broker no-route req_id={} tool={} reason=\"{message}\" elapsed_ms={}",
+                crate::profile::log_tag(),
+                req.req_id,
+                req.name,
+                discovery::wall_ms().saturating_sub(started)
+            ));
+            json!({
+                "kind": "tool.call",
+                "req_id": req.req_id,
+                "content": mcp_content(Value::String(message)),
+                "isError": true,
+            })
+        }
+    };
+    publish_reply(&reply_topic, &reply);
+    Ok(())
+}
+
+/// Evaluate the per-principal [`crate::policy`] rule set against the native
+/// tool a PreToolUse hook is asking about, and build the broker `tool.call`
+/// reply whose `content` text is the Claude hook-decision JSON.
+///
+/// The host calls (policy load, audit publish, log) live here; the pure
+/// reply shaping is delegated to [`gate_reply_body`] so the allow/deny ->
+/// JSON contract stays unit-testable without a live bus.
+fn pretooluse_gate_reply(req: &CallRequest) -> Value {
+    let tool_name = req
+        .arguments
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let tool_input = gate_tool_input(&req.arguments);
+
+    let decision = crate::policy::evaluate(&crate::policy::load_rules(), tool_name, &tool_input);
+
+    if let crate::policy::Decision::Deny { reason } = &decision {
+        log::info(format!(
+            "{}: PreToolUse policy denied native tool '{tool_name}' (req_id '{}'): {reason}",
+            crate::profile::log_tag(),
+            req.req_id
+        ));
+        // Audit the native-tool denial on the same `astrid.v1.audit.policy_*`
+        // family the in-process broker gate uses. Operator rule id only —
+        // never the reflected tool arguments (injection). Best-effort.
+        let _ = ipc::publish_json(
+            &crate::profile::audit_topic("pretooluse_deny"),
+            &json!({ "tool": tool_name, "rule": reason }),
+        );
+    }
+
+    gate_reply_body(&req.req_id, &decision)
+}
+
+/// Pure shaper: map a PDP [`Decision`](crate::policy::Decision) to the broker
+/// `tool.call` reply the shim relays verbatim to Claude's PreToolUse hook.
+/// No host calls — fully unit-testable.
+///
+/// Two invariants this encodes:
+///
+/// * `isError` is ALWAYS `false`. Claude treats an `isError:true` MCP result
+///   as a non-blocking error and runs the tool anyway (fail-open), so a DENY
+///   must travel in the `content` payload, not the error flag.
+/// * It can only NARROW. `Decision::Deny` -> `permissionDecision:"deny"`;
+///   `Decision::Allow` (which is also the no-rule / load-failure default)
+///   -> a no-op `{"continue":true}` that defers to Claude's existing
+///   permission flow (the allow-list + `dontAsk`), NEVER an explicit
+///   `"allow"` that could skip a prompt or broaden the surface.
+fn gate_reply_body(req_id: &str, decision: &crate::policy::Decision) -> Value {
+    let hook_output = match decision {
+        crate::policy::Decision::Deny { reason } => json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason":
+                    format!("denied by Astrid policy (rule: {reason})"),
+            }
+        }),
+        crate::policy::Decision::Allow => json!({ "continue": true }),
+    };
+
+    // The hook parses the gate tool's TEXT content like command-hook stdout,
+    // so serialize the decision object to a JSON string and wrap it in the
+    // standard MCP content block. `isError:false` — see the invariants above.
+    json!({
+        "kind": "tool.call",
+        "req_id": req_id,
+        "content": mcp_content(Value::String(
+            serde_json::to_string(&hook_output)
+                .unwrap_or_else(|_| String::from("{\"continue\":true}")),
+        )),
+        "isError": false,
+    })
+}
+
+/// Extract the native tool's input object from the gate-call arguments.
+///
+/// The hook authors `"tool_input": "${tool_input}"`. Claude's `${...}`
+/// interpolator resolves the `tool_input` node of the hook payload and — as
+/// VERIFIED against the shipped `claude` executor, whose interpolator
+/// `JSON.stringify`s any resolved object before splicing it into the string —
+/// replaces the token with `JSON.stringify(tool_input)`. So `tool_input`
+/// reaches the broker as a JSON STRING, which we parse back into the object
+/// the PDP matches against (full argument-level rules). A native tool always
+/// carries a non-empty `tool_input`; an absent path would interpolate to `""`
+/// (the executor's missing-path rule), which parses to `Null`.
+///
+/// The non-string arms are defensive belt-and-suspenders for a future build
+/// that injects structurally, or another MCP client; an unparseable value
+/// degrades to `Null` -> tool-NAME-only matching, a safe narrowing (never a
+/// broadening, since the PDP default is allow):
+///
+/// * a JSON STRING -> parsed (the verified, real-world path);
+/// * a nested JSON object/array -> used directly;
+/// * absent / non-JSON -> `Null` (tool-name-only matching).
+///
+/// `pub(crate)` so the `before_tool_call` hook responder ([`crate::hook_gate`])
+/// reuses the exact same defensive extraction — one definition, no drift
+/// between the two native-tool gate transports.
+pub(crate) fn gate_tool_input(arguments: &Value) -> Value {
+    match arguments.get("tool_input") {
+        Some(v @ (Value::Object(_) | Value::Array(_))) => v.clone(),
+        Some(Value::String(s)) => serde_json::from_str(s).unwrap_or(Value::Null),
+        _ => Value::Null,
+    }
+}
+
+/// Read the kernel-stamped caller attribution for ingress logging on a
+/// read-only path (`tools.list`) that does not otherwise need it. Returns
+/// `(source_id, principal)` rendered for a log line — never fails the
+/// request: a missing caller context degrades to `unknown` placeholders so
+/// observability never changes control flow. The mutating `tool.call` path
+/// keeps its own caller fetch (it fails closed on error) and does not use
+/// this.
+fn caller_fields() -> (String, String) {
+    match runtime::caller() {
+        Ok(ctx) => {
+            let principal = ctx.principal.unwrap_or_default();
+            let principal = if principal.is_empty() {
+                "unknown".to_string()
+            } else {
+                principal
+            };
+            (ctx.source_id, principal)
+        }
+        Err(_) => ("unknown".to_string(), "unknown".to_string()),
+    }
+}
+
+/// Render a principal id for a log line, mapping the empty/absent case (the
+/// SDK exposes `principal` as `Option<String>`) to a stable `unknown` tag so
+/// the `principal=` field is never blank/ambiguous when grepping.
+fn display_principal(principal: &str) -> &str {
+    if principal.is_empty() {
+        "unknown"
+    } else {
+        principal
+    }
+}
+
+/// Number of top-level tool arguments, for a non-sensitive shape signal in
+/// the ingress log. We log the COUNT, never the argument CONTENTS (a value
+/// may carry a secret). A JSON object counts its keys; any other shape
+/// (array / scalar / null) is reported as `0` — the broker's tools all take
+/// an object argument, so a non-object is the no-arguments case.
+fn arg_count(arguments: &Value) -> usize {
+    arguments.as_object().map_or(0, serde_json::Map::len)
+}
+
+/// Build the single-segment egress topic for `req_id`, or `None` if the
+/// id cannot form a clean single segment.
+///
+/// Rejects empty, oversized, and any id carrying a `.` (which would
+/// turn the 4-segment response topic into a 5-segment one the proxy's
+/// `astrid.v1.response.*` subscription can't match) or whitespace /
+/// control / wildcard bytes (which would forge or shadow topics). Same
+/// charset family the tool-name gate uses, so the surface is uniform.
+///
+/// `pub(crate)` so the approval bridge ([`crate::approval`]) reuses the
+/// exact same egress-topic gate when acking the shim — one definition,
+/// no drift.
+pub(crate) fn reply_topic(req_id: &str) -> Option<String> {
+    if req_id.is_empty() || req_id.len() > MAX_REQ_ID_LEN {
+        return None;
+    }
+    let clean = req_id
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-'));
+    if !clean {
+        return None;
+    }
+    Some(format!("{RESPONSE_PREFIX}{req_id}"))
+}
+
+/// Wrap a tool result into the MCP `content` block array the host already
+/// emits elsewhere: `[{ "type":"text", "text":<string> }]`. Structured
+/// (non-string) results are serialized to JSON text so the wire stays
+/// UTF-8 string-shaped and the proxy needs no schema knowledge.
+///
+/// `pub(crate)` so the approval bridge ([`crate::approval`]) shapes the
+/// resumed/denied terminal `tool.call` reply with the exact same content
+/// encoding the non-parked path uses — no drift between the two reply legs.
+pub(crate) fn mcp_content(content: Value) -> Value {
+    let text = match &content {
+        Value::String(s) => s.clone(),
+        _ => serde_json::to_string(&content)
+            .unwrap_or_else(|_| String::from("<unserializable tool result>")),
+    };
+    json!([{ "type": "text", "text": text }])
+}
+
+/// Human-readable, actionable guidance for an untrusted-ingress denial.
+///
+/// The confused-deputy gate in [`handle_mcp_call`] withholds a state-mutating
+/// tool call from an ingress `source_id` the user has not yet consented to, and
+/// asks the shim to raise a one-time interactive consent prompt. On a client
+/// that cannot render elicitation, that prompt never appears and the call would
+/// otherwise dead-end as a bare "not authorized" with no path forward. This
+/// text is carried on the `ingress_approval_required` reply so any surface that
+/// renders it tells the user WHICH session was withheld (`source_id`), WHY (the
+/// one-time consent gate), and HOW to proceed.
+///
+/// Trust is granted EXCLUSIVELY by accepting the interactive prompt — there is
+/// deliberately no operator allow-list, config key, env var, or CLI flag that
+/// grants it. Any such non-interactive path would reopen the confused-deputy
+/// hole this gate exists to close, so the guidance must never imply one.
+pub(crate) fn ingress_consent_guidance(source_id: &str) -> String {
+    format!(
+        "Astrid withheld this tool call: the ingress session (source_id: {source_id}) \
+         is not yet trusted. The first tool call from a new client session opens a \
+         one-time interactive consent prompt; approving it records trust for this \
+         source_id so later calls dispatch without re-prompting. Approve the prompt \
+         in your MCP client. If your client cannot display interactive prompts (no \
+         MCP elicitation support), the call fails closed by design — retry from a \
+         client that can, such as the Astrid CLI uplink. This interactive prompt is \
+         the only way to grant trust: there is no operator allow-list or config key \
+         to set."
+    )
+}
+
+/// Publish the broker reply, logging (not erroring) on host failure —
+/// the proxy times out on its side if delivery fails.
+fn publish_reply(topic: &str, reply: &Value) {
+    if let Err(e) = ipc::publish_json(topic, reply) {
+        log::warn(format!(
+            "{}: broker failed to publish {topic}: {e}",
+            crate::profile::log_tag()
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    fn install_test_profile() {
+        crate::profile::install_aos();
+    }
+
+    use super::*;
+
+    #[test]
+    fn reply_topic_accepts_uuid_simple() {
+        install_test_profile();
+        let id = "0191f3a2b4c74d8e9f01234567890abc";
+        assert_eq!(
+            reply_topic(id).as_deref(),
+            Some("astrid.v1.response.0191f3a2b4c74d8e9f01234567890abc")
+        );
+    }
+
+    #[test]
+    fn reply_topic_rejects_dotted_req_id() {
+        install_test_profile();
+        // A `.` would make the egress topic 5 segments — the proxy's
+        // 4-segment `astrid.v1.response.*` subscription would never
+        // match it, so the reply would be silently dropped.
+        assert!(reply_topic("a.b").is_none());
+    }
+
+    #[test]
+    fn reply_topic_rejects_topic_smuggling() {
+        install_test_profile();
+        assert!(reply_topic("").is_none());
+        assert!(reply_topic("a b").is_none());
+        assert!(reply_topic("a*b").is_none());
+        assert!(reply_topic("a\nb").is_none());
+        assert!(reply_topic("a/b").is_none());
+        let too_long = "a".repeat(MAX_REQ_ID_LEN + 1);
+        assert!(reply_topic(&too_long).is_none());
+    }
+
+    #[test]
+    fn reply_topic_accepts_hyphenated_uuid() {
+        install_test_profile();
+        let id = "0191f3a2-b4c7-4d8e-9f01-234567890abc";
+        assert!(reply_topic(id).is_some());
+    }
+
+    #[test]
+    fn arg_count_counts_object_keys_only() {
+        install_test_profile();
+        // The ingress log reports the COUNT of top-level arguments (a
+        // non-sensitive shape signal), never the values. An object counts its
+        // keys; any non-object shape is the no-arguments case (0).
+        assert_eq!(arg_count(&json!({ "a": 1, "b": 2 })), 2);
+        assert_eq!(arg_count(&json!({})), 0);
+        assert_eq!(arg_count(&Value::Null), 0);
+        assert_eq!(arg_count(&json!([1, 2, 3])), 0);
+        assert_eq!(arg_count(&json!("scalar")), 0);
+    }
+
+    #[test]
+    fn display_principal_maps_empty_to_unknown() {
+        install_test_profile();
+        assert_eq!(display_principal(""), "unknown");
+        assert_eq!(display_principal("user-7"), "user-7");
+    }
+
+    #[test]
+    fn mcp_content_wraps_string_verbatim() {
+        install_test_profile();
+        let blocks = mcp_content(Value::String("hello".into()));
+        assert_eq!(blocks, json!([{ "type": "text", "text": "hello" }]));
+    }
+
+    #[test]
+    fn mcp_content_serializes_structured_result() {
+        install_test_profile();
+        let blocks = mcp_content(json!({ "ok": true }));
+        assert_eq!(blocks, json!([{ "type": "text", "text": "{\"ok\":true}" }]));
+    }
+
+    #[test]
+    fn list_request_requires_req_id() {
+        install_test_profile();
+        assert!(serde_json::from_value::<ListRequest>(json!({})).is_err());
+        let ok: ListRequest = serde_json::from_value(json!({ "req_id": "x" })).unwrap();
+        assert_eq!(ok.req_id, "x");
+    }
+
+    #[test]
+    fn call_request_defaults_arguments() {
+        install_test_profile();
+        let req: CallRequest =
+            serde_json::from_value(json!({ "req_id": "x", "name": "fs.read" })).unwrap();
+        assert_eq!(req.req_id, "x");
+        assert_eq!(req.name, "fs.read");
+        assert_eq!(req.arguments, Value::Null);
+    }
+
+    #[test]
+    fn ingress_denial_guidance_is_actionable() {
+        install_test_profile();
+        // Regression: an untrusted-ingress denial must NOT dead-end. The
+        // guidance the `ingress_approval_required` reply carries has to name
+        // the withheld session's source_id and tell the user how to proceed,
+        // so a client that cannot render the elicitation still shows a path
+        // forward instead of a bare "not authorized".
+        let source_id = "cap-0191f3a2b4c74d8e9f01234567890abc";
+        let guidance = ingress_consent_guidance(source_id);
+
+        // Names the exact session that was withheld.
+        assert!(
+            guidance.contains(source_id),
+            "guidance must echo the source_id: {guidance}"
+        );
+        // Explains the one-time interactive consent gate.
+        assert!(
+            guidance.contains("consent") && guidance.contains("one-time"),
+            "guidance must explain the one-time consent gate: {guidance}"
+        );
+        // Tells the user to approve the interactive prompt.
+        assert!(
+            guidance.to_lowercase().contains("approve"),
+            "guidance must instruct the user to approve the prompt: {guidance}"
+        );
+        // Truthful about the fail-closed model: no operator allow-list / config
+        // key grants trust (only the interactive prompt does). Guards against a
+        // regression that reintroduces the confused-deputy escape hatch in text.
+        assert!(
+            guidance.contains("no operator allow-list"),
+            "guidance must state there is no non-interactive grant path: {guidance}"
+        );
+
+        // And the reply the gate publishes actually carries it, on both the
+        // human-readable `message` field and the MCP `content` block, while
+        // keeping the `ingress_approval_required` signal and NOT flipping to an
+        // error (which would suppress an elicit-capable shim's prompt).
+        let reply = json!({
+            "kind": "tool.call",
+            "req_id": "req1",
+            "ingress_approval_required": true,
+            "source_id": source_id,
+            "tool_name": "fs.write",
+            "message": guidance,
+            "content": mcp_content(Value::String(guidance.clone())),
+            "isError": false,
+        });
+        assert_eq!(
+            reply
+                .pointer("/ingress_approval_required")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            reply.pointer("/isError").and_then(Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            reply.pointer("/message").and_then(Value::as_str),
+            Some(guidance.as_str())
+        );
+        assert_eq!(
+            reply.pointer("/content/0/text").and_then(Value::as_str),
+            Some(guidance.as_str())
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // PreToolUse native-tool gate.
+    // ------------------------------------------------------------------
+
+    /// Parse the hook-decision JSON back out of a gate reply's single text
+    /// content block, so a test can assert on the decision the hook sees.
+    fn gate_decision_json(reply: &Value) -> Value {
+        let text = reply
+            .pointer("/content/0/text")
+            .and_then(Value::as_str)
+            .expect("gate reply must carry one text content block");
+        serde_json::from_str(text).expect("gate decision content must be JSON")
+    }
+
+    #[test]
+    fn gate_deny_blocks_via_content_never_iserror() {
+        install_test_profile();
+        let decision = crate::policy::Decision::Deny {
+            reason: "no-ssh-write".into(),
+        };
+        let reply = gate_reply_body("req1", &decision);
+
+        // The fail-open invariant: a DENY must NOT be signalled via
+        // `isError` (that would let the tool run); it rides in `content`.
+        assert_eq!(
+            reply.pointer("/isError").and_then(Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            reply.pointer("/req_id").and_then(Value::as_str),
+            Some("req1")
+        );
+
+        let decision_json = gate_decision_json(&reply);
+        assert_eq!(
+            decision_json.pointer("/hookSpecificOutput/hookEventName"),
+            Some(&Value::String("PreToolUse".into()))
+        );
+        assert_eq!(
+            decision_json.pointer("/hookSpecificOutput/permissionDecision"),
+            Some(&Value::String("deny".into()))
+        );
+        // The reason is the operator rule id, not a reflected argument.
+        let reason = decision_json
+            .pointer("/hookSpecificOutput/permissionDecisionReason")
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(reason.contains("no-ssh-write"), "reason was {reason:?}");
+    }
+
+    #[test]
+    fn gate_allow_defers_never_broadens() {
+        install_test_profile();
+        let reply = gate_reply_body("req2", &crate::policy::Decision::Allow);
+        assert_eq!(
+            reply.pointer("/isError").and_then(Value::as_bool),
+            Some(false)
+        );
+
+        // Allow must be a no-op continue, NOT an explicit permissionDecision
+        // — an explicit "allow" would suppress a prompt / broaden the surface,
+        // and the gate only ever narrows.
+        let decision_json = gate_decision_json(&reply);
+        assert_eq!(decision_json, json!({ "continue": true }));
+        assert!(
+            decision_json.pointer("/hookSpecificOutput").is_none(),
+            "allow path must not assert a permissionDecision"
+        );
+    }
+
+    #[test]
+    fn gate_tool_input_accepts_nested_object() {
+        install_test_profile();
+        let args = json!({ "tool_name": "Bash", "tool_input": { "command": "rm -rf /" } });
+        assert_eq!(gate_tool_input(&args), json!({ "command": "rm -rf /" }));
+    }
+
+    #[test]
+    fn gate_tool_input_parses_json_string() {
+        install_test_profile();
+        // If `${tool_input}` substitution stringifies the object, parse it
+        // back so argument-level rules still work.
+        let args =
+            json!({ "tool_name": "Write", "tool_input": "{\"file_path\":\"home://.ssh/x\"}" });
+        assert_eq!(
+            gate_tool_input(&args),
+            json!({ "file_path": "home://.ssh/x" })
+        );
+    }
+
+    #[test]
+    fn gate_tool_input_degrades_to_null_on_unsubstituted_or_absent() {
+        install_test_profile();
+        // A literal un-substituted placeholder is not valid JSON -> Null
+        // (tool-name-only matching), never a parse panic.
+        let literal = json!({ "tool_name": "Bash", "tool_input": "${tool_input}" });
+        assert_eq!(gate_tool_input(&literal), Value::Null);
+        // Absent tool_input -> Null.
+        let absent = json!({ "tool_name": "Bash" });
+        assert_eq!(gate_tool_input(&absent), Value::Null);
+    }
+
+    #[test]
+    fn gate_tool_name_is_pinned() {
+        install_test_profile();
+        // Value anchor for the cross-crate SYNC with
+        // `claude_install::layout::PRETOOLUSE_GATE_TOOL`. No dependency edge
+        // between the crates, so the name is mirrored, not shared; the
+        // claude-install pins the same literal in
+        // `pretooluse_gate_tool_name_is_pinned`. A rename on one side without
+        // the other silently disables the gate (fail-open), so both anchor the
+        // exact string and a deliberate edit must touch both tests.
+        assert_eq!(PRETOOLUSE_GATE_TOOL, "aos_pretooluse_gate");
+    }
+
+    #[test]
+    fn gate_end_to_end_shapes_a_deny_from_a_string_input() {
+        install_test_profile();
+        // Exercise gate_tool_input -> evaluate -> gate_reply_body together
+        // (the pure spine of pretooluse_gate_reply, minus the host calls).
+        let rules = vec![crate::policy::Rule {
+            id: "no-rm-rf".into(),
+            effect: crate::policy::Effect::Deny,
+            tool: "Bash".into(),
+            when: vec![crate::policy::ArgMatcher {
+                pointer: "/command".into(),
+                op: crate::policy::MatchOp::Contains,
+                value: "rm -rf".into(),
+            }],
+        }];
+        let args = json!({ "tool_name": "Bash", "tool_input": { "command": "rm -rf /tmp" } });
+        let decision = crate::policy::evaluate(
+            &rules,
+            args.get("tool_name").and_then(Value::as_str).unwrap(),
+            &gate_tool_input(&args),
+        );
+        let reply = gate_reply_body("req3", &decision);
+        assert_eq!(
+            reply.pointer("/isError").and_then(Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            gate_decision_json(&reply).pointer("/hookSpecificOutput/permissionDecision"),
+            Some(&Value::String("deny".into()))
+        );
+    }
+}

--- a/crates/aos-mcp-broker/src/cache.rs
+++ b/crates/aos-mcp-broker/src/cache.rs
@@ -1,0 +1,299 @@
+//! KV-backed tool descriptor cache.
+//!
+//! The cache is keyed by tool name (last-write-wins on duplicates) and
+//! carries a monotonic-ish timestamp so [`super::discovery::describe_tools`]
+//! can short-circuit on a fresh cache hit. Updates use `kv::cas` so the
+//! event-driven `collect_tool_descriptors` handler and the on-demand
+//! `describe_tools` fan-out don't clobber each other on concurrent writes.
+
+use std::collections::BTreeMap;
+
+use astrid_sdk::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// KV key for the cached tool descriptor map.
+pub(crate) const CACHE_KEY: &str = "tools.cache";
+
+/// Cache freshness window for `describe_tools` short-circuit. Anything
+/// older than this triggers a fresh fan-out.
+pub(crate) const CACHE_TTL_MS: u64 = 60_000;
+
+/// CAS retry budget for cache updates. The cache is contended by the
+/// describe fan-out and the broadcast collector; a handful of retries
+/// covers contention without unbounded looping.
+const CAS_MAX_RETRIES: u32 = 8;
+
+/// Hard cap on cached descriptors. A hostile capsule broadcasting a
+/// flood of fake tools cannot bloat the persistent cache past this.
+/// On overflow the upsert path silently drops trailing entries from
+/// the merged set — discovery will re-publish what survived.
+pub(crate) const MAX_CACHED_TOOLS: usize = 512;
+
+/// MCP tool descriptor.
+///
+/// Field names match the MCP `tools/list` response shape so the agent
+/// runner can forward this verbatim. `capabilities` is host-specific
+/// metadata (the source capsule's capability discriminator) and is
+/// preserved through the cache for downstream capability checks.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) struct McpToolDescriptor {
+    pub(crate) name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) title: Option<String>,
+    #[serde(default)]
+    pub(crate) description: String,
+    #[serde(rename = "inputSchema", default)]
+    pub(crate) input_schema: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) capabilities: Option<serde_json::Value>,
+}
+
+/// On-disk cache envelope. `BTreeMap` for stable serialization order
+/// (CAS depends on byte-equality of the prior value).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct CacheState {
+    /// Wall-clock millis (host clock) when this snapshot was last updated.
+    pub(crate) updated_at_ms: u64,
+    /// Descriptors keyed by tool name. Last-write-wins on collision.
+    pub(crate) tools: BTreeMap<String, McpToolDescriptor>,
+}
+
+impl CacheState {
+    /// Are the contents fresh enough to short-circuit describe_tools?
+    ///
+    /// `now_ms == 0` means the host clock is unavailable. We refuse to
+    /// treat that as "fresh" — without a real wall clock the TTL is
+    /// undefined and a degraded host would otherwise pin the cache
+    /// forever. Likewise `updated_at_ms == 0` (cache was written under
+    /// a degraded clock) bypasses the short-circuit.
+    pub(crate) fn is_fresh(&self, now_ms: u64) -> bool {
+        if now_ms == 0 || self.updated_at_ms == 0 || self.tools.is_empty() {
+            return false;
+        }
+        now_ms.saturating_sub(self.updated_at_ms) < CACHE_TTL_MS
+    }
+
+    /// Descriptors as an ordered Vec.
+    pub(crate) fn as_vec(&self) -> Vec<McpToolDescriptor> {
+        self.tools.values().cloned().collect()
+    }
+}
+
+/// Read the current cache snapshot. Missing / corrupt KV entries yield
+/// a fresh default (the worst case is one extra discovery fan-out).
+pub(crate) fn load() -> CacheState {
+    match kv::get_bytes_opt(CACHE_KEY) {
+        Ok(Some(bytes)) => serde_json::from_slice(&bytes).unwrap_or_default(),
+        _ => CacheState::default(),
+    }
+}
+
+/// Merge `incoming` into the cache via CAS so concurrent writers
+/// (describe fan-out vs broadcast collector) don't clobber each other.
+/// Last-write-wins per tool name. Returns the merged snapshot.
+///
+/// Enforces [`MAX_CACHED_TOOLS`] on the merged set so a hostile
+/// broadcaster cannot grow the persistent cache unbounded — overflow
+/// entries are dropped from the tail of the sorted `BTreeMap` (the
+/// order is deterministic for byte-stable CAS).
+pub(crate) fn upsert(incoming: Vec<McpToolDescriptor>) -> CacheState {
+    if incoming.is_empty() {
+        return load();
+    }
+
+    for _ in 0..CAS_MAX_RETRIES {
+        let expected = kv::get_bytes_opt(CACHE_KEY).ok().flatten();
+        let mut state: CacheState = expected
+            .as_ref()
+            .and_then(|b| serde_json::from_slice(b).ok())
+            .unwrap_or_default();
+
+        for desc in &incoming {
+            // Upserting an existing name never grows the cache; only a
+            // genuinely new name does. Cap insertion when at the limit.
+            if state.tools.len() >= MAX_CACHED_TOOLS && !state.tools.contains_key(&desc.name) {
+                continue;
+            }
+            state.tools.insert(desc.name.clone(), desc.clone());
+        }
+        state.updated_at_ms = now_ms();
+
+        let Ok(new_bytes) = serde_json::to_vec(&state) else {
+            log::warn(format!(
+                "{}: failed to serialize tool cache",
+                crate::profile::log_tag()
+            ));
+            return state;
+        };
+
+        match kv::cas(CACHE_KEY, expected.as_deref(), &new_bytes) {
+            Ok(true) => return state,
+            Ok(false) => continue, // Lost race — reload and retry.
+            Err(e) => {
+                log::warn(format!(
+                    "{}: tool cache CAS failed: {e}",
+                    crate::profile::log_tag()
+                ));
+                return state;
+            }
+        }
+    }
+
+    log::warn(format!(
+        "{}: tool cache CAS exhausted retries",
+        crate::profile::log_tag()
+    ));
+    load()
+}
+
+/// Replace the cache wholesale (used after a full describe fan-out so
+/// stale entries from departed capsules don't linger forever). Still
+/// goes through CAS so an in-flight broadcast update isn't dropped on
+/// the floor; on the rare CAS miss we fall back to a per-tool merge.
+///
+/// Same [`MAX_CACHED_TOOLS`] cap as [`upsert`]: anything beyond is
+/// dropped before write. Discovery already deduplicates by name, so
+/// the only path to overflow is a single fan-out returning more
+/// descriptors than the cap.
+pub(crate) fn replace(snapshot: Vec<McpToolDescriptor>) -> CacheState {
+    let mut state = CacheState {
+        updated_at_ms: now_ms(),
+        tools: BTreeMap::new(),
+    };
+    for desc in snapshot.iter() {
+        if state.tools.len() >= MAX_CACHED_TOOLS {
+            break;
+        }
+        state.tools.insert(desc.name.clone(), desc.clone());
+    }
+
+    let expected = kv::get_bytes_opt(CACHE_KEY).ok().flatten();
+    let Ok(new_bytes) = serde_json::to_vec(&state) else {
+        log::warn(format!(
+            "{}: failed to serialize tool cache (replace)",
+            crate::profile::log_tag()
+        ));
+        return state;
+    };
+    match kv::cas(CACHE_KEY, expected.as_deref(), &new_bytes) {
+        Ok(true) => state,
+        Ok(false) => {
+            // Concurrent broadcast wrote between our read and CAS; merge
+            // our snapshot into whatever's there instead of clobbering.
+            upsert(snapshot)
+        }
+        Err(e) => {
+            log::warn(format!(
+                "{}: tool cache CAS (replace) failed: {e}",
+                crate::profile::log_tag()
+            ));
+            state
+        }
+    }
+}
+
+/// Force the next `tools/list` to re-discover by emptying the cached
+/// descriptor map.
+///
+/// Called when the loaded-capsule set changes — the kernel's
+/// `astrid.v1.capsules_loaded` signal (install / live upgrade / live remove).
+/// The event-driven merge path ([`upsert`], via `collect_tool_descriptors`)
+/// only ever ADDS descriptors, so a removed or upgraded capsule's stale tools
+/// would otherwise linger in the cache (callable, erroring) until the TTL
+/// expires. An empty cache is never [`CacheState::is_fresh`] (the cold-start
+/// guard), so the next [`super::discovery::collect_snapshot`] re-runs the
+/// describe fan-out — a departed capsule no longer responds and its tools drop
+/// out, while a freshly added one is picked up.
+///
+/// Best-effort: a failed write just leaves the prior cache to self-heal at the
+/// TTL. This empties only the `tools/list` DESCRIPTOR cache — `tools/call`
+/// routing never reads it — so an emptied cache cannot break a concurrent tool
+/// call. The write is intentionally non-CAS: by the time the kernel publishes
+/// `capsules_loaded` the registry change has already happened, so any fan-out
+/// that runs after this invalidation observes the new set.
+pub(crate) fn invalidate() {
+    let Ok(bytes) = serde_json::to_vec(&CacheState::default()) else {
+        log::warn(format!(
+            "{}: failed to serialize empty tool cache (invalidate)",
+            crate::profile::log_tag()
+        ));
+        return;
+    };
+    if let Err(e) = kv::set_bytes(CACHE_KEY, &bytes) {
+        log::warn(format!(
+            "{}: tool cache invalidate failed: {e}",
+            crate::profile::log_tag()
+        ));
+    }
+}
+
+/// Wall-clock millis. The host clock is monotonic enough at the
+/// 60-second TTL granularity we care about.
+fn now_ms() -> u64 {
+    time::now()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+}
+
+#[cfg(test)]
+mod tests {
+    fn install_test_profile() {
+        crate::profile::install_aos();
+    }
+
+    use super::*;
+
+    fn state(updated_at_ms: u64, n_tools: usize) -> CacheState {
+        let mut tools = BTreeMap::new();
+        for i in 0..n_tools {
+            let name = format!("tool{i}");
+            tools.insert(
+                name.clone(),
+                McpToolDescriptor {
+                    name,
+                    title: None,
+                    description: String::new(),
+                    input_schema: serde_json::Value::Null,
+                    capabilities: None,
+                },
+            );
+        }
+        CacheState {
+            updated_at_ms,
+            tools,
+        }
+    }
+
+    #[test]
+    fn fresh_within_ttl() {
+        install_test_profile();
+        assert!(state(1_000, 3).is_fresh(1_000 + CACHE_TTL_MS - 1));
+    }
+
+    #[test]
+    fn stale_past_ttl() {
+        install_test_profile();
+        assert!(!state(1_000, 3).is_fresh(1_000 + CACHE_TTL_MS + 1));
+    }
+
+    /// The `tools/list` reliability guard: an empty cache (cold, or left
+    /// empty by a transient empty fan-out) must NEVER short-circuit, so the
+    /// server always re-discovers rather than pinning an empty `tools/list`
+    /// for the TTL.
+    #[test]
+    fn empty_cache_is_never_fresh() {
+        install_test_profile();
+        assert!(!state(1_000, 0).is_fresh(1_000 + 1));
+    }
+
+    /// A degraded host clock (`now == 0`) or a snapshot written under one
+    /// (`updated_at == 0`) leaves the TTL undefined — never treat either as
+    /// fresh, or a degraded host pins the cache forever.
+    #[test]
+    fn degraded_clock_is_never_fresh() {
+        install_test_profile();
+        assert!(!state(1_000, 3).is_fresh(0));
+        assert!(!state(0, 3).is_fresh(1_000));
+    }
+}

--- a/crates/aos-mcp-broker/src/discovery.rs
+++ b/crates/aos-mcp-broker/src/discovery.rs
@@ -1,0 +1,648 @@
+//! Tool descriptor discovery and the `astrid.v1.tools.list` publish path.
+//!
+//! Two entry points feed the cache:
+//!
+//! * [`describe_tools`] — on-demand fan-out (subscribe-before-publish
+//!   ordering, mirrors the registry capsule). Replaces the cached
+//!   snapshot wholesale so descriptors from departed capsules don't
+//!   linger. Cache-hit short-circuits the fan-out when the snapshot is
+//!   fresher than [`super::cache::CACHE_TTL_MS`].
+//! * [`collect_tool_descriptors`] — event-driven; merges every
+//!   broadcast `tool.v1.response.describe.*` into the cache via CAS.
+//!
+//! Both publish `astrid.v1.tools.list` with MCP-shaped descriptors whose
+//! names are prefixed `mcp__aos__<original>` so the agent runner can
+//! pass them straight to Claude via `--allowed-tools mcp__aos__*`.
+
+use astrid_sdk::prelude::*;
+
+use crate::cache::{self, McpToolDescriptor};
+
+/// Fan-out topic — every tool-providing capsule subscribes to this and
+/// replies on its own `tool.v1.response.describe.<source_id>`.
+const DESCRIBE_REQUEST_TOPIC: &str = "tool.v1.request.describe";
+/// Wildcard pattern for the per-source response topics.
+const DESCRIBE_RESPONSE_PATTERN: &str = "tool.v1.response.describe.*";
+/// Topic on which the agent runner consumes the assembled MCP tool list.
+fn tools_list_topic() -> &'static str {
+    crate::profile::tools_list_topic()
+}
+
+/// MCP tool name prefix Astrid exposes to Claude. The `--allowed-tools
+/// mcp__aos__*` flag on the agent subprocess matches against this.
+fn mcp_tool_prefix() -> &'static str {
+    crate::profile::mcp_tool_prefix()
+}
+
+/// Total drain window for the describe fan-out. Sized to cover a COLD
+/// start: the first `tools/list` after a plain daemon boot races the
+/// fan-out against WASM instantiation + kernel broadcast latency, and the
+/// old 500 ms lost that race — which matters because an MCP client fetches
+/// `tools/list` once at connect, so an empty first answer sticks for the
+/// session. The loop below still returns as soon as responders go quiet
+/// AFTER replying, so this is headroom for a slow cold start, not a fixed
+/// wait on the warm path.
+const DISCOVERY_TIMEOUT_MS: u64 = 2_500;
+/// Slice size for the drain loop. A single `recv(timeout)` would only
+/// pick up the first batch; the loop keeps polling in shorter slices
+/// until the budget closes.
+const DISCOVERY_SLICE_MS: u64 = 100;
+
+/// Per-tool name length cap. MCP+claude accept long names but a
+/// hostile capsule could publish kilobyte names — reject anything
+/// past this before it reaches the cache.
+const MAX_TOOL_NAME_LEN: usize = 128;
+/// Per-tool description cap.
+const MAX_DESCRIPTION_LEN: usize = 4_096;
+/// Per-tool serialized `inputSchema` cap (JSON bytes). Bigger than a
+/// realistic tool schema needs but small enough to bound the cache
+/// regardless of provider behaviour.
+const MAX_INPUT_SCHEMA_BYTES: usize = 16_384;
+/// Per-tool serialized `capabilities` cap.
+const MAX_CAPABILITIES_BYTES: usize = 2_048;
+/// Hard cap on tools accepted from a single `describe` response /
+/// broadcast. Caches further cap the merged state via
+/// `cache::MAX_CACHED_TOOLS`.
+const MAX_TOOLS_PER_RESPONSE: usize = 256;
+
+/// Handle `astrid.v1.tools.describe`.
+///
+/// Cache-fresh path: republish the cached list and return. Cache-miss /
+/// stale path: subscribe-before-publish fan-out, dedupe by name
+/// (last-write-wins), replace the cache, publish the new list.
+pub(crate) fn describe_tools() {
+    // The agent-runner describe path has no proxy `req_id`; tag its fan-out
+    // logs with a stable synthetic id so they are still distinguishable from
+    // the broker `tools.list` path when grepping a shared log.
+    let snapshot = collect_snapshot("describe_tools");
+    publish_tools_list(&snapshot);
+}
+
+/// Assemble the current tool-descriptor snapshot, running the
+/// describe-collect fan-out only when the cache is stale.
+///
+/// Shared by the agent-facing `describe_tools` publish path and the
+/// broker-facing `astrid.v1.request.mcp.tools.list` handler so the two
+/// front doors run the exact same discovery + cache logic — no
+/// duplicated fan-out, dedupe, or TTL handling.
+///
+/// `req_id` tags the fan-out lifecycle logs (start / per-responder / complete
+/// / incomplete) so a single `tools.list` is greppable end to end. It is a
+/// log tag only — when the cache is fresh no fan-out runs and it goes unused.
+pub(crate) fn collect_snapshot(req_id: &str) -> Vec<McpToolDescriptor> {
+    let cached = cache::load();
+    let now = wall_ms();
+    if cached.is_fresh(now) {
+        return cached.as_vec();
+    }
+
+    let descriptors = discover(req_id);
+    match snapshot_outcome(&descriptors) {
+        // Keep the prior cache untouched and let the next call retry — see
+        // [`snapshot_outcome`].
+        SnapshotOutcome::Keep => cached.as_vec(),
+        SnapshotOutcome::Replace => cache::replace(descriptors).as_vec(),
+    }
+}
+
+/// Whether a fresh fan-out result should REPLACE the cache or be discarded in
+/// favour of the prior cache.
+#[derive(Debug, PartialEq, Eq)]
+enum SnapshotOutcome {
+    /// Discard the fan-out; serve the prior cache and write nothing. An EMPTY
+    /// fan-out is a cold-start race-loss (WASM instantiation + broadcast
+    /// latency beat the drain window), NOT a genuine "no tools" answer:
+    /// caching it would clobber a prior good snapshot and pin an empty
+    /// `tools/list` for the session (the MCP client fetches it once at
+    /// connect). `is_fresh` already refuses to short-circuit an empty cache,
+    /// so a cold cache simply re-discovers on the next call.
+    Keep,
+    /// Persist the fan-out and serve it.
+    Replace,
+}
+
+/// Pure reconciliation decision for [`collect_snapshot`] — the host calls
+/// (load / discover / replace) stay in the caller, so this is unit-testable.
+fn snapshot_outcome(discovered: &[McpToolDescriptor]) -> SnapshotOutcome {
+    if discovered.is_empty() {
+        SnapshotOutcome::Keep
+    } else {
+        SnapshotOutcome::Replace
+    }
+}
+
+/// Convert internal descriptors to the standard MCP `tools/list`
+/// descriptor shape (`name`, `description`, `inputSchema`, plus optional
+/// `title`/`capabilities`) for the broker reply body.
+///
+/// Unlike [`publish_tools_list`], names are emitted RAW — the broker is
+/// a generic MCP front door, not Claude's `mcp__aos__*` namespace, so
+/// it must not stamp the agent-runner prefix onto the descriptors a
+/// third-party MCP client consumes.
+pub(crate) fn to_mcp_descriptors(descriptors: &[McpToolDescriptor]) -> Vec<serde_json::Value> {
+    descriptors.iter().map(mcp_descriptor).collect()
+}
+
+/// Shape one internal descriptor into an MCP tool-descriptor object.
+/// `prefix` is prepended to the name (empty for the broker surface,
+/// `mcp__aos__` for the agent-runner surface).
+fn mcp_descriptor_with_prefix(d: &McpToolDescriptor, prefix: &str) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        "name".to_string(),
+        serde_json::Value::String(format!("{prefix}{}", d.name)),
+    );
+    if let Some(title) = &d.title {
+        obj.insert(
+            "title".to_string(),
+            serde_json::Value::String(title.clone()),
+        );
+    }
+    obj.insert(
+        "description".to_string(),
+        serde_json::Value::String(d.description.clone()),
+    );
+    obj.insert("inputSchema".to_string(), d.input_schema.clone());
+    if let Some(caps) = &d.capabilities {
+        obj.insert("capabilities".to_string(), caps.clone());
+    }
+    serde_json::Value::Object(obj)
+}
+
+/// Broker-surface MCP descriptor: raw (unprefixed) name.
+fn mcp_descriptor(d: &McpToolDescriptor) -> serde_json::Value {
+    mcp_descriptor_with_prefix(d, "")
+}
+
+/// Handle an inbound `tool.v1.response.describe.*` broadcast.
+///
+/// The kernel routes every matching message to this action. We
+/// extract descriptors, merge them into the cache via CAS, and
+/// re-publish the assembled list so downstream consumers see fresh
+/// additions immediately.
+pub(crate) fn collect_tool_descriptors(payload: serde_json::Value) {
+    let descriptors = parse_describe_response(&payload);
+    if descriptors.is_empty() {
+        return;
+    }
+
+    let merged = cache::upsert(descriptors).as_vec();
+    publish_tools_list(&merged);
+}
+
+/// Handle the kernel's `astrid.v1.capsules_loaded` signal.
+///
+/// The kernel includes each loaded capsule's installed `meta.json` (opaque) in
+/// the payload under `capsules[].meta`. When EVERY loaded capsule has a
+/// **captured** tool surface (`meta.tools` present — whether `[..]` or `[]`),
+/// the broker rebuilds its cache purely from that static set: deterministic, no
+/// describe fan-out, so the first `tools/list` after boot is already complete
+/// (this is where the cold-start fan-out race dies). If ANY capsule's surface
+/// is uncaptured (built before tool-baking, or its `meta` could not be read),
+/// the static set would be incomplete, so we fall back to invalidating the
+/// cache and let the next `tools/list` re-discover via the fan-out. As the
+/// fleet rebuilds with baked tools it tips into the deterministic path
+/// automatically, with no missing-tool window in between.
+pub(crate) fn on_capsules_loaded(payload: serde_json::Value) {
+    match static_tools_from_payload(&payload) {
+        Some(descriptors) => {
+            // Authoritative, complete surface — replace the cache and publish
+            // so the agent-runner view refreshes too (the broker shim
+            // separately re-fetches `tools/list` on this same signal).
+            let count = descriptors.len();
+            let snapshot = cache::replace(descriptors).as_vec();
+            log::info(format!(
+                "{}: tool cache rebuilt from static capsule metadata ({count} tools); describe fan-out skipped",
+                crate::profile::log_tag()
+            ));
+            publish_tools_list(&snapshot);
+        }
+        None => {
+            // At least one uncaptured surface — discover at runtime.
+            log::info(format!(
+                "{}: capsule-set change includes an uncaptured tool surface; cache invalidated for fan-out rediscovery",
+                crate::profile::log_tag()
+            ));
+            cache::invalidate();
+        }
+    }
+}
+
+/// Assemble the union of every loaded capsule's build-captured tool descriptors
+/// from a `capsules_loaded` payload — but only if EVERY capsule's surface is
+/// captured.
+///
+/// Returns `None` (caller falls back to the fan-out) when the payload predates
+/// the enriched-metadata kernel (no `capsules` array), or when any capsule's
+/// `meta` is missing / `null` (the kernel could not read it) or carries no
+/// `tools` array (a capsule built before tool-baking). A capsule with
+/// `tools: []` is authoritatively tool-less — it contributes nothing without
+/// disqualifying the static path.
+fn static_tools_from_payload(payload: &serde_json::Value) -> Option<Vec<McpToolDescriptor>> {
+    let capsules = payload.get("capsules")?.as_array()?;
+    let mut all = Vec::new();
+    for capsule in capsules {
+        // `meta` absent / null => the kernel could not read this capsule's
+        // `meta.json` => unknown surface => disqualify the static path.
+        let meta = capsule.get("meta").filter(|m| !m.is_null())?;
+        // `tools` absent / non-array => not captured => unknown.
+        let tools = meta.get("tools")?.as_array()?;
+        for tool in tools {
+            let Some(name) = tool.get("name").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            all.push(McpToolDescriptor {
+                name: name.to_string(),
+                title: None,
+                description: tool
+                    .get("description")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                input_schema: tool
+                    .get("input_schema")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                capabilities: None,
+            });
+        }
+    }
+    Some(all)
+}
+
+/// Subscribe-before-publish fan-out. Mirrors the registry capsule
+/// pattern: open the subscription, fire the empty `{}` request, drain
+/// up to `DISCOVERY_TIMEOUT_MS` in `DISCOVERY_SLICE_MS` slices.
+///
+/// `req_id` is the correlation token for the originating describe request
+/// (the broker's `req_id` for a `tools.list`, or a synthesized id for the
+/// agent-runner `describe_tools` path) so the whole fan-out lifecycle —
+/// start, each responder collected, completion, and any timeout/drop — is
+/// greppable end to end. It is a LOG TAG only and never reaches the wire.
+fn discover(req_id: &str) -> Vec<McpToolDescriptor> {
+    let started = wall_ms();
+    let sub = match ipc::subscribe(DESCRIBE_RESPONSE_PATTERN) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn(format!(
+                "{}: broker fan-out subscribe failed req_id={req_id} \
+                 topic={DESCRIBE_RESPONSE_PATTERN}: {e}",
+                crate::profile::log_tag()
+            ));
+            return Vec::new();
+        }
+    };
+
+    log::info(format!(
+        "{}: broker fan-out start req_id={req_id} deadline_ms={DISCOVERY_TIMEOUT_MS}",
+        crate::profile::log_tag()
+    ));
+
+    if let Err(e) = ipc::publish(DESCRIBE_REQUEST_TOPIC, "{}") {
+        log::warn(format!(
+            "{}: broker fan-out publish failed req_id={req_id} \
+             topic={DESCRIBE_REQUEST_TOPIC}: {e}",
+            crate::profile::log_tag()
+        ));
+        return Vec::new();
+    }
+
+    let mut acc: Vec<McpToolDescriptor> = Vec::new();
+    let mut seen_any = false;
+    // Count of distinct responder source_ids whose describe broadcast we
+    // collected, plus the cumulative dropped/lagged signal the bus reports —
+    // these feed the completion / incomplete WARN below so a first-call
+    // fan-out drop is visible rather than silent.
+    let mut responders: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut dropped: u64 = 0;
+    let mut lagged: u64 = 0;
+    let mut remaining = DISCOVERY_TIMEOUT_MS;
+    loop {
+        let step = remaining.min(DISCOVERY_SLICE_MS);
+        match sub.recv(step) {
+            Ok(result) if !result.messages.is_empty() => {
+                seen_any = true;
+                dropped = dropped.saturating_add(result.dropped);
+                lagged = lagged.saturating_add(result.lagged);
+                for msg in &result.messages {
+                    let Ok(value) = serde_json::from_str::<serde_json::Value>(&msg.payload) else {
+                        continue;
+                    };
+                    let tools = parse_describe_response(&value);
+                    responders.insert(msg.source_id.clone());
+                    log::debug(format!(
+                        "{}: broker fan-out collected req_id={req_id} \
+                         responder={} tool_count={}",
+                        crate::profile::log_tag(),
+                        msg.source_id,
+                        tools.len()
+                    ));
+                    acc.extend(tools);
+                }
+            }
+            // A quiet slice — the host returned early-empty, OR `recv` timed
+            // out on this slice. Two cases: if responders have ALREADY replied,
+            // this is quiescence → stop. If NOT, we're still racing a cold
+            // start (WASM instantiation + broadcast latency), so keep polling
+            // until the budget closes rather than breaking at the first 100 ms
+            // gap — otherwise widening `DISCOVERY_TIMEOUT_MS` buys nothing,
+            // because the loop would bail before the first response arrives.
+            Ok(result) => {
+                // Quiet but non-error slice may still carry drop/lag counters.
+                dropped = dropped.saturating_add(result.dropped);
+                lagged = lagged.saturating_add(result.lagged);
+                if seen_any {
+                    break;
+                }
+            }
+            Err(_) => {
+                if seen_any {
+                    break;
+                }
+            }
+        }
+        remaining = remaining.saturating_sub(step);
+        if remaining == 0 {
+            break;
+        }
+    }
+
+    // Dedupe by name, last-write-wins. We iterate in reverse so the
+    // final retain preserves the last occurrence.
+    acc.reverse();
+    let mut seen = std::collections::HashSet::new();
+    acc.retain(|d| seen.insert(d.name.clone()));
+    acc.reverse();
+
+    let elapsed = wall_ms().saturating_sub(started);
+    let timed_out = remaining == 0;
+    // Incomplete iff the bus dropped/lagged messages (a responder's reply was
+    // missed), OR we exhausted the whole budget without quiescence (a slow /
+    // never-replying responder — the known first-call fan-out drop). Either
+    // way the answer below may be missing tools, so surface it at WARN rather
+    // than letting an under-count look like a clean result.
+    if dropped > 0 || lagged > 0 || (timed_out && !seen_any) {
+        log::warn(format!(
+            "{}: broker fan-out incomplete req_id={req_id} responders={} tools={} \
+             dropped={dropped} lagged={lagged} timed_out={timed_out} elapsed_ms={elapsed}",
+            crate::profile::log_tag(),
+            responders.len(),
+            acc.len()
+        ));
+    } else {
+        log::info(format!(
+            "{}: broker fan-out complete req_id={req_id} responders={} tools={} \
+             elapsed_ms={elapsed}",
+            crate::profile::log_tag(),
+            responders.len(),
+            acc.len()
+        ));
+    }
+
+    acc
+}
+
+/// Extract descriptors from a `tool.v1.response.describe.*` payload.
+///
+/// Honours both the direct envelope (`{ "tools": [...] }`, emitted by
+/// the SDK `tool_describe` macro arm) and the wrapped Custom envelope
+/// (`{ "data": { "tools": [...] } }`). Each entry is deserialized
+/// independently — malformed entries are skipped without aborting the
+/// whole response. Untrusted-input gates:
+///
+/// * names that are empty or don't match the `^[A-Za-z0-9_.-]+$`
+///   charset are dropped (prevents path-style names, unicode bidi
+///   overrides, control chars from reaching the wire);
+/// * descriptors with oversized name / description / schema /
+///   capabilities are dropped — a hostile broadcaster cannot DoS the
+///   cache by inflating individual entries;
+/// * the per-response array is hard-capped at
+///   [`MAX_TOOLS_PER_RESPONSE`].
+fn parse_describe_response(value: &serde_json::Value) -> Vec<McpToolDescriptor> {
+    let tools = value
+        .get("tools")
+        .or_else(|| value.get("data").and_then(|d| d.get("tools")))
+        .and_then(|t| t.as_array());
+
+    let Some(tools) = tools else {
+        return Vec::new();
+    };
+
+    let take = tools.len().min(MAX_TOOLS_PER_RESPONSE);
+    let mut out = Vec::with_capacity(take);
+    for raw in tools.iter().take(take) {
+        let Ok(desc) = serde_json::from_value::<McpToolDescriptor>(remap_input_schema(raw.clone()))
+        else {
+            continue;
+        };
+        if !is_valid_descriptor(&desc) {
+            continue;
+        }
+        out.push(desc);
+    }
+    out
+}
+
+/// Allowed tool-name charset. Matches `^[A-Za-z0-9_.-]+$` — same shape
+/// MCP uses for tool identifiers. Anything else (path separators,
+/// whitespace, unicode bidi, control chars) is rejected.
+fn is_valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_TOOL_NAME_LEN
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b'-'))
+}
+
+/// Full descriptor validation: charset on the name, byte-size caps on
+/// description / schema / capabilities. Discard anything that violates;
+/// the broadcaster has no claim on cache state.
+fn is_valid_descriptor(desc: &McpToolDescriptor) -> bool {
+    if !is_valid_name(&desc.name) {
+        return false;
+    }
+    if desc.description.len() > MAX_DESCRIPTION_LEN {
+        return false;
+    }
+    if let Some(t) = &desc.title
+        && t.len() > MAX_DESCRIPTION_LEN
+    {
+        return false;
+    }
+    if json_byte_len(&desc.input_schema) > MAX_INPUT_SCHEMA_BYTES {
+        return false;
+    }
+    if let Some(caps) = &desc.capabilities
+        && json_byte_len(caps) > MAX_CAPABILITIES_BYTES
+    {
+        return false;
+    }
+    true
+}
+
+/// Serialized-byte length of a JSON value. Used for hostile-payload
+/// size checks. `serde_json::to_vec` on an in-memory `Value` should
+/// not fail in practice; treat a serializer error as "oversized" so
+/// the guard remains fail-closed.
+fn json_byte_len(value: &serde_json::Value) -> usize {
+    serde_json::to_vec(value).map_or(usize::MAX, |v| v.len())
+}
+
+/// SDK-generated tool schemas use the field name `input_schema` while
+/// MCP uses `inputSchema`. Accept both at parse time by renaming on
+/// the fly so downstream code can rely on the MCP shape.
+fn remap_input_schema(mut value: serde_json::Value) -> serde_json::Value {
+    if let Some(obj) = value.as_object_mut()
+        && !obj.contains_key("inputSchema")
+        && let Some(schema) = obj.remove("input_schema")
+    {
+        obj.insert("inputSchema".to_string(), schema);
+    }
+    value
+}
+
+/// Publish the assembled MCP tool list. Names are prefixed
+/// `mcp__aos__<original>` so the agent runner can pass them through
+/// `--allowed-tools mcp__aos__*`. The cache stores raw names; the
+/// prefix is purely a wire concern for the agent-facing topic.
+fn publish_tools_list(descriptors: &[McpToolDescriptor]) {
+    let mcp_shaped: Vec<serde_json::Value> = descriptors
+        .iter()
+        .map(|d| mcp_descriptor_with_prefix(d, mcp_tool_prefix()))
+        .collect();
+
+    if let Err(e) = ipc::publish_json(tools_list_topic(), &mcp_shaped) {
+        let topic = tools_list_topic();
+        log::warn(format!(
+            "{}: failed to publish {topic}: {e}",
+            crate::profile::log_tag()
+        ));
+    }
+}
+
+/// Wall-clock millis used for cache TTL bookkeeping and lifecycle-log
+/// elapsed measurement. `pub(crate)` so the broker / execute paths measure
+/// elapsed against the same monotone-ish wall clock — one definition.
+pub(crate) fn wall_ms() -> u64 {
+    time::now()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+}
+
+#[cfg(test)]
+mod tests {
+    fn install_test_profile() {
+        crate::profile::install_aos();
+    }
+
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn static_tools_all_captured_unions_descriptors() {
+        install_test_profile();
+        // Two capsules, both captured: one with a tool, one authoritatively
+        // tool-less (`tools: []`). The union is the single tool; the empty
+        // capsule does not disqualify the static path.
+        let payload = json!({
+            "status": "ready",
+            "capsules": [
+                { "name": "fs", "meta": { "tools": [
+                    { "name": "read_file", "description": "Read a file",
+                      "input_schema": { "type": "object" } }
+                ] } },
+                { "name": "cli", "meta": { "tools": [] } },
+            ],
+        });
+        let tools = static_tools_from_payload(&payload).expect("all captured -> Some");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "read_file");
+        assert_eq!(tools[0].description, "Read a file");
+        assert_eq!(tools[0].input_schema, json!({ "type": "object" }));
+    }
+
+    #[test]
+    fn static_tools_any_uncaptured_is_none() {
+        install_test_profile();
+        // One captured, one with no `tools` key (built before tool-baking).
+        let payload = json!({
+            "status": "ready",
+            "capsules": [
+                { "name": "fs", "meta": { "tools": [ { "name": "read_file" } ] } },
+                { "name": "legacy", "meta": { "version": "0.1.0" } },
+            ],
+        });
+        assert!(static_tools_from_payload(&payload).is_none());
+    }
+
+    #[test]
+    fn static_tools_null_meta_is_none() {
+        install_test_profile();
+        // The kernel could not read this capsule's meta.json.
+        let payload = json!({
+            "status": "ready",
+            "capsules": [ { "name": "broken", "meta": serde_json::Value::Null } ],
+        });
+        assert!(static_tools_from_payload(&payload).is_none());
+    }
+
+    #[test]
+    fn static_tools_null_tools_is_none() {
+        install_test_profile();
+        // Explicit `tools: null` is the wire form of `None` (uncaptured).
+        let payload = json!({
+            "status": "ready",
+            "capsules": [ { "name": "x", "meta": { "tools": serde_json::Value::Null } } ],
+        });
+        assert!(static_tools_from_payload(&payload).is_none());
+    }
+
+    #[test]
+    fn static_tools_legacy_payload_without_capsules_is_none() {
+        install_test_profile();
+        // A pre-enrichment kernel publishes a bare `{status:"ready"}`.
+        let payload = json!({ "status": "ready" });
+        assert!(static_tools_from_payload(&payload).is_none());
+    }
+
+    #[test]
+    fn static_tools_no_capsules_loaded_is_empty_some() {
+        install_test_profile();
+        // An empty (but present) capsules array is "all captured, zero tools".
+        let payload = json!({ "status": "ready", "capsules": [] });
+        assert_eq!(static_tools_from_payload(&payload), Some(Vec::new()));
+    }
+
+    fn desc(name: &str) -> McpToolDescriptor {
+        McpToolDescriptor {
+            name: name.to_string(),
+            title: None,
+            description: String::new(),
+            input_schema: serde_json::Value::Null,
+            capabilities: None,
+        }
+    }
+
+    /// Regression for the `tools/list` empty-cache pin: a cold-start
+    /// race-loss returns no descriptors, which must KEEP the prior cache and
+    /// never replace it. Replacing on empty clobbered a good snapshot and
+    /// pinned an empty `tools/list` for the whole session (the MCP client
+    /// fetches the list once at connect).
+    #[test]
+    fn empty_fanout_keeps_cache() {
+        install_test_profile();
+        assert_eq!(snapshot_outcome(&[]), SnapshotOutcome::Keep);
+    }
+
+    /// A non-empty fan-out is a genuine answer and replaces the cache.
+    #[test]
+    fn non_empty_fanout_replaces_cache() {
+        install_test_profile();
+        assert_eq!(
+            snapshot_outcome(&[desc("fs.read")]),
+            SnapshotOutcome::Replace
+        );
+    }
+}

--- a/crates/aos-mcp-broker/src/execute.rs
+++ b/crates/aos-mcp-broker/src/execute.rs
@@ -1,0 +1,855 @@
+//! Tool execute core — `tool.v1.execute.<name>` fan-out and
+//! `tool.v1.execute.<name>.result` drain, behind the `astrid.v1.*` broker.
+//!
+//! Wire contract:
+//!
+//! * **Outbound request** (`tool.v1.execute.<tool_name>`): the SDK-canonical
+//!   `ToolExecuteRequest` shape `{ type:"tool_execute_request", call_id,
+//!   tool_name, arguments }`, mirroring what the router capsule emits.
+//!   The handler-side macro deserializes via `__AstridToolExecPayload`
+//!   which only requires `{ call_id, tool_name, arguments }`, so the
+//!   tagged form is accepted unchanged.
+//! * **Inbound result** (`tool.v1.execute.<tool_name>.result`): parsed by
+//!   [`match_result`], filtered on `call_id`, and returned to the broker
+//!   caller as `(content, is_error)` for reshaping into the MCP
+//!   `tool.call` reply.
+//!
+//! The bare tool name is supplied by the broker, which strips the
+//! `mcp__aos__` MCP prefix and charset-validates before constructing the
+//! routed topic — see [`crate::broker`]. The single execution door is the
+//! broker; there is no `astrid-removed tool.call.*` agent-runner leg (it was
+//! retired — the registered `aos mcp serve` MCP server is where the
+//! supervised `claude -p` executes tools, so an inline runner dispatch would
+//! double-execute).
+
+use astrid_sdk::prelude::*;
+use serde_json::{Value, json};
+
+use crate::approval::{self, ApprovalRequired, GrantRequired};
+
+/// Per-call drain window for the `tool.v1.execute.<name>.result` reply.
+/// Bounded well under the runner's 60 s `TOOL_CALL_DEADLINE` so the bridge
+/// times out first and synthesises a clean `isError:true` result rather
+/// than letting the supervisor's deadline-sweeper write back a generic
+/// "deadline exceeded" string. 50 s leaves comfortable headroom for the
+/// stdin write + bus hop on top of a worst-case tool runtime.
+const EXECUTE_TIMEOUT_MS: u64 = 50_000;
+
+/// Slice length for the result-drain loop. A single `recv(timeout)`
+/// would only pick up the first batch on the subscription; the loop
+/// keeps polling in shorter slices until either the matching result
+/// arrives or the timeout budget closes.
+const EXECUTE_SLICE_MS: u64 = 250;
+
+/// Tool-name charset cap. Same shape as the discovery validator
+/// ([`crate::discovery`]) — names must be non-empty, ASCII
+/// alphanumeric plus `_`, `.`, `-`. Rejects path separators, unicode
+/// bidi overrides, control chars, and the like before they can reach
+/// the routed topic. The hostile input here is the inbound
+/// `astrid.v1.request.mcp.tool.call` payload — a crafted `tool_name`
+/// that, if appended verbatim, would forge or shadow a
+/// `tool.v1.execute.*` topic.
+const MAX_TOOL_NAME_LEN: usize = 128;
+
+/// KV key prefix recording an ingress `source_id` the user has consented
+/// to trust for state-mutating broker calls. See [`is_ingress_trusted`].
+const INGRESS_TRUST_KEY_PREFIX: &str = "mcp.ingress.trust.";
+
+/// KV key prefix marking that the broker has an OUTSTANDING consent prompt
+/// for an ingress `source_id` — written when [`crate::broker::handle_mcp_call`]
+/// replies `ingress_approval_required` and consumed by
+/// [`crate::approval::handle_mcp_ingress_respond`]. See
+/// [`mark_ingress_pending`] / [`take_ingress_pending`].
+const INGRESS_PENDING_KEY_PREFIX: &str = "mcp.ingress.pending.";
+
+/// KV key prefix marking that the broker has an OUTSTANDING capsule-grant
+/// consent prompt for a `(principal, capsule_id)` pair — written when
+/// [`crate::broker::handle_mcp_call`] surfaces a `grant_required` flag and
+/// consumed by [`crate::approval::handle_mcp_grant_respond`]. See
+/// [`mark_grant_pending`] / [`take_grant_pending`]. KV is per-principal-scoped
+/// by the kernel, so the capsule id alone suffices within the keyspace.
+const GRANT_PENDING_KEY_PREFIX: &str = "mcp.grant.pending.";
+
+/// Self-heal TTL for a grant-pending marker, in milliseconds.
+///
+/// Unlike the ingress marker — which clears on a kernel-stamped `source_id`
+/// always present on the respond — a grant marker clears on the respond's
+/// `capsule_id` body field. If the shim crashes after the broker marked
+/// pending, or ever sends a respond without that field, the marker would
+/// otherwise stick and suppress EVERY future grant prompt for the pair. So the
+/// marker carries the wall-clock ms it was written, and a marker older than
+/// this is treated as stale (ignored, best-effort deleted) — the dedup
+/// self-heals regardless of which leg dropped the clear. Wall-clock (not
+/// monotonic) so a daemon restart, after which the KV marker survives but a
+/// monotonic clock would reset, still measures elapsed time correctly. Set
+/// well above the kernel's 60 s grant-awaiter window so a marker never expires
+/// while its grant could still land: the worst case is one duplicate prompt,
+/// never a double grant (the kernel grant is idempotent).
+pub(crate) const GRANT_PENDING_TTL_MS: u64 = 120_000;
+
+/// Outcome of a broker tool dispatch that watches for a mid-call approval.
+///
+/// The capability-gated tool's host-side `request_approval` syscall
+/// publishes an `astrid.v1.approval` envelope and BLOCKS its WASM thread
+/// until a decision lands. When [`dispatch_with_approval`] observes that
+/// envelope it short-circuits with [`DispatchOutcome::ApprovalRequired`]
+/// so the broker can surface the elicit flag in its reply rather than
+/// burning the whole drain window on a tool that cannot make progress
+/// until a human (via the shim → Claude) decides.
+pub(crate) enum DispatchOutcome {
+    /// The tool produced a result within the window: `(content, is_error)`.
+    Result(Value, bool),
+    /// The tool requested capability approval mid-call; the broker must
+    /// relay this to the shim and, on the returned choice, publish the
+    /// matching `astrid.v1.approval.response.<request_id>` decision.
+    ApprovalRequired(ApprovalRequired),
+    /// The kernel access gate refused the call because the principal has not
+    /// granted the target capsule. The kernel DROPPED the original
+    /// `tool.call` (nothing is parked) and published a `grant_required`
+    /// signal; the broker must surface a `grant_required` flag so the shim
+    /// can elicit consent and, on approve, publish the
+    /// `astrid.v1.approval.response.<request_id>` decision the kernel grant
+    /// handler consumes — then RE-SEND the original call. This mirrors the
+    /// ingress gate → consent → re-send flow, NOT the approval park →
+    /// resume flow: there is no result to drain.
+    GrantRequired(GrantRequired),
+    /// Dispatch failed before producing either (subscribe / publish error,
+    /// drain timeout with no approval observed).
+    Failed(String),
+}
+
+/// Broker dispatch: subscribe-before-publish on `tool.v1.execute.<name>`,
+/// drain `tool.v1.execute.<name>.result` for the matching `call_id`, and
+/// additionally watch `astrid.v1.approval` for the duration of the drain.
+///
+/// The sole execute path behind the `astrid.v1.request.mcp.tool.call`
+/// broker — the wire-shape, the charset/topic-segment hardening, the 50 s
+/// bounded drain, and the `call_id` filtering live here. It subscribes
+/// (before publishing the execute request) to the fixed `astrid.v1.approval`
+/// topic too. If the routed tool blocks on a capability approval, that
+/// envelope arrives on this subscription and the dispatch returns
+/// [`DispatchOutcome::ApprovalRequired`] so the broker can drive the
+/// elicitation/approval bridge ([`crate::approval`]). Otherwise the first
+/// matching result wins; a closed window → `Failed`.
+///
+/// `tool_name` MUST already be charset-validated by the caller (the broker
+/// validates via [`is_valid_tool_name`] before calling) — constructing the
+/// routed topic from an unchecked name would let a hostile publisher forge
+/// `tool.v1.execute.*` segments.
+pub(crate) fn dispatch_with_approval(
+    tool_name: &str,
+    call_id: &str,
+    arguments: &Value,
+) -> DispatchOutcome {
+    if !is_valid_tool_name(tool_name) {
+        return DispatchOutcome::Failed(format!(
+            "{}: invalid tool name '{tool_name}'",
+            crate::profile::log_tag()
+        ));
+    }
+
+    let route_topic = format!("tool.v1.execute.{tool_name}");
+    let result_topic = format!("tool.v1.execute.{tool_name}.result");
+
+    // Subscribe to BOTH the per-tool result topic and the fixed approval
+    // topic BEFORE publishing the execute request, so neither a fast
+    // result nor a fast approval can race ahead of our subscription. RAII
+    // Drop on both handles releases the kernel-side resources on every
+    // return path.
+    let result_sub = match ipc::subscribe(&result_topic) {
+        Ok(s) => s,
+        Err(e) => {
+            return DispatchOutcome::Failed(format!(
+                "{}: failed to subscribe to {result_topic}: {e}",
+                crate::profile::log_tag()
+            ));
+        }
+    };
+    let approval_sub = match ipc::subscribe(approval::APPROVAL_REQUEST_TOPIC) {
+        Ok(s) => s,
+        Err(e) => {
+            return DispatchOutcome::Failed(format!(
+                "{}: failed to subscribe to {}: {e}",
+                crate::profile::log_tag(),
+                approval::APPROVAL_REQUEST_TOPIC
+            ));
+        }
+    };
+
+    let forward = json!({
+        "type": "tool_execute_request",
+        "call_id": call_id,
+        "tool_name": tool_name,
+        "arguments": arguments,
+    });
+    if let Err(e) = ipc::publish_json(&route_topic, &forward) {
+        return DispatchOutcome::Failed(format!(
+            "{}: failed to publish {route_topic}: {e}",
+            crate::profile::log_tag()
+        ));
+    }
+
+    // Drain both subscriptions in lockstep slices until a matching result
+    // arrives, an approval surfaces, or the window closes. Each `recv` is
+    // bounded by the slice; we poll the approval sub non-blocking between
+    // result slices so an approval published while we're parked on the
+    // result `recv` is still seen within one slice.
+    let mut remaining = EXECUTE_TIMEOUT_MS;
+    while remaining > 0 {
+        let step = remaining.min(EXECUTE_SLICE_MS);
+
+        // Check the approval topic first (non-blocking). Both a capability
+        // approval AND a kernel grant-gate miss ride the same already-subscribed
+        // `astrid.v1.approval` topic, so ONE drain of the subscription must
+        // serve both: a `poll()` consumes its batch, so two separate polls
+        // would let the first discard a signal the second was looking for.
+        // [`poll_signal`] inspects each message once and prefers a
+        // `grant_required` (the kernel DROPPED the call — no result will ever
+        // come) over an `approval_required` (the tool is parked). Either way the
+        // result topic can make no further progress, so we must not keep
+        // blocking on it.
+        match poll_signal(&approval_sub) {
+            Some(DispatchOutcome::GrantRequired(grant)) => {
+                return DispatchOutcome::GrantRequired(grant);
+            }
+            Some(DispatchOutcome::ApprovalRequired(req)) => {
+                return DispatchOutcome::ApprovalRequired(req);
+            }
+            _ => {}
+        }
+
+        match result_sub.recv(step) {
+            Ok(poll) => {
+                for msg in poll.messages {
+                    if let Some((content, is_error)) = match_result(&msg.payload, call_id) {
+                        return DispatchOutcome::Result(content, is_error);
+                    }
+                }
+            }
+            Err(_) => {
+                // Result `recv` timed out for this slice; loop will re-check
+                // the approval sub and continue until the budget closes.
+            }
+        }
+
+        // One more combined check after the result slice — covers a signal
+        // that landed during the blocking `recv` above. Same grant-first
+        // single-drain rationale as the pre-`recv` check.
+        match poll_signal(&approval_sub) {
+            Some(DispatchOutcome::GrantRequired(grant)) => {
+                return DispatchOutcome::GrantRequired(grant);
+            }
+            Some(DispatchOutcome::ApprovalRequired(req)) => {
+                return DispatchOutcome::ApprovalRequired(req);
+            }
+            _ => {}
+        }
+
+        remaining = remaining.saturating_sub(step);
+    }
+
+    DispatchOutcome::Failed(format!(
+        "{}: tool '{tool_name}' did not respond within {}s",
+        crate::profile::log_tag(),
+        EXECUTE_TIMEOUT_MS / 1_000
+    ))
+}
+
+/// Non-blocking single-drain poll of the shared `astrid.v1.approval`
+/// subscription for EITHER signal the broker must surface, returning the
+/// matching [`DispatchOutcome`] variant or `None`.
+///
+/// Both an `approval_required` (a capability-gated tool parked on
+/// `request_approval`) and a `grant_required` (the kernel access gate refused
+/// and DROPPED the call) are published on this one topic. `sub.poll()`
+/// consumes its batch, so the two must be checked in a SINGLE pass — two
+/// separate polls could let the first discard a signal the second wanted.
+/// A `grant_required` is preferred when both appear in the batch: a dropped
+/// call has no result and nothing parked, so surfacing it promptly avoids
+/// burning the drain window. The variant is mapped here so the caller's match
+/// stays uniform; this never returns [`DispatchOutcome::Result`] /
+/// [`DispatchOutcome::Failed`].
+///
+/// `astrid.v1.approval` is a single global broadcast topic carrying no
+/// `call_id` / `tool_name`. Correctness here rests on the engine serialising
+/// guest calls per capsule instance behind the store mutex: this dispatch
+/// holds that lock for its whole drain, so no other aos-mcp `handle_mcp_call`
+/// can be watching the topic concurrently. The only signal we can observe
+/// during our window is the one OUR OWN routed tool raised — see the
+/// "Concurrency / correlation" note in [`crate::approval`]. The decision is
+/// independently routed by `request_id` to the host's per-request topic, so
+/// the surfaced signal is always tied to exactly the tool that raised it.
+///
+/// Skips any payload on the shared topic that is neither envelope (other
+/// `IpcPayload` variants could in principle share it) and any that fails to
+/// deserialize.
+fn poll_signal(sub: &ipc::Subscription) -> Option<DispatchOutcome> {
+    let poll = sub.poll().ok()?;
+    let mut approval: Option<ApprovalRequired> = None;
+    for msg in poll.messages {
+        let Ok(value) = serde_json::from_str::<Value>(&msg.payload) else {
+            continue;
+        };
+        // Grant wins: return the instant we see one, even if an approval was
+        // already buffered this batch.
+        if approval::is_grant_required(&value)
+            && let Ok(grant) = serde_json::from_value::<GrantRequired>(value.clone())
+        {
+            return Some(DispatchOutcome::GrantRequired(grant));
+        }
+        // Remember the first well-formed approval but keep scanning for a
+        // grant later in the same batch.
+        if approval.is_none()
+            && approval::is_approval_required(&value)
+            && let Ok(req) = serde_json::from_value::<ApprovalRequired>(value)
+        {
+            approval = Some(req);
+        }
+    }
+    approval.map(DispatchOutcome::ApprovalRequired)
+}
+
+/// Match a `tool.v1.execute.<name>.result` payload against `call_id`,
+/// returning `(content, is_error)` when it is the result for this call.
+///
+/// Used by [`dispatch_with_approval`]'s drain loop. `pub(crate)` so the
+/// approval bridge ([`crate::approval`]) reuses the exact same parser when
+/// it drains the resumed/denied result after a decision — one definition,
+/// no wire-shape drift between the two result legs.
+pub(crate) fn match_result(payload: &str, call_id: &str) -> Option<(Value, bool)> {
+    let value = serde_json::from_str::<Value>(payload).ok()?;
+    if value.get("call_id").and_then(Value::as_str) != Some(call_id) {
+        return None;
+    }
+    let result_obj = value.get("result");
+    let content = result_obj
+        .and_then(|r| r.get("content"))
+        .cloned()
+        .unwrap_or(Value::String(String::new()));
+    let is_error = result_obj
+        .and_then(|r| r.get("is_error"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    Some((content, is_error))
+}
+
+/// KV key recording consent to trust an ingress `source_id`. Split out so
+/// the prefix is applied in exactly one place and both the read
+/// ([`is_ingress_trusted`]) and the write
+/// ([`crate::approval::handle_mcp_ingress_respond`]) agree on the key shape.
+///
+/// Returns `None` for an empty `source_id` — an unattributed caller must
+/// never resolve to a routable trust key (which, with an empty suffix,
+/// would collapse to the bare prefix and risk a spurious match / write).
+pub(crate) fn ingress_trust_key(source_id: &str) -> Option<String> {
+    if source_id.is_empty() {
+        return None;
+    }
+    Some(format!("{INGRESS_TRUST_KEY_PREFIX}{source_id}"))
+}
+
+/// KV key marking an outstanding consent prompt for `source_id`. Same
+/// empty-source guard as [`ingress_trust_key`] — an unattributed caller must
+/// never resolve to a routable pending key.
+fn ingress_pending_key(source_id: &str) -> Option<String> {
+    if source_id.is_empty() {
+        return None;
+    }
+    Some(format!("{INGRESS_PENDING_KEY_PREFIX}{source_id}"))
+}
+
+/// Record that the broker has surfaced an `ingress_approval_required` prompt
+/// for `source_id`, so a later `ingress.respond` can be correlated to a prompt
+/// the broker actually issued ([`take_ingress_pending`]).
+///
+/// Best-effort: a write failure is logged, not fatal. If the marker is lost
+/// the subsequent accept simply fails the correlation check and the user is
+/// re-prompted on the next call — fail-secure, never a spurious grant.
+///
+/// The keyspace is bounded by the set of installed capsules (a `source_id` is
+/// a kernel-stamped capsule UUID), and every marker is consumed by the paired
+/// respond, so no TTL/sweep is needed.
+pub(crate) fn mark_ingress_pending(source_id: &str) {
+    let Some(key) = ingress_pending_key(source_id) else {
+        log::warn(format!(
+            "{}: empty source_id; not marking an ingress consent prompt as pending",
+            crate::profile::log_tag()
+        ));
+        return;
+    };
+    if let Err(e) = kv::set_bytes(&key, b"1") {
+        log::warn(format!(
+            "{}: failed to mark ingress consent prompt pending for source_id \
+             '{source_id}': {e}",
+            crate::profile::log_tag()
+        ));
+    }
+}
+
+/// Consume the outstanding consent-prompt marker for `source_id`, returning
+/// whether one existed.
+///
+/// This is the req-correlation gate: [`crate::approval::handle_mcp_ingress_respond`]
+/// only honours an `accept` when this returns `true`, so an UNSOLICITED or
+/// replayed `ingress.respond` (one for which the broker never issued a prompt)
+/// cannot prime trust. The marker is deleted on consume — both on accept and
+/// on decline — so it is single-use and a decline does not leave a stale
+/// marker a later unsolicited accept could ride.
+///
+/// Fail-closed: an empty `source_id`, a missing marker, or a host read error
+/// all return `false`. A delete failure after a confirmed-present marker is
+/// logged but still reported as consumed (the grant proceeds; the worst case
+/// is one re-usable stale marker, never a denied legitimate grant).
+pub(crate) fn take_ingress_pending(source_id: &str) -> bool {
+    let Some(key) = ingress_pending_key(source_id) else {
+        return false;
+    };
+    match kv::get_bytes_opt(&key) {
+        Ok(Some(_)) => {
+            if let Err(e) = kv::delete(&key) {
+                log::warn(format!(
+                    "{}: failed to clear ingress pending marker for source_id \
+                     '{source_id}': {e}",
+                    crate::profile::log_tag()
+                ));
+            }
+            true
+        }
+        Ok(None) => false,
+        Err(e) => {
+            log::warn(format!(
+                "{}: ingress pending read error for source_id '{source_id}', \
+                 failing closed: {e}",
+                crate::profile::log_tag()
+            ));
+            false
+        }
+    }
+}
+
+/// KV key marking an outstanding capsule-grant consent prompt for a
+/// `(principal, capsule_id)` pair. KV is per-principal-scoped by the kernel,
+/// so the capsule id alone disambiguates within the keyspace — the principal
+/// is implicit in the storage scope, not the key suffix. Same empty-suffix
+/// guard as [`ingress_pending_key`]: an empty `capsule_id` must never resolve
+/// to a routable key (it would collapse to the bare prefix and let one marker
+/// dedup every grant prompt for the principal). The `principal` is accepted
+/// for symmetry with the call sites and to keep the dedup key intent explicit,
+/// but is NOT stamped into the suffix (the KV scope already carries it).
+fn grant_pending_key(_principal: &str, capsule_id: &str) -> Option<String> {
+    if capsule_id.is_empty() {
+        return None;
+    }
+    Some(format!("{GRANT_PENDING_KEY_PREFIX}{capsule_id}"))
+}
+
+/// Record that the broker has surfaced a `grant_required` prompt for
+/// `(principal, capsule_id)`, so a duplicate ungranted call for the same pair
+/// while one is pending is suppressed instead of spawning a second prompt, and
+/// so [`take_grant_pending`] can clear it on respond.
+///
+/// The marker VALUE is the wall-clock ms it was written: [`grant_pending`]
+/// treats a marker older than [`GRANT_PENDING_TTL_MS`] as stale and ignores it,
+/// so the dedup self-heals even when the paired respond never clears it (a shim
+/// crash, or a respond that arrives without the `capsule_id` the clear keys on).
+/// If the clock read fails the marker is written as `0` — already stale — so the
+/// failure degrades to "no dedup" (one extra prompt), never a stuck marker.
+///
+/// Best-effort: a write failure is logged, not fatal. A lost marker just means
+/// a duplicate prompt could surface (one extra elicit), never a spurious grant
+/// — the grant itself is still gated on a human approve flowing through
+/// [`crate::approval::handle_mcp_grant_respond`].
+pub(crate) fn mark_grant_pending(principal: &str, capsule_id: &str) {
+    let Some(key) = grant_pending_key(principal, capsule_id) else {
+        log::warn(format!(
+            "{}: empty capsule_id; not marking a grant consent prompt as pending",
+            crate::profile::log_tag()
+        ));
+        return;
+    };
+    let stamp = crate::discovery::wall_ms().to_string();
+    if let Err(e) = kv::set_bytes(&key, stamp.as_bytes()) {
+        log::warn(format!(
+            "{}: failed to mark grant consent prompt pending for capsule_id \
+             '{capsule_id}': {e}",
+            crate::profile::log_tag()
+        ));
+    }
+}
+
+/// Whether a grant-pending marker value (the wall-clock ms it was written, per
+/// [`crate::discovery::wall_ms`]) is still within [`GRANT_PENDING_TTL_MS`].
+fn marker_is_fresh(value: &[u8]) -> bool {
+    marker_is_fresh_at(value, crate::discovery::wall_ms())
+}
+
+/// Core of [`marker_is_fresh`] with the clock injected, so the freshness logic
+/// is unit-testable without a host (mirrors [`crate::cache`]'s `is_fresh`).
+///
+/// Reads as NOT fresh — fail toward re-prompting (surface a fresh consent
+/// prompt), never toward a stuck marker — when: the value does not parse; the
+/// stored stamp is `0` (the mark-time clock was unavailable); `now` is `0` (the
+/// clock is unavailable now); or the stamp is in the FUTURE relative to `now`
+/// (`written > now`). A future stamp means the wall clock stepped backward (NTP
+/// correction) or the stored value is corrupt/forged; reading it as fresh would
+/// suppress prompts far beyond the TTL (until the clock caught back up), which
+/// defeats the self-heal, so it too fails open to a re-prompt. With those guards
+/// the freshness window is exactly `[written, written + TTL)` and `now - written`
+/// can never underflow.
+fn marker_is_fresh_at(value: &[u8], now: u64) -> bool {
+    if now == 0 {
+        return false;
+    }
+    let Ok(written) = std::str::from_utf8(value)
+        .map(str::trim)
+        .unwrap_or("")
+        .parse::<u64>()
+    else {
+        return false;
+    };
+    if written == 0 || written > now {
+        return false;
+    }
+    now - written < GRANT_PENDING_TTL_MS
+}
+
+/// Returns whether a grant-consent prompt is already outstanding for
+/// `(principal, capsule_id)` WITHOUT consuming the marker.
+///
+/// Used at the broker's `grant_required` surface point: if a prompt is already
+/// pending for this pair, the broker replies a benign "already pending"
+/// terminal result instead of a fresh elicit (dedup). The marker is left in
+/// place — it is consumed only by [`take_grant_pending`] on the respond, so the
+/// dedup holds across every duplicate call until the user decides.
+///
+/// Fail-OPEN on a read error (returns `false` → the broker surfaces a fresh
+/// prompt): a transient KV read failure must never SUPPRESS a consent prompt,
+/// or an ungranted call could be silently swallowed with no way for the user to
+/// approve it. The worst case is a duplicate prompt, never a swallowed call.
+pub(crate) fn grant_pending(principal: &str, capsule_id: &str) -> bool {
+    let Some(key) = grant_pending_key(principal, capsule_id) else {
+        return false;
+    };
+    match kv::get_bytes_opt(&key) {
+        Ok(Some(bytes)) => {
+            if marker_is_fresh(&bytes) {
+                true
+            } else {
+                // Stale (or unparseable / clock-unavailable) marker: the paired
+                // respond never cleared it. Treat as not pending and best-effort
+                // delete so the next ungranted call re-prompts — the self-heal
+                // that keeps a dropped respond from wedging the pair forever.
+                let _ = kv::delete(&key);
+                false
+            }
+        }
+        Ok(None) => false,
+        Err(e) => {
+            log::warn(format!(
+                "{}: grant pending read error for capsule_id '{capsule_id}', \
+                 surfacing a fresh prompt: {e}",
+                crate::profile::log_tag()
+            ));
+            false
+        }
+    }
+}
+
+/// Consume the outstanding grant-consent prompt marker for
+/// `(principal, capsule_id)`, returning whether one existed.
+///
+/// Called by [`crate::approval::handle_mcp_grant_respond`] on BOTH approve and
+/// deny so the marker is single-use and can never stick: a declined prompt must
+/// not leave a marker that suppresses every future grant prompt for the pair.
+/// The return value is informational (the grant itself is driven by the
+/// published decision, not this marker); clearing the marker is the effect that
+/// matters here.
+///
+/// Fail-closed shape mirrors [`take_ingress_pending`]: an empty `capsule_id`, a
+/// missing marker, or a read error all return `false`. A delete failure after a
+/// confirmed-present marker is logged but reported as consumed.
+pub(crate) fn take_grant_pending(principal: &str, capsule_id: &str) -> bool {
+    let Some(key) = grant_pending_key(principal, capsule_id) else {
+        return false;
+    };
+    match kv::get_bytes_opt(&key) {
+        Ok(Some(_)) => {
+            if let Err(e) = kv::delete(&key) {
+                log::warn(format!(
+                    "{}: failed to clear grant pending marker for capsule_id \
+                     '{capsule_id}': {e}",
+                    crate::profile::log_tag()
+                ));
+            }
+            true
+        }
+        Ok(None) => false,
+        Err(e) => {
+            log::warn(format!(
+                "{}: grant pending read error for capsule_id '{capsule_id}', \
+                 failing closed: {e}",
+                crate::profile::log_tag()
+            ));
+            false
+        }
+    }
+}
+
+/// Confused-deputy guard for state-mutating broker calls.
+///
+/// `source_id` is the kernel-set UUID of the capsule that originated the
+/// inbound IPC message ([`astrid_sdk::runtime::caller`] →
+/// `CallerContext::source_id`). It is NOT guest-settable — the kernel
+/// stamps it from the publishing capsule's invocation context, so a
+/// malicious guest cannot forge it the way it could forge a body field.
+/// An ingress is trusted iff the per-(principal, source_id) KV key
+/// `mcp.ingress.trust.<source_id>` exists — written ONLY by
+/// [`crate::approval::handle_mcp_ingress_respond`] after the user
+/// interactively consents via the shim's elicit prompt. There is no
+/// operator-maintained allow-list and nothing a capsule computes; trust is
+/// recorded purely from a human accept, keyed on the kernel-stamped
+/// originating identity.
+///
+/// KV is scoped per-principal (and per-capsule) by the kernel, so this is
+/// naturally per-(principal, source_id) — consent granted under one
+/// principal does not leak to another. Fails CLOSED: an empty source_id, a
+/// missing key, or a host read error all return `false`.
+///
+/// ## Why `principal.verified()` is insufficient here
+///
+/// The broker surface (`astrid.v1.request.mcp.tool.call`) is reached
+/// through the cli proxy, which forwards client traffic with a plain
+/// [`astrid_sdk::ipc::publish`] (see `capsule-cli`'s ingress path) — NOT
+/// `publish_as`. The host therefore attributes the principal as
+/// `Verified(<proxy's own invocation principal>)`: the host NEVER emits
+/// `Claimed` on this path (that variant only appears behind `publish_as`,
+/// which the proxy does not use for tool calls), and the proxy stamps
+/// the default verified attribution. So `verified()` returning `Some`
+/// proves only "*some* capsule published this in a verified invocation
+/// context" — it does NOT identify *which* capsule, and every sibling
+/// capsule on the bus would equally satisfy it. The confused-deputy
+/// question is "did a TRUSTED ingress forward this?", which only
+/// `source_id` (the originating capsule's identity) answers. We keep the
+/// kernel-resolved principal for downstream capability checks but gate
+/// admission on `source_id`, not trust marker.
+pub(crate) fn is_ingress_trusted(source_id: &str) -> bool {
+    let Some(key) = ingress_trust_key(source_id) else {
+        return false;
+    };
+    // Present key (any value) → trusted; missing → not; host error → fail
+    // closed.
+    matches!(kv::get_bytes_opt(&key), Ok(Some(_)))
+}
+
+/// Tool-name charset gate. Same rule as the discovery validator —
+/// non-empty, length-capped, ASCII alphanumeric plus `_ . -`. See
+/// [`crate::discovery::is_valid_name`] for the source of the rule.
+///
+/// `pub(crate)` so the approval bridge ([`crate::approval`]) applies the
+/// exact same gate to the `tool_name` the shim echoes back before it builds
+/// the `tool.v1.execute.<name>.result` topic to drain — one definition, no
+/// drift between the dispatch and resume legs.
+pub(crate) fn is_valid_tool_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_TOOL_NAME_LEN
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b'-'))
+}
+
+#[cfg(test)]
+mod tests {
+    fn install_test_profile() {
+        crate::profile::install_aos();
+    }
+
+    use super::*;
+
+    #[test]
+    fn tool_name_charset_rejects_path_traversal() {
+        install_test_profile();
+        assert!(is_valid_tool_name("read_file"));
+        assert!(is_valid_tool_name("fs.read"));
+        assert!(is_valid_tool_name("a-b-c"));
+        assert!(!is_valid_tool_name(""));
+        assert!(!is_valid_tool_name("foo/bar"));
+        assert!(!is_valid_tool_name("foo bar"));
+        assert!(!is_valid_tool_name("foo\nbar"));
+        assert!(!is_valid_tool_name("foo*"));
+    }
+
+    #[test]
+    fn tool_name_length_capped() {
+        install_test_profile();
+        let ok = "a".repeat(MAX_TOOL_NAME_LEN);
+        let too_long = "a".repeat(MAX_TOOL_NAME_LEN + 1);
+        assert!(is_valid_tool_name(&ok));
+        assert!(!is_valid_tool_name(&too_long));
+    }
+
+    #[test]
+    fn ingress_trust_key_applies_prefix() {
+        install_test_profile();
+        let id = "0191f3a2-b4c7-4d8e-9f01-234567890abc";
+        assert_eq!(
+            ingress_trust_key(id).as_deref(),
+            Some("mcp.ingress.trust.0191f3a2-b4c7-4d8e-9f01-234567890abc")
+        );
+    }
+
+    #[test]
+    fn ingress_trust_key_rejects_empty_source() {
+        install_test_profile();
+        // An unattributed (empty) source_id must never resolve to a routable
+        // trust key — otherwise the read would collapse to the bare prefix
+        // and a write under an empty caller would grant blanket trust.
+        assert_eq!(ingress_trust_key(""), None);
+    }
+
+    #[test]
+    fn ingress_pending_key_applies_prefix() {
+        install_test_profile();
+        let id = "0191f3a2-b4c7-4d8e-9f01-234567890abc";
+        assert_eq!(
+            ingress_pending_key(id).as_deref(),
+            Some("mcp.ingress.pending.0191f3a2-b4c7-4d8e-9f01-234567890abc")
+        );
+    }
+
+    #[test]
+    fn ingress_pending_key_rejects_empty_source() {
+        install_test_profile();
+        // Mirror the trust-key guard: an unattributed (empty) source must not
+        // resolve to a routable pending key, or `mark`/`take` would collapse
+        // to the bare prefix and a single marker would correlate every
+        // unattributed respond.
+        assert_eq!(ingress_pending_key(""), None);
+    }
+
+    #[test]
+    fn take_ingress_pending_empty_source_fails_closed() {
+        install_test_profile();
+        // No host KV call is reached for an empty source_id — it short-circuits
+        // to `false` via `ingress_pending_key` returning `None`, so an
+        // unattributed accept can never satisfy the correlation gate. (The
+        // non-empty path needs a live host and is exercised by integration.)
+        assert!(!take_ingress_pending(""));
+    }
+
+    #[test]
+    fn is_ingress_trusted_empty_source_fails_closed() {
+        install_test_profile();
+        // No host KV call is reached for an empty source_id — it short-circuits
+        // to `false` via `ingress_trust_key` returning `None`. (The non-empty
+        // path needs a live host and is exercised by integration, not here.)
+        assert!(!is_ingress_trusted(""));
+    }
+
+    #[test]
+    fn grant_pending_key_applies_prefix_on_capsule_only() {
+        install_test_profile();
+        // The key suffix is the capsule id alone — the principal is implicit
+        // in the per-principal KV scope, never stamped into the suffix. Two
+        // different principals naturally get separate markers via the scope,
+        // so the same capsule id under each maps to the same suffix without
+        // colliding across principals.
+        let cap = "fs";
+        assert_eq!(
+            grant_pending_key("alice", cap).as_deref(),
+            Some("mcp.grant.pending.fs")
+        );
+        // The principal does not change the key — proves it is scope-implicit,
+        // not suffix-encoded.
+        assert_eq!(
+            grant_pending_key("bob", cap),
+            grant_pending_key("alice", cap)
+        );
+    }
+
+    #[test]
+    fn grant_pending_key_rejects_empty_capsule() {
+        install_test_profile();
+        // Mirror the ingress-pending guard: an empty capsule_id must not
+        // resolve to a routable key, or one marker would dedup every grant
+        // prompt for the principal.
+        assert_eq!(grant_pending_key("alice", ""), None);
+    }
+
+    #[test]
+    fn grant_pending_empty_capsule_is_not_pending() {
+        install_test_profile();
+        // No host KV call is reached for an empty capsule_id — it short-circuits
+        // to `false` via `grant_pending_key` returning `None`, so the broker
+        // surfaces a fresh prompt rather than spuriously deduping. (The
+        // non-empty path needs a live host and is exercised by integration.)
+        assert!(!grant_pending("alice", ""));
+    }
+
+    #[test]
+    fn take_grant_pending_empty_capsule_fails_closed() {
+        install_test_profile();
+        // No host KV call is reached for an empty capsule_id — short-circuits
+        // to `false` via `grant_pending_key` returning `None`. (The non-empty
+        // path needs a live host and is exercised by integration, not here.)
+        assert!(!take_grant_pending("alice", ""));
+    }
+
+    #[test]
+    fn marker_fresh_within_ttl() {
+        install_test_profile();
+        // A marker written `TTL - 1ms` ago is still within the window → fresh,
+        // so the dedup holds and a duplicate call is suppressed.
+        let now = 10_000_000;
+        let written = now - (GRANT_PENDING_TTL_MS - 1);
+        assert!(marker_is_fresh_at(written.to_string().as_bytes(), now));
+    }
+
+    #[test]
+    fn marker_stale_at_or_past_ttl_self_heals() {
+        install_test_profile();
+        // At exactly the TTL and beyond, the marker is stale → not fresh, so
+        // `grant_pending` ignores it and the next call re-prompts. This is the
+        // self-heal that keeps a never-cleared marker (shim crash, or a respond
+        // without `capsule_id`) from suppressing prompts forever.
+        let now = 10_000_000;
+        let at_ttl = now - GRANT_PENDING_TTL_MS;
+        let past_ttl = now - (GRANT_PENDING_TTL_MS + 60_000);
+        assert!(!marker_is_fresh_at(at_ttl.to_string().as_bytes(), now));
+        assert!(!marker_is_fresh_at(past_ttl.to_string().as_bytes(), now));
+    }
+
+    #[test]
+    fn marker_not_fresh_when_clock_unavailable_now_or_at_write() {
+        install_test_profile();
+        // `wall_ms() == 0` means the host clock is unavailable. Either a now of 0
+        // or a stored stamp of 0 reads as NOT fresh — fail toward re-prompting,
+        // never toward trusting an unageable marker.
+        assert!(!marker_is_fresh_at(b"10000000", 0));
+        assert!(!marker_is_fresh_at(b"0", 10_000_000));
+    }
+
+    #[test]
+    fn marker_not_fresh_when_unparseable() {
+        install_test_profile();
+        // A non-numeric value (e.g. a legacy `b"1"` presence marker, or garbage)
+        // cannot be aged → treated as not fresh so it cannot linger.
+        assert!(!marker_is_fresh_at(b"1", 10_000_000));
+        assert!(!marker_is_fresh_at(b"not-a-number", 10_000_000));
+        assert!(!marker_is_fresh_at(b"", 10_000_000));
+    }
+
+    #[test]
+    fn marker_future_stamp_is_stale() {
+        install_test_profile();
+        // A stamp dated in the FUTURE relative to `now` (the wall clock stepped
+        // backward, or the stored value is corrupt/forged) must read as STALE —
+        // fail open to a re-prompt — never as fresh. Reading it as fresh would
+        // suppress prompts until the clock caught back up (potentially far beyond
+        // the TTL), defeating the self-heal. The cost of failing open is at most
+        // one extra prompt, never indefinite suppression.
+        assert!(!marker_is_fresh_at(
+            20_000_000u64.to_string().as_bytes(),
+            10_000_000
+        ));
+    }
+}

--- a/crates/aos-mcp-broker/src/grant_decision.rs
+++ b/crates/aos-mcp-broker/src/grant_decision.rs
@@ -1,0 +1,574 @@
+//! Durable per-principal grant-on-use decisions — the convergence anchor.
+//!
+//! Grant-on-use consent (the kernel `GrantRequired` -> shim elicit ->
+//! `grant.respond` -> kernel grant flow, see [`crate::approval`]) has a race
+//! that can wedge a first-run session: the kernel awaiter that raised a
+//! `GrantRequired` expires FAIL-CLOSED after 60 s, so a human answer that
+//! arrives late — a slow user, or a prompt the client lost and re-asked — can
+//! miss its awaiter and never persist the grant. The elicit pipeline can also
+//! drop a single accept, and the 120 s pending-dedup then answers every retry
+//! with "already pending", so the flow never converges without an operator
+//! escape hatch (`aos --principal default agent modify <principal>
+//! --add-capsule <id>`).
+//!
+//! This module makes the user's ACCEPT durable. The moment a `grant.respond`
+//! arrives with an approve verb the broker records it here, keyed on the
+//! capsule, BEFORE forwarding the decision to the kernel. Then, wherever the
+//! broker would surface a fresh grant prompt, it consults the record first: a
+//! recorded APPROVE auto-answers the NEXT `GrantRequired` for that capsule
+//! (against a fresh, live awaiter) WITHOUT re-prompting, so the flow converges
+//! even though the awaiter that originally prompted expired.
+//!
+//! ## Why a DENY is deliberately NOT recorded
+//!
+//! The core shim's `resolve_grant` contract is that it ALWAYS responds: it
+//! publishes `deny` not only when the user clicks Deny but on EVERY non-accept
+//! path — an elicit error, an elicit timeout, and a client that lacks the
+//! elicitation capability entirely (that unconditional respond exists to clear
+//! the broker's pending marker). The respond body carries no provenance, so the
+//! broker cannot distinguish "the user said no" from "the consent machinery
+//! failed". Durably recording such a deny would make a transport glitch — or
+//! simply using a plain MCP client without elicitation support — a PERMANENT
+//! auto-deny the user never chose, until an operator intervenes. So a deny
+//! keeps its ephemeral semantics: the pending marker is consumed and the next
+//! call re-prompts — deny means "not now", never "never". See
+//! [`respond_decision_to_record`], the recording chokepoint that encodes this.
+//!
+//! The [`GrantDecision::Deny`] variant, its parse path, and the broker's
+//! [`GrantAction::AutoDeny`] arm are kept intact as defence-in-depth: if a deny
+//! record ever exists (written manually via KV, or by a future version once the
+//! respond carries provenance — astrid-runtime/astrid#1114 — so genuine user
+//! denies CAN be recorded durably), it is honoured rather than silently
+//! ignored.
+//!
+//! Security posture: this stores only the user's own recorded answer and the
+//! broker only ever replays it onto a kernel-correlated `GrantRequired`'s
+//! response topic — the kernel remains the sole grantor; nothing here grants a
+//! capsule itself. Every read fails toward PROMPTING (a missing / unreadable
+//! record is "no decision"), never toward auto-approve.
+//!
+//! KV is per-principal-scoped by the kernel, so — exactly like the grant-pending
+//! marker in [`crate::execute`] — the capsule id alone is the key suffix and the
+//! principal is implicit in the storage scope, never stamped into the key.
+
+use astrid_sdk::prelude::*;
+use serde_json::{Value, json};
+
+/// KV key prefix recording the user's durable grant decision for a capsule.
+const GRANT_DECISION_KEY_PREFIX: &str = "mcp.grant.decision.";
+
+/// The verb persisted for an approve decision (and the wire verb the shim sends).
+const GRANT_DECISION_APPROVE: &str = "approve";
+/// The verb persisted for a deny decision.
+const GRANT_DECISION_DENY: &str = "deny";
+
+/// The user's durable grant decision for a capsule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GrantDecision {
+    /// The user granted the capsule.
+    Approve,
+    /// The user denied the capsule.
+    Deny,
+}
+
+impl GrantDecision {
+    /// The KV value byte-string this decision persists as. Round-trips through
+    /// [`parse_grant_decision`].
+    fn as_kv_value(self) -> &'static str {
+        match self {
+            GrantDecision::Approve => GRANT_DECISION_APPROVE,
+            GrantDecision::Deny => GRANT_DECISION_DENY,
+        }
+    }
+}
+
+/// The broker's action for an observed `GrantRequired`, decided purely from the
+/// recorded decision so the choice is unit-testable without a host. See
+/// [`grant_action`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GrantAction {
+    /// A durable approve is on record -> auto-publish an approve for the live
+    /// kernel request_id WITHOUT eliciting.
+    AutoApprove,
+    /// A durable deny is on record -> suppress the prompt and return the
+    /// operator-actionable deny message.
+    AutoDeny,
+    /// No durable decision -> fall through to the pending-dedup + elicit path.
+    Prompt,
+}
+
+/// KV key recording the user's durable grant decision for `capsule_id`.
+///
+/// Mirrors `execute::grant_pending_key`: an empty `capsule_id` returns `None` so
+/// an unattributed decision can never collapse to the bare prefix and answer for
+/// every capsule of the principal.
+fn grant_decision_key(capsule_id: &str) -> Option<String> {
+    if capsule_id.is_empty() {
+        return None;
+    }
+    Some(format!("{GRANT_DECISION_KEY_PREFIX}{capsule_id}"))
+}
+
+/// Parse a recorded grant-decision KV value into a [`GrantDecision`].
+///
+/// Pure (no host) so it is unit-testable. Anything that is not exactly one of
+/// the two recognised verbs — garbage, empty, a legacy presence marker, a
+/// truncated write, invalid UTF-8 — yields `None`, which the read path
+/// ([`recorded_grant_decision`]) surfaces as "no decision" so the broker PROMPTS
+/// rather than acting on an unreadable record. Fail toward prompting, never
+/// toward auto-approve.
+fn parse_grant_decision(value: &[u8]) -> Option<GrantDecision> {
+    match std::str::from_utf8(value).map(str::trim).unwrap_or("") {
+        GRANT_DECISION_APPROVE => Some(GrantDecision::Approve),
+        GRANT_DECISION_DENY => Some(GrantDecision::Deny),
+        _ => None,
+    }
+}
+
+/// What (if anything) a `grant.respond` should durably record, given whether it
+/// carried an approve verb.
+///
+/// This is THE recording chokepoint, pure so it is unit-testable without a
+/// host: an approve records [`GrantDecision::Approve`]; a deny records NOTHING.
+/// The shim publishes `deny` on every non-accept path — user decline, elicit
+/// error, elicit timeout, or a client with no elicitation support — with no
+/// provenance to tell them apart, so recording a deny durably would turn a
+/// machinery failure into a permanent auto-deny the user never chose (see the
+/// module doc). A deny therefore stays ephemeral ("not now"): the pending
+/// marker is consumed by the respond handler and the next call re-prompts.
+pub(crate) fn respond_decision_to_record(granted: bool) -> Option<GrantDecision> {
+    if granted {
+        Some(GrantDecision::Approve)
+    } else {
+        None
+    }
+}
+
+/// Record the user's durable grant decision for `capsule_id`.
+///
+/// Called by [`crate::approval::handle_mcp_grant_respond`] — via the
+/// [`respond_decision_to_record`] chokepoint, so in practice only ever with
+/// [`GrantDecision::Approve`] — BEFORE the kernel decision is published, so the
+/// record survives even when the kernel awaiter that prompted the grant has
+/// already expired fail-closed: the next call converges from the record.
+/// Accepts [`GrantDecision::Deny`] for the defence-in-depth read path (module
+/// doc), but no current caller passes it. Best-effort: a write failure is
+/// logged, not fatal, and only costs a re-prompt on the next call (fail toward
+/// prompting). An empty `capsule_id` records nothing.
+pub(crate) fn record_grant_decision(capsule_id: &str, decision: GrantDecision) {
+    let Some(key) = grant_decision_key(capsule_id) else {
+        log::warn(format!(
+            "{}: empty capsule_id; not recording a grant decision",
+            crate::profile::log_tag()
+        ));
+        return;
+    };
+    if let Err(e) = kv::set_bytes(&key, decision.as_kv_value().as_bytes()) {
+        log::warn(format!(
+            "{}: failed to record grant decision for capsule_id '{capsule_id}': {e}",
+            crate::profile::log_tag()
+        ));
+    }
+}
+
+/// Read the durable recorded grant decision for `capsule_id`, or `None` if the
+/// user has not decided (or the record cannot be read / parsed).
+///
+/// Fail toward prompting: a missing key, a KV read error, or an unparseable
+/// value all return `None` so the broker surfaces a fresh consent prompt. It
+/// NEVER returns `Approve` on a read it is unsure about — an auto-approve must
+/// only ever follow a record the user actually created.
+pub(crate) fn recorded_grant_decision(capsule_id: &str) -> Option<GrantDecision> {
+    let key = grant_decision_key(capsule_id)?;
+    match kv::get_bytes_opt(&key) {
+        Ok(Some(bytes)) => parse_grant_decision(&bytes),
+        Ok(None) => None,
+        Err(e) => {
+            log::warn(format!(
+                "{}: grant decision read error for capsule_id '{capsule_id}', \
+                 will prompt: {e}",
+                crate::profile::log_tag()
+            ));
+            None
+        }
+    }
+}
+
+/// Map a recorded-decision read to the broker's [`GrantAction`].
+///
+/// Pure — the KV read happens in [`recorded_grant_decision`]; this is the
+/// testable decision spine (a recorded approve auto-responds, a recorded deny
+/// suppresses, no record prompts).
+pub(crate) fn grant_action(decision: Option<GrantDecision>) -> GrantAction {
+    match decision {
+        Some(GrantDecision::Approve) => GrantAction::AutoApprove,
+        Some(GrantDecision::Deny) => GrantAction::AutoDeny,
+        None => GrantAction::Prompt,
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Terminal `tool.call` reply shaping for the grant-on-use outcomes.
+//
+// Pure (the only host touch is `crate::broker::mcp_content`, itself pure) so the
+// user-facing text and the `isError` contract are unit-testable without a live
+// bus. The broker arm calls these; keeping them here keeps the grant-on-use
+// presentation with its decision logic and keeps `broker.rs` under the size cap.
+// ----------------------------------------------------------------------------
+
+/// Terminal reply for the grant-pending DEDUP: a consent prompt is already open
+/// for this capsule, so instead of stacking a duplicate elicit we return an
+/// actionable message. `isError:false` — a prompt is in flight, not a failure.
+///
+/// The improved text replaces the old opaque "a capsule-access grant prompt is
+/// already pending for this capsule": it now tells the user exactly what to do,
+/// and that a lost prompt is re-asked after the pending TTL. The wait hint is
+/// DERIVED from [`crate::execute::GRANT_PENDING_TTL_MS`] (never hard-coded) so
+/// the guidance cannot drift if the TTL is retuned.
+pub(crate) fn grant_dedup_reply(req_id: &str) -> Value {
+    grant_reply(
+        req_id,
+        format!(
+            "{}: a consent prompt for this capsule is open in your client. Answer \
+             it and retry; if it never appeared, retry after {} and it will be re-asked.",
+            crate::profile::log_tag(),
+            ttl_hint(crate::execute::GRANT_PENDING_TTL_MS)
+        ),
+        false,
+    )
+}
+
+/// Render a TTL in milliseconds as the human wait hint the dedup reply carries:
+/// whole minutes when the TTL divides evenly into them, else whole seconds
+/// (rounded UP, so the hint never advises retrying before the marker can have
+/// expired). Pure, so the formatting is unit-testable and the reply text stays
+/// pinned to the real constant.
+fn ttl_hint(ttl_ms: u64) -> String {
+    const MS_PER_MINUTE: u64 = 60_000;
+    if ttl_ms > 0 && ttl_ms.is_multiple_of(MS_PER_MINUTE) {
+        let minutes = ttl_ms / MS_PER_MINUTE;
+        if minutes == 1 {
+            "~1 minute".to_string()
+        } else {
+            format!("~{minutes} minutes")
+        }
+    } else {
+        format!("~{} seconds", ttl_ms.div_ceil(1_000))
+    }
+}
+
+/// Terminal reply after a DURABLE recorded APPROVE auto-answered the kernel grant
+/// gate: the grant is applied against a fresh, live awaiter, so the re-sent call
+/// converges. `isError:false` — access was granted, not a failure.
+pub(crate) fn grant_auto_approve_reply(req_id: &str, capsule_id: &str) -> Value {
+    grant_reply(
+        req_id,
+        format!(
+            "{}: session access to capsule '{capsule_id}' is already approved for \
+             this identity; the grant has been applied. Retry the tool call.",
+            crate::profile::log_tag()
+        ),
+        false,
+    )
+}
+
+/// Terminal reply after a DURABLE recorded DENY suppressed the grant prompt: the
+/// user denied this capsule, so the call cannot proceed. `isError:true`, with the
+/// operator escape hatch.
+pub(crate) fn grant_auto_deny_reply(req_id: &str, capsule_id: &str, principal: &str) -> Value {
+    let who = if principal.is_empty() {
+        "<principal>"
+    } else {
+        principal
+    };
+    grant_reply(
+        req_id,
+        format!(
+            "{}: session access to capsule '{capsule_id}' was denied for this \
+             identity. An operator can allow it with: aos --principal default agent modify {who} \
+             --add-capsule {capsule_id} (or later revoke a grant with --remove-capsule).",
+            crate::profile::log_tag()
+        ),
+        true,
+    )
+}
+
+/// Terminal reply when a recorded approve could NOT be applied because the kernel
+/// request_id was unroutable. Defensive: a kernel-minted UUID is always routable,
+/// but if that ever changed we must NOT return the retry-hint reply (the caller
+/// would spin retrying a grant that can never publish) — `isError:true` breaks
+/// the loop and points at the operator escape hatch.
+pub(crate) fn grant_unroutable_reply(req_id: &str, capsule_id: &str) -> Value {
+    grant_reply(
+        req_id,
+        format!(
+            "{}: could not apply the recorded grant for capsule '{capsule_id}' \
+             (unroutable kernel request id). Re-grant it, or an operator can run: \
+             aos --principal default agent modify <principal> --add-capsule {capsule_id}.",
+            crate::profile::log_tag()
+        ),
+        true,
+    )
+}
+
+/// Shape a terminal `tool.call` reply with the broker's standard content
+/// encoding, so every grant-outcome reply agrees on the envelope.
+fn grant_reply(req_id: &str, message: String, is_error: bool) -> Value {
+    json!({
+        "kind": "tool.call",
+        "req_id": req_id,
+        "content": crate::broker::mcp_content(Value::String(message)),
+        "isError": is_error,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    fn install_test_profile() {
+        crate::profile::install_aos();
+    }
+
+    use super::*;
+
+    #[test]
+    fn grant_decision_key_applies_prefix_on_capsule_only() {
+        install_test_profile();
+        // KV is per-principal-scoped, so the suffix is the capsule id alone; the
+        // principal is implicit in the storage scope, mirroring grant_pending_key.
+        assert_eq!(
+            grant_decision_key("fs").as_deref(),
+            Some("mcp.grant.decision.fs")
+        );
+    }
+
+    #[test]
+    fn grant_decision_key_rejects_empty_capsule() {
+        install_test_profile();
+        // An empty capsule id must never resolve to a routable key, or one record
+        // would answer for every capsule of the principal.
+        assert_eq!(grant_decision_key(""), None);
+    }
+
+    #[test]
+    fn parse_grant_decision_reads_recognised_verbs() {
+        install_test_profile();
+        assert_eq!(
+            parse_grant_decision(b"approve"),
+            Some(GrantDecision::Approve)
+        );
+        assert_eq!(parse_grant_decision(b"deny"), Some(GrantDecision::Deny));
+        // Whitespace-tolerant, mirroring the marker parser.
+        assert_eq!(
+            parse_grant_decision(b"  approve\n"),
+            Some(GrantDecision::Approve)
+        );
+    }
+
+    #[test]
+    fn parse_grant_decision_unknown_is_none_fail_toward_prompt() {
+        install_test_profile();
+        // Garbage, empty, a legacy presence marker, a partial write, or invalid
+        // UTF-8 all read as "no decision" so the broker prompts rather than
+        // acting on an unreadable record — never silently auto-approving.
+        assert_eq!(parse_grant_decision(b""), None);
+        assert_eq!(parse_grant_decision(b"1"), None);
+        assert_eq!(parse_grant_decision(b"approved"), None);
+        assert_eq!(parse_grant_decision(b"yes"), None);
+        assert_eq!(parse_grant_decision(&[0xff, 0xfe]), None);
+    }
+
+    #[test]
+    fn grant_decision_kv_value_roundtrips() {
+        install_test_profile();
+        // The value written is exactly what parse reads back.
+        assert_eq!(
+            parse_grant_decision(GrantDecision::Approve.as_kv_value().as_bytes()),
+            Some(GrantDecision::Approve)
+        );
+        assert_eq!(
+            parse_grant_decision(GrantDecision::Deny.as_kv_value().as_bytes()),
+            Some(GrantDecision::Deny)
+        );
+    }
+
+    #[test]
+    fn grant_action_maps_recorded_decision() {
+        install_test_profile();
+        // The crux decision spine: a recorded approve auto-responds (respond, not
+        // elicit); a recorded deny suppresses the prompt (defence-in-depth — no
+        // current respond path writes one, see respond_records_approve_only);
+        // no record prompts.
+        assert_eq!(
+            grant_action(Some(GrantDecision::Approve)),
+            GrantAction::AutoApprove
+        );
+        assert_eq!(
+            grant_action(Some(GrantDecision::Deny)),
+            GrantAction::AutoDeny
+        );
+        assert_eq!(grant_action(None), GrantAction::Prompt);
+    }
+
+    #[test]
+    fn respond_records_approve_only_never_deny() {
+        install_test_profile();
+        // REGRESSION: the shim's resolve_grant publishes `deny` on EVERY
+        // non-accept path — user decline, elicit error, elicit timeout, or a
+        // client with no elicitation capability — and the respond body carries
+        // no provenance to tell them apart. A deny must therefore record
+        // NOTHING durable (ephemeral "not now"; the pending marker clears and
+        // the next call re-prompts), or a timed-out dialog / plain MCP client
+        // would permanently auto-deny a capsule the user never answered on.
+        // Only an approve is durably recorded.
+        assert_eq!(
+            respond_decision_to_record(true),
+            Some(GrantDecision::Approve)
+        );
+        assert_eq!(respond_decision_to_record(false), None);
+    }
+
+    #[test]
+    fn grant_action_composes_with_parse() {
+        install_test_profile();
+        // End to end over the pure spine (parse -> action) as the broker runs it,
+        // minus the host KV read: a stored "approve" chooses AutoApprove
+        // (respond), a stored "deny" chooses AutoDeny (suppress), an unreadable
+        // value prompts.
+        assert_eq!(
+            grant_action(parse_grant_decision(b"approve")),
+            GrantAction::AutoApprove
+        );
+        assert_eq!(
+            grant_action(parse_grant_decision(b"deny")),
+            GrantAction::AutoDeny
+        );
+        assert_eq!(
+            grant_action(parse_grant_decision(b"garbage")),
+            GrantAction::Prompt
+        );
+    }
+
+    /// Pull the single text content block out of a grant-outcome reply.
+    fn reply_text(reply: &Value) -> String {
+        reply
+            .pointer("/content/0/text")
+            .and_then(Value::as_str)
+            .expect("grant reply must carry one text content block")
+            .to_string()
+    }
+
+    #[test]
+    fn grant_dedup_reply_is_actionable_not_an_error() {
+        install_test_profile();
+        let reply = grant_dedup_reply("req-d");
+        // A prompt in flight is not a failure — isError must stay false so the
+        // client treats it as a normal (retriable) result.
+        assert_eq!(
+            reply.pointer("/isError").and_then(Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            reply.pointer("/req_id").and_then(Value::as_str),
+            Some("req-d")
+        );
+        // The improved D text: tell the user what to do, and that a lost prompt
+        // is re-asked after the TTL — not the old opaque "already pending".
+        let text = reply_text(&reply);
+        assert!(text.contains("open in your client"), "text was {text:?}");
+        assert!(text.contains("retry"), "text was {text:?}");
+        assert!(text.contains("re-asked"), "text was {text:?}");
+        assert!(
+            !text.contains("already pending"),
+            "must not keep the old opaque text: {text:?}"
+        );
+    }
+
+    #[test]
+    fn grant_dedup_reply_wait_hint_derives_from_pending_ttl() {
+        install_test_profile();
+        // The wait hint must be DERIVED from the real TTL constant, never a
+        // re-hard-coded literal: this asserts the derived rendering of
+        // GRANT_PENDING_TTL_MS appears, so it fails if someone changes the
+        // constant while the reply text stays behind (or inlines a literal).
+        let expected = ttl_hint(crate::execute::GRANT_PENDING_TTL_MS);
+        let text = reply_text(&grant_dedup_reply("req-d"));
+        assert!(
+            text.contains(&format!("retry after {expected} ")),
+            "hint {expected:?} missing from {text:?}"
+        );
+    }
+
+    #[test]
+    fn ttl_hint_renders_minutes_or_ceil_seconds() {
+        install_test_profile();
+        // Whole minutes when the TTL divides evenly (the current 120s TTL reads
+        // "~2 minutes"), singular at exactly one minute, else whole seconds
+        // rounded UP so the hint never advises retrying before the marker can
+        // have expired. Zero degrades to seconds, not "0 minutes".
+        assert_eq!(ttl_hint(120_000), "~2 minutes");
+        assert_eq!(ttl_hint(60_000), "~1 minute");
+        assert_eq!(ttl_hint(90_000), "~90 seconds");
+        assert_eq!(ttl_hint(90_500), "~91 seconds");
+        assert_eq!(ttl_hint(0), "~0 seconds");
+    }
+
+    #[test]
+    fn grant_auto_approve_reply_names_capsule_and_asks_retry() {
+        install_test_profile();
+        let reply = grant_auto_approve_reply("req-a", "fs");
+        // Access granted -> not an error; a retry converges.
+        assert_eq!(
+            reply.pointer("/isError").and_then(Value::as_bool),
+            Some(false)
+        );
+        let text = reply_text(&reply);
+        assert!(text.contains("'fs'"), "text was {text:?}");
+        assert!(text.contains("already approved"), "text was {text:?}");
+        assert!(text.contains("Retry"), "text was {text:?}");
+    }
+
+    #[test]
+    fn grant_auto_deny_reply_is_error_with_operator_path() {
+        install_test_profile();
+        let reply = grant_auto_deny_reply("req-x", "system", "claude-code");
+        // A denied capsule is a hard failure for the call.
+        assert_eq!(
+            reply.pointer("/isError").and_then(Value::as_bool),
+            Some(true)
+        );
+        let text = reply_text(&reply);
+        assert!(text.contains("'system'"), "text was {text:?}");
+        assert!(text.contains("denied"), "text was {text:?}");
+        // The actionable operator escape hatch, with the resolved principal.
+        assert!(
+            text.contains("aos --principal default agent modify claude-code --add-capsule system"),
+            "text was {text:?}"
+        );
+    }
+
+    #[test]
+    fn grant_auto_deny_reply_placeholder_principal_when_unknown() {
+        install_test_profile();
+        // An empty principal degrades to a readable placeholder, never a blank
+        // command the operator cannot run.
+        let reply = grant_auto_deny_reply("req-x", "system", "");
+        let text = reply_text(&reply);
+        assert!(
+            text.contains("aos --principal default agent modify <principal> --add-capsule system"),
+            "text was {text:?}"
+        );
+    }
+
+    #[test]
+    fn grant_unroutable_reply_is_error_breaks_retry_loop() {
+        install_test_profile();
+        // The defensive path must be an error, not the auto-approve retry-hint,
+        // or the caller would spin retrying a grant that can never publish.
+        let reply = grant_unroutable_reply("req-u", "fs");
+        assert_eq!(
+            reply.pointer("/isError").and_then(Value::as_bool),
+            Some(true)
+        );
+        assert!(reply_text(&reply).contains("'fs'"));
+    }
+}

--- a/crates/aos-mcp-broker/src/hook_gate.rs
+++ b/crates/aos-mcp-broker/src/hook_gate.rs
@@ -1,0 +1,266 @@
+//! Native-tool `before_tool_call` verdict responder — aos-mcp as a
+//! `ToolCallBefore` merge participant.
+//!
+//! This is the SECOND plane of the same per-principal PDP. The broker
+//! ([`crate::broker`]) gates the `mcp__aos__*` tool plane in-process and
+//! un-bypassably. This module gates Claude's NATIVE tools (`Bash`, `Write`,
+//! …), which execute inside the agent process and reach no in-process
+//! chokepoint — the only lever there is the agent's PreToolUse hook. Both
+//! planes evaluate the SAME [`crate::policy`] rule set; one operator policy,
+//! two transports.
+//!
+//! ## Wire contract (the hook-bridge `ToolCallBefore` fan-out)
+//!
+//! * **inbound** `hook.v1.event.before_tool_call` — a fan-out request
+//!   carrying `{ hook, payload, correlation_id? }`. `payload` is the
+//!   tool-call info (`{ tool_name, tool_input, … }`). The publisher is
+//!   either the kernel hook-bridge (a bus-mediated lifecycle event) or an
+//!   external `astrid-gate` PreToolUse hook (the native-tool path) — the
+//!   responder does not care which.
+//! * **outbound** `hook.v1.response.before_tool_call.<correlation_id>` —
+//!   `{ skip: bool, reason? }`. Per [`astrid_capsule_hook_bridge`]'s
+//!   `ToolCallBefore` merge, **any** responder returning `skip:true` blocks
+//!   the call (deny-wins), so a deny here is binding regardless of other
+//!   participants.
+//!
+//! A request with **no** `correlation_id` is a fire-and-forget / observe
+//! fan-out (no reply expected); the responder evaluates nothing and stays
+//! silent. Only a correlation-keyed request is a decision request.
+//!
+//! ## Relationship to the broker's mcp_tool gate
+//!
+//! The broker's [`crate::broker::pretooluse_gate_reply`] is the MVP native
+//! gate (Claude's `mcp_tool` PreToolUse hook → broker → policy). This
+//! responder is the production transport the `astrid-gate` binary drives. The
+//! two never double-fire: the mcp_tool gate answers `astrid.v1.request.mcp.
+//! tool.call`, this answers `hook.v1.event.before_tool_call` — different
+//! topics. When `astrid-gate` lands and host install migrates the hook
+//! authoring `mcp_tool → astrid-gate`, the mcp_tool gate retires and this
+//! becomes the live native-tool path.
+
+use astrid_sdk::prelude::*;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+/// Reply topic prefix; the egress topic is `<prefix><correlation_id>`.
+const REPLY_PREFIX: &str = "hook.v1.response.before_tool_call.";
+
+/// Correlation-id length cap — a UUID-ish token; anything longer is rejected
+/// before it can be stamped into an egress topic. Same family as the
+/// broker's `req_id` gate.
+const MAX_CORRELATION_LEN: usize = 128;
+
+/// Inbound `hook.v1.event.before_tool_call` request.
+///
+/// Mirrors the hook-bridge `HookEventRequest` shape (`hook`, `payload`,
+/// `correlation_id`); we only read `payload` + `correlation_id`. Any other
+/// fields are ignored (forward-compat).
+#[derive(Debug, Deserialize)]
+struct BeforeToolCallEvent {
+    #[serde(default)]
+    payload: Value,
+    #[serde(default)]
+    correlation_id: Option<String>,
+}
+
+/// Handle a `hook.v1.event.before_tool_call` fan-out.
+///
+/// Evaluates the native tool named in the payload against the invoking
+/// principal's [`crate::policy`] rule set and, when a correlation id is
+/// present, replies `{ skip }` on the correlation topic. A `Deny` →
+/// `skip:true` (blocks the tool); an `Allow` (incl. the no-rule /
+/// load-failure default) → `skip:false` (defers to the agent's own
+/// permission flow). Every failure path stays silent rather than erroring —
+/// a broken responder must not wedge the fan-out, and a missing reply simply
+/// means "no opinion" to the merge.
+pub(crate) fn handle_before_tool_call(payload: Value) -> Result<(), SysError> {
+    let event: BeforeToolCallEvent = match serde_json::from_value(payload) {
+        Ok(v) => v,
+        Err(e) => {
+            log::warn(format!(
+                "{}: before_tool_call: malformed event payload: {e}",
+                crate::profile::log_tag()
+            ));
+            return Ok(());
+        }
+    };
+
+    // No correlation id → observe/fire-and-forget fan-out (e.g. the kernel
+    // bridge with no responder expected). Nothing to answer.
+    let Some(correlation_id) = event.correlation_id.as_deref() else {
+        return Ok(());
+    };
+    let Some(reply_topic) = reply_topic(correlation_id) else {
+        log::warn(format!(
+            "{}: before_tool_call: rejecting unroutable correlation_id '{correlation_id}'",
+            crate::profile::log_tag()
+        ));
+        return Ok(());
+    };
+
+    let tool_name = event
+        .payload
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let tool_input = crate::broker::gate_tool_input(&event.payload);
+
+    let reply = verdict(tool_name, &tool_input);
+
+    if let Err(e) = ipc::publish_json(&reply_topic, &reply) {
+        log::warn(format!(
+            "{}: before_tool_call: failed to reply on {reply_topic}: {e}",
+            crate::profile::log_tag()
+        ));
+    }
+    Ok(())
+}
+
+/// Evaluate one native tool call and shape the `ToolCallBefore` reply. The
+/// host calls (policy load, deny audit, log) live here; the pure
+/// decision→reply mapping is [`verdict_body`] so it stays unit-testable.
+fn verdict(tool_name: &str, tool_input: &Value) -> Value {
+    let decision = crate::policy::evaluate(&crate::policy::load_rules(), tool_name, tool_input);
+    if let crate::policy::Decision::Deny { reason } = &decision {
+        log::info(format!(
+            "{}: before_tool_call denied native tool '{tool_name}': {reason}",
+            crate::profile::log_tag()
+        ));
+        // Audit on the same `astrid.v1.audit.*` family the other gate uses.
+        // Operator rule id only — never reflected arguments (injection).
+        let _ = ipc::publish_json(
+            &crate::profile::audit_topic("pretooluse_deny"),
+            &json!({ "tool": tool_name, "rule": reason }),
+        );
+    }
+    verdict_body(&decision)
+}
+
+/// Pure decision → `ToolCallBefore` reply. No host calls — unit-testable.
+///
+/// `Deny` → `{ skip: true, reason }` (blocks; `reason` is the operator rule
+/// id, surfaced for the merge's logging, not a reflected argument). `Allow`
+/// → `{ skip: false }` (no veto; the agent's own permission flow decides).
+/// It only ever NARROWS — `skip:false` is not an assertion that the tool is
+/// safe, only that THIS policy has no objection.
+fn verdict_body(decision: &crate::policy::Decision) -> Value {
+    match decision {
+        crate::policy::Decision::Deny { reason } => json!({ "skip": true, "reason": reason }),
+        crate::policy::Decision::Allow => json!({ "skip": false }),
+    }
+}
+
+/// Build the single-segment egress topic for `correlation_id`, or `None` if
+/// it cannot form a clean single segment. Rejects empty, oversized, and any
+/// id carrying a `.` (which would over-extend the egress topic) or
+/// whitespace / control / wildcard bytes (which would forge or shadow
+/// topics). Same charset family the broker's `reply_topic` uses.
+fn reply_topic(correlation_id: &str) -> Option<String> {
+    if correlation_id.is_empty() || correlation_id.len() > MAX_CORRELATION_LEN {
+        return None;
+    }
+    let clean = correlation_id
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-'));
+    if !clean {
+        return None;
+    }
+    Some(format!("{REPLY_PREFIX}{correlation_id}"))
+}
+
+#[cfg(test)]
+mod tests {
+    fn install_test_profile() {
+        crate::profile::install_aos();
+    }
+
+    use super::*;
+
+    #[test]
+    fn deny_skips_with_rule_reason() {
+        install_test_profile();
+        let body = verdict_body(&crate::policy::Decision::Deny {
+            reason: "no-ssh-write".into(),
+        });
+        assert_eq!(body.pointer("/skip").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            body.pointer("/reason").and_then(Value::as_str),
+            Some("no-ssh-write")
+        );
+    }
+
+    #[test]
+    fn allow_does_not_skip_and_never_broadens() {
+        install_test_profile();
+        let body = verdict_body(&crate::policy::Decision::Allow);
+        // skip:false = "no objection", never an assertion of safety.
+        assert_eq!(body.pointer("/skip").and_then(Value::as_bool), Some(false));
+        assert!(
+            body.pointer("/reason").is_none(),
+            "allow must not carry a reason"
+        );
+    }
+
+    #[test]
+    fn reply_topic_accepts_uuid_and_rejects_smuggling() {
+        install_test_profile();
+        assert_eq!(
+            reply_topic("0191f3a2b4c74d8e9f01234567890abc").as_deref(),
+            Some("hook.v1.response.before_tool_call.0191f3a2b4c74d8e9f01234567890abc")
+        );
+        assert!(reply_topic("0191f3a2-b4c7-4d8e-9f01-234567890abc").is_some());
+        // A `.` would over-extend the egress topic; wildcards / whitespace
+        // forge or shadow topics; empty / oversize are rejected.
+        assert!(reply_topic("a.b").is_none());
+        assert!(reply_topic("a*b").is_none());
+        assert!(reply_topic("a b").is_none());
+        assert!(reply_topic("").is_none());
+        assert!(reply_topic(&"a".repeat(MAX_CORRELATION_LEN + 1)).is_none());
+    }
+
+    #[test]
+    fn event_without_correlation_id_deserializes_as_observe() {
+        install_test_profile();
+        // No correlation_id present → the handler treats it as observe-only
+        // and never replies. Confirm the shape parses with it absent.
+        let event: BeforeToolCallEvent = serde_json::from_value(json!({
+            "hook": "before_tool_call",
+            "payload": { "tool_name": "Bash", "tool_input": { "command": "ls" } }
+        }))
+        .unwrap();
+        assert!(event.correlation_id.is_none());
+        assert_eq!(
+            event.payload.pointer("/tool_name").and_then(Value::as_str),
+            Some("Bash")
+        );
+    }
+
+    #[test]
+    fn end_to_end_pure_spine_denies_matching_native_tool() {
+        install_test_profile();
+        // gate_tool_input -> evaluate -> verdict_body, minus host calls.
+        let rules = vec![crate::policy::Rule {
+            id: "no-rm-rf".into(),
+            effect: crate::policy::Effect::Deny,
+            tool: "Bash".into(),
+            when: vec![crate::policy::ArgMatcher {
+                pointer: "/command".into(),
+                op: crate::policy::MatchOp::Contains,
+                value: "rm -rf".into(),
+            }],
+        }];
+        let payload = json!({ "tool_name": "Bash", "tool_input": { "command": "rm -rf /tmp" } });
+        let tool_input = crate::broker::gate_tool_input(&payload);
+        let decision = crate::policy::evaluate(
+            &rules,
+            payload.get("tool_name").and_then(Value::as_str).unwrap(),
+            &tool_input,
+        );
+        assert_eq!(
+            verdict_body(&decision)
+                .pointer("/skip")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+    }
+}

--- a/crates/aos-mcp-broker/src/identity.rs
+++ b/crates/aos-mcp-broker/src/identity.rs
@@ -1,0 +1,36 @@
+//! Fixed AOS product identity for the MCP broker.
+
+/// Product identity used by the single AOS MCP broker capsule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct McpIdentity {
+    /// Capsule component id.
+    pub capsule_name: &'static str,
+    /// Full MCP tool prefix including the trailing separator.
+    pub mcp_tool_prefix: &'static str,
+    /// Log tag.
+    pub log_tag: &'static str,
+    /// Tool-list publication topic.
+    pub tools_list_topic: &'static str,
+    /// Audit topic prefix.
+    pub audit_topic_prefix: &'static str,
+}
+
+impl McpIdentity {
+    /// The singleton product identity.
+    pub const AOS: Self = Self {
+        capsule_name: "aos-mcp",
+        mcp_tool_prefix: "mcp__aos__",
+        log_tag: "aos-mcp",
+        tools_list_topic: "astrid.v1.tools.list",
+        audit_topic_prefix: "astrid.v1.audit.",
+    };
+
+    /// Build a full audit topic.
+    #[must_use]
+    pub fn audit_topic(self, event: &str) -> String {
+        let mut topic = String::with_capacity(self.audit_topic_prefix.len() + event.len());
+        topic.push_str(self.audit_topic_prefix);
+        topic.push_str(event);
+        topic
+    }
+}

--- a/crates/aos-mcp-broker/src/lib.rs
+++ b/crates/aos-mcp-broker/src/lib.rs
@@ -1,0 +1,73 @@
+//! AOS-owned MCP broker over Astrid Runtime's neutral event bus.
+
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+#![deny(unreachable_pub)]
+#![warn(missing_docs)]
+
+mod approval;
+mod broker;
+mod cache;
+mod discovery;
+mod execute;
+mod grant_decision;
+mod hook_gate;
+mod identity;
+mod policy;
+mod profile;
+
+pub use identity::McpIdentity;
+pub use profile::install_aos;
+
+/// Capsule entry points used by the thin `aos-mcp` component.
+pub mod handlers {
+    use astrid_sdk::prelude::*;
+
+    /// Assemble and publish the tool list.
+    pub fn describe_tools(_payload: serde_json::Value) -> Result<(), SysError> {
+        crate::discovery::describe_tools();
+        Ok(())
+    }
+
+    /// Merge an event-driven tool descriptor response.
+    pub fn collect_tool_descriptors(payload: serde_json::Value) -> Result<(), SysError> {
+        crate::discovery::collect_tool_descriptors(payload);
+        Ok(())
+    }
+
+    /// Invalidate tool discovery after the loaded capsule set changes.
+    pub fn handle_capsules_changed(payload: serde_json::Value) -> Result<(), SysError> {
+        crate::discovery::on_capsules_loaded(payload);
+        Ok(())
+    }
+
+    /// Handle `astrid.v1.request.mcp.tools.list`.
+    pub fn handle_mcp_list(payload: serde_json::Value) -> Result<(), SysError> {
+        crate::broker::handle_mcp_list(payload)
+    }
+
+    /// Handle `astrid.v1.request.mcp.tool.call`.
+    pub fn handle_mcp_call(payload: serde_json::Value) -> Result<(), SysError> {
+        crate::broker::handle_mcp_call(payload)
+    }
+
+    /// Handle constrained capability approval decisions.
+    pub fn handle_mcp_approval(payload: serde_json::Value) -> Result<(), SysError> {
+        crate::approval::handle_mcp_approval(payload)
+    }
+
+    /// Handle ingress-consent decisions.
+    pub fn handle_mcp_ingress_respond(payload: serde_json::Value) -> Result<(), SysError> {
+        crate::approval::handle_mcp_ingress_respond(payload)
+    }
+
+    /// Handle capsule-grant decisions.
+    pub fn handle_mcp_grant_respond(payload: serde_json::Value) -> Result<(), SysError> {
+        crate::approval::handle_mcp_grant_respond(payload)
+    }
+
+    /// Handle native host tool-call policy hooks.
+    pub fn handle_before_tool_call(payload: serde_json::Value) -> Result<(), SysError> {
+        crate::hook_gate::handle_before_tool_call(payload)
+    }
+}

--- a/crates/aos-mcp-broker/src/policy.rs
+++ b/crates/aos-mcp-broker/src/policy.rs
@@ -1,0 +1,542 @@
+//! Per-principal policy decision point (PDP) for supervised `claude -p`
+//! tool calls — the binding argument-level gate.
+//!
+//! # Two planes, one rule engine
+//!
+//! Every `mcp__aos__*` tool the supervised Claude invokes funnels through
+//! [`crate::broker::handle_mcp_call`] before
+//! [`crate::execute::dispatch_with_approval`] fans it out on the bus. That
+//! is the ONE capsule-space point that holds the parsed `(tool_name,
+//! arguments)` and can refuse to dispatch, so for that plane the PDP is
+//! evaluated there UNCONDITIONALLY and IN-PROCESS: the broker chokepoint
+//! cannot be routed around — the tool literally cannot execute without
+//! passing it.
+//!
+//! Claude's NATIVE tools (`Bash`, `Write`, …) reach no such chokepoint —
+//! they execute inside the `claude` process. The only per-call lever for
+//! them is a PreToolUse `type:"mcp_tool"` hook, which calls back into this
+//! SAME [`evaluate`] via the reserved [`crate::broker::PRETOOLUSE_GATE_TOOL`].
+//! That path is honestly ADVISORY: the hook is read from a settings tier a
+//! capable session can edit, the gate call is one Claude could skip, and the
+//! platform fails open. So it is defence-in-depth on top of the host sandbox
+//! and the binding `--disallowedTools` deny-list — never a substitute for
+//! the in-process gate the `mcp__aos__*` plane enjoys. One operator rule
+//! set, two enforcement strengths.
+//!
+//! # What it adds over the host capability PEP (non-redundancy)
+//!
+//! The kernel enforces CAPABILITIES at execution time
+//! (`request_approval`): "may this principal's tool make this
+//! capability-gated host call at all". That is coarse and ARGUMENT-BLIND
+//! — a granted `fs_write` scope approves every path inside it; a granted
+//! `host_process` cap approves every argv. This PDP adds the
+//! INTRA-capability, argument-level layer the capability model cannot
+//! express. It only ever NARROWS: the default is [`Decision::Allow`], so a
+//! PDP that finds no matching rule (or fails to load) degrades to the
+//! existing capability enforcement — never to "anything goes".
+//!
+//! # Honest limits (do NOT oversell this)
+//!
+//! * DENY rules over free-form strings (a shell command, a VFS path) are
+//!   BEST-EFFORT, not a guarantee. They match the RAW argument value; the
+//!   kernel resolves `home://` host-side, so a path deny on the
+//!   pre-resolution literal is evadable (`home://./x`, `home://a/../x`),
+//!   and a command deny is evadable by quoting / encoding. The ROBUST
+//!   shapes are ALLOWLIST-style (`eq` / `prefix` against a closed set,
+//!   e.g. an egress-host allowlist), not denylists.
+//! * The reachable surface is the `mcp__aos__*` capsule tools Claude is
+//!   allowed; the built-in shell/file tools are already removed by
+//!   `REQUIRED_DENIES`, so a `rm -rf` rule guards a tool that may not even
+//!   exist in the surface.
+//! * The rule `reason` surfaced back to Claude is the operator's static
+//!   `id`, NEVER a reflected argument substring — reflecting attacker-
+//!   influenced args into the model's context is an injection vector.
+//! * Matchers are linear (`eq`/`prefix`/`contains`/`glob`) — NO regex —
+//!   so an attacker-influenced argument cannot trigger ReDoS on the
+//!   tool-call hot path.
+
+use astrid_sdk::prelude::*;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Manifest `[env]` key holding the per-principal policy rule set (a JSON
+/// array of [`Rule`]). Read via [`astrid_sdk::env::var_opt`] at decision
+/// time, so it resolves the invoking principal's overlay — per-principal
+/// rules with no cross-capsule KV write.
+const POLICY_RULES_ENV: &str = "policy_rules";
+
+/// Cap on the number of rules accepted from the `[env]` value. A fat-
+/// fingered or hostile rule blob must not be able to make the
+/// per-tool-call evaluation loop unbounded.
+const MAX_RULES: usize = 256;
+
+/// Cap on a single matcher's `value` / a rule's `tool` glob length. Bounds
+/// the linear matcher cost and rejects kilobyte patterns.
+const MAX_PATTERN_LEN: usize = 512;
+
+/// Cap on a JSON-pointer length. Pointers index into the tool arguments;
+/// a pathological pointer is rejected at load.
+const MAX_POINTER_LEN: usize = 256;
+
+/// What a matched rule does. v1 is deny/allow only — `ask` is deliberately
+/// omitted because surfacing an interactive prompt needs an elicitation
+/// primitive the broker cannot call synchronously here; deny + a clear
+/// reason is the v1 fail-secure verb.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Effect {
+    /// Refuse the tool call — the broker replies `isError` and never
+    /// dispatches.
+    Deny,
+    /// Permit the tool call (an explicit allow short-circuits later deny
+    /// rules — first-match-wins).
+    Allow,
+}
+
+/// One argument predicate. ALL of a rule's matchers must hold (AND) for
+/// the rule to fire; an empty matcher list makes the rule purely
+/// tool-name scoped.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct ArgMatcher {
+    /// RFC-6901 JSON pointer into the tool `arguments` object (e.g.
+    /// `/path`, `/command`, `/url`).
+    pub pointer: String,
+    /// The comparison applied to the value at `pointer`.
+    pub op: MatchOp,
+    /// The operand. For `glob`, `*` matches any run and `?` any single
+    /// character.
+    pub value: String,
+}
+
+/// Argument comparison operators. All linear / backtrack-free — no regex,
+/// so an attacker-influenced argument cannot induce ReDoS.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum MatchOp {
+    /// Exact string equality.
+    Eq,
+    /// The value starts with the operand.
+    Prefix,
+    /// The value contains the operand as a substring.
+    Contains,
+    /// `*` / `?` wildcard match (linear two-pointer, no backtracking).
+    Glob,
+}
+
+/// One declarative rule. Operator-authored; never agent-authored.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct Rule {
+    /// Stable operator-chosen id. Surfaced to Claude as the deny reason —
+    /// it MUST NOT embed argument values (injection).
+    pub id: String,
+    /// Effect when this rule fires.
+    pub effect: Effect,
+    /// Glob over the RAW tool name (no `mcp__aos__` prefix — the broker
+    /// receives raw names). `*` matches any run, `?` any character.
+    pub tool: String,
+    /// Argument predicates; ALL must hold. Empty = tool-scoped rule.
+    #[serde(default)]
+    pub when: Vec<ArgMatcher>,
+}
+
+/// The PDP verdict for one tool call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Decision {
+    /// Permit — the broker proceeds to dispatch (capability enforcement
+    /// still applies at execution time).
+    Allow,
+    /// Refuse — the broker replies `isError` with `reason` (the rule id)
+    /// and never dispatches.
+    Deny {
+        /// The matched rule's `id`. Sanitized by construction (operator
+        /// string, no reflected args).
+        reason: String,
+    },
+}
+
+/// Evaluate `rules` against one tool call. First-match-wins over the
+/// ordered list; the default is [`Decision::Allow`] so the PDP only ever
+/// narrows the surface the capability PEP already guards.
+///
+/// Pure and total: no host calls, no panics, no allocation beyond the
+/// returned reason string. Fully unit-testable without a live bus.
+pub(crate) fn evaluate(rules: &[Rule], tool_name: &str, arguments: &Value) -> Decision {
+    for rule in rules {
+        if !glob_match(&rule.tool, tool_name) {
+            continue;
+        }
+        if rule.when.iter().all(|m| matcher_holds(m, arguments)) {
+            return match rule.effect {
+                Effect::Deny => Decision::Deny {
+                    reason: rule.id.clone(),
+                },
+                Effect::Allow => Decision::Allow,
+            };
+        }
+    }
+    Decision::Allow
+}
+
+/// True when the matcher's operator relates the value at its pointer to
+/// its operand. A pointer that does not resolve, or resolves to a
+/// non-string scalar, is rendered to a string first (numbers/bools) or
+/// fails to match (objects/arrays/null) — so a rule can only ever ACT on
+/// a value it can actually see, and a missing argument never accidentally
+/// satisfies a deny.
+fn matcher_holds(matcher: &ArgMatcher, arguments: &Value) -> bool {
+    let Some(target) = arguments.pointer(&matcher.pointer) else {
+        return false;
+    };
+    let value = match target {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        // Null / array / object have no meaningful string form to match
+        // against here; treat as "no match" rather than stringifying so a
+        // deny can't fire on an unintended shape.
+        _ => return false,
+    };
+    match matcher.op {
+        MatchOp::Eq => value == matcher.value,
+        MatchOp::Prefix => value.starts_with(&matcher.value),
+        MatchOp::Contains => value.contains(&matcher.value),
+        MatchOp::Glob => glob_match(&matcher.value, &value),
+    }
+}
+
+/// Linear `*`/`?` glob match (classic two-pointer wildcard algorithm).
+///
+/// `*` matches any run (including empty), `?` matches exactly one
+/// character. There is no alternation or repetition operator, so the
+/// worst case is O(pattern × text) with a single backtrack pointer — it
+/// cannot blow up the way a backtracking regex can.
+fn glob_match(pattern: &str, text: &str) -> bool {
+    let pat: Vec<char> = pattern.chars().collect();
+    let txt: Vec<char> = text.chars().collect();
+    let (mut p, mut t) = (0usize, 0usize);
+    // Backtrack anchors: the last `*` position and the text index to
+    // resume from when a tentative match fails.
+    let (mut star, mut resume): (Option<usize>, usize) = (None, 0);
+
+    while t < txt.len() {
+        if p < pat.len() && (pat[p] == '?' || pat[p] == txt[t]) {
+            p += 1;
+            t += 1;
+        } else if p < pat.len() && pat[p] == '*' {
+            star = Some(p);
+            resume = t;
+            p += 1;
+        } else if let Some(sp) = star {
+            // Mismatch under a prior `*` — let the `*` absorb one more
+            // character and retry.
+            p = sp + 1;
+            resume += 1;
+            t = resume;
+        } else {
+            return false;
+        }
+    }
+    // Trailing `*`s match the empty remainder.
+    while p < pat.len() && pat[p] == '*' {
+        p += 1;
+    }
+    p == pat.len()
+}
+
+/// Load the invoking principal's rule set from the `policy_rules` `[env]`
+/// value. Returns an EMPTY rule set (→ default allow → capability PEP is
+/// the live boundary) on any of: unset/empty value, host read error,
+/// JSON parse error, or a cap/shape violation — and emits a LOUD audit on
+/// the failure paths so an operator monitoring `astrid.v1.audit.policy_*`
+/// sees that policy is not in force.
+///
+/// This degrades to the capability PEP rather than failing CLOSED
+/// (deny-all) on a config error, so a malformed rule blob or a transient
+/// KV hiccup cannot brick every session. A deployment that wants strict
+/// fail-closed on config error is a future hardening knob; the tradeoff
+/// is recorded here deliberately.
+pub(crate) fn load_rules() -> Vec<Rule> {
+    let raw = match env::var_opt(POLICY_RULES_ENV) {
+        Ok(Some(s)) if !s.trim().is_empty() => s,
+        Ok(_) => return Vec::new(),
+        Err(e) => {
+            audit_load_failure("env_read_error");
+            log::warn(format!(
+                "{}: policy_rules env read failed: {e:?}",
+                crate::profile::log_tag()
+            ));
+            return Vec::new();
+        }
+    };
+
+    let parsed: Vec<Rule> = match serde_json::from_str(&raw) {
+        Ok(rules) => rules,
+        Err(e) => {
+            audit_load_failure("parse_error");
+            log::warn(format!(
+                "{}: policy_rules failed to parse: {e}",
+                crate::profile::log_tag()
+            ));
+            return Vec::new();
+        }
+    };
+
+    if let Err(reason) = validate(&parsed) {
+        audit_load_failure(reason);
+        log::warn(format!(
+            "{}: policy_rules rejected ({reason}); policy NOT in force",
+            crate::profile::log_tag()
+        ));
+        return Vec::new();
+    }
+    parsed
+}
+
+/// Enforce the load-time caps. A violation rejects the WHOLE set (policy
+/// degrades to the capability PEP + loud audit) rather than partially
+/// applying a malformed blob — a half-applied rule set is harder to reason
+/// about than none.
+fn validate(rules: &[Rule]) -> Result<(), &'static str> {
+    if rules.len() > MAX_RULES {
+        return Err("too_many_rules");
+    }
+    for rule in rules {
+        if rule.id.is_empty() || rule.id.len() > MAX_PATTERN_LEN {
+            return Err("bad_rule_id");
+        }
+        if rule.tool.is_empty() || rule.tool.len() > MAX_PATTERN_LEN {
+            return Err("bad_tool_glob");
+        }
+        for matcher in &rule.when {
+            if matcher.pointer.is_empty() || matcher.pointer.len() > MAX_POINTER_LEN {
+                return Err("bad_pointer");
+            }
+            // A JSON pointer is either empty (whole doc) or starts with
+            // `/`; we already reject empty above, so require the `/`.
+            if !matcher.pointer.starts_with('/') {
+                return Err("bad_pointer");
+            }
+            if matcher.value.len() > MAX_PATTERN_LEN {
+                return Err("oversize_matcher_value");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Audit a policy-load failure on `astrid.v1.audit.policy_load_failed`.
+/// Best-effort — the bus failing here must not itself wedge the tool
+/// path; the load already degraded to "no policy".
+fn audit_load_failure(reason: &str) {
+    let _ = ipc::publish_json(
+        &crate::profile::audit_topic("policy_load_failed"),
+        &serde_json::json!({ "reason": reason }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    fn install_test_profile() {
+        crate::profile::install_aos();
+    }
+
+    use super::*;
+    use serde_json::json;
+
+    fn deny(id: &str, tool: &str, when: Vec<ArgMatcher>) -> Rule {
+        Rule {
+            id: id.into(),
+            effect: Effect::Deny,
+            tool: tool.into(),
+            when,
+        }
+    }
+    fn m(pointer: &str, op: MatchOp, value: &str) -> ArgMatcher {
+        ArgMatcher {
+            pointer: pointer.into(),
+            op,
+            value: value.into(),
+        }
+    }
+
+    #[test]
+    fn empty_rules_default_allow() {
+        install_test_profile();
+        assert_eq!(evaluate(&[], "fs_read", &json!({})), Decision::Allow);
+    }
+
+    #[test]
+    fn tool_scoped_deny_fires_without_arg_matchers() {
+        install_test_profile();
+        let rules = vec![deny("no-http", "http_*", vec![])];
+        assert_eq!(
+            evaluate(&rules, "http_fetch", &json!({"url": "x"})),
+            Decision::Deny {
+                reason: "no-http".into()
+            }
+        );
+        // A different tool is unaffected.
+        assert_eq!(evaluate(&rules, "fs_read", &json!({})), Decision::Allow);
+    }
+
+    #[test]
+    fn arg_matchers_are_anded() {
+        install_test_profile();
+        let rules = vec![deny(
+            "scoped",
+            "fs_write",
+            vec![
+                m("/path", MatchOp::Prefix, "home://.ssh"),
+                m("/mode", MatchOp::Eq, "overwrite"),
+            ],
+        )];
+        // Both hold → deny.
+        assert_eq!(
+            evaluate(
+                &rules,
+                "fs_write",
+                &json!({"path": "home://.ssh/authorized_keys", "mode": "overwrite"})
+            ),
+            Decision::Deny {
+                reason: "scoped".into()
+            }
+        );
+        // Only one holds → allow (AND not satisfied).
+        assert_eq!(
+            evaluate(
+                &rules,
+                "fs_write",
+                &json!({"path": "home://.ssh/authorized_keys", "mode": "append"})
+            ),
+            Decision::Allow
+        );
+    }
+
+    #[test]
+    fn first_match_wins_allow_short_circuits_later_deny() {
+        install_test_profile();
+        let rules = vec![
+            Rule {
+                id: "allow-readme".into(),
+                effect: Effect::Allow,
+                tool: "fs_write".into(),
+                when: vec![m("/path", MatchOp::Eq, "home://README.md")],
+            },
+            deny("deny-all-writes", "fs_write", vec![]),
+        ];
+        // The earlier allow wins for the README.
+        assert_eq!(
+            evaluate(&rules, "fs_write", &json!({"path": "home://README.md"})),
+            Decision::Allow
+        );
+        // Anything else falls to the deny.
+        assert_eq!(
+            evaluate(&rules, "fs_write", &json!({"path": "home://other"})),
+            Decision::Deny {
+                reason: "deny-all-writes".into()
+            }
+        );
+    }
+
+    #[test]
+    fn missing_argument_never_satisfies_a_deny() {
+        install_test_profile();
+        let rules = vec![deny(
+            "x",
+            "fs_write",
+            vec![m("/path", MatchOp::Contains, "secret")],
+        )];
+        // No `/path` in the args → matcher fails → allow.
+        assert_eq!(
+            evaluate(&rules, "fs_write", &json!({"other": "secret"})),
+            Decision::Allow
+        );
+    }
+
+    #[test]
+    fn reason_is_rule_id_never_reflected_arguments() {
+        install_test_profile();
+        let rules = vec![deny(
+            "denied-by-policy",
+            "*",
+            vec![m("/command", MatchOp::Contains, "rm -rf")],
+        )];
+        let d = evaluate(
+            &rules,
+            "shell",
+            &json!({"command": "rm -rf / # attacker-controlled"}),
+        );
+        // The reason is the static id, NOT the attacker's command string.
+        assert_eq!(
+            d,
+            Decision::Deny {
+                reason: "denied-by-policy".into()
+            }
+        );
+    }
+
+    #[test]
+    fn glob_matches_runs_and_single_chars() {
+        install_test_profile();
+        assert!(glob_match("mcp__aos__*", "mcp__aos__fs_read"));
+        assert!(glob_match("fs_*", "fs_write"));
+        assert!(glob_match("a?c", "abc"));
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("*.md", "home://x/y/readme.md"));
+        assert!(!glob_match("fs_*", "http_fetch"));
+        assert!(!glob_match("a?c", "ac"));
+        assert!(!glob_match("abc", "abcd"));
+        // Pathological many-star patterns terminate (no backtracking
+        // blowup): the first has no trailing `b` to match, the second does.
+        assert!(!glob_match("a*a*a*a*a*b", "aaaaaaaaaaaaaaaaaaaa"));
+        assert!(glob_match("a*a*a*a*a*b", "aaaaaaaaaaaaaaaaaaab"));
+        assert!(glob_match("*a*a*a*", "xxaxxaxxax"));
+    }
+
+    #[test]
+    fn numbers_and_bools_stringify_for_matching() {
+        install_test_profile();
+        let rules = vec![deny("n", "tool", vec![m("/n", MatchOp::Eq, "5")])];
+        assert_eq!(
+            evaluate(&rules, "tool", &json!({"n": 5})),
+            Decision::Deny { reason: "n".into() }
+        );
+    }
+
+    #[test]
+    fn validate_enforces_caps() {
+        install_test_profile();
+        // A pointer not starting with `/` is rejected.
+        let bad_ptr = vec![deny("x", "t", vec![m("path", MatchOp::Eq, "v")])];
+        assert!(validate(&bad_ptr).is_err());
+        // Empty id rejected.
+        let empty_id = vec![deny("", "t", vec![])];
+        assert!(validate(&empty_id).is_err());
+        // Oversize value rejected.
+        let big = vec![deny(
+            "x",
+            "t",
+            vec![m("/p", MatchOp::Eq, &"a".repeat(MAX_PATTERN_LEN + 1))],
+        )];
+        assert!(validate(&big).is_err());
+        // A well-formed rule passes.
+        let ok = vec![deny("ok", "fs_*", vec![m("/path", MatchOp::Prefix, "x")])];
+        assert!(validate(&ok).is_ok());
+    }
+
+    #[test]
+    fn rules_deserialize_from_env_json_shape() {
+        install_test_profile();
+        let raw = r#"[
+            {"id":"no-ssh-write","effect":"deny","tool":"fs_write",
+             "when":[{"pointer":"/path","op":"contains","value":".ssh/"}]},
+            {"id":"allow-fetch","effect":"allow","tool":"http_fetch","when":[]}
+        ]"#;
+        let rules: Vec<Rule> = serde_json::from_str(raw).unwrap();
+        assert_eq!(rules.len(), 2);
+        assert!(validate(&rules).is_ok());
+        assert_eq!(rules[0].effect, Effect::Deny);
+        assert_eq!(rules[0].when[0].op, MatchOp::Contains);
+        assert_eq!(rules[1].effect, Effect::Allow);
+    }
+}

--- a/crates/aos-mcp-broker/src/profile.rs
+++ b/crates/aos-mcp-broker/src/profile.rs
@@ -1,0 +1,59 @@
+//! Active product identity for the AOS-owned broker.
+
+use std::sync::OnceLock;
+
+use crate::identity::McpIdentity;
+
+static IDENTITY: OnceLock<&'static McpIdentity> = OnceLock::new();
+
+/// Install the singleton AOS identity if it is not already set.
+pub fn install_aos() {
+    match IDENTITY.set(&McpIdentity::AOS) {
+        Ok(()) => {}
+        Err(existing) => assert!(
+            core::ptr::eq(existing, &McpIdentity::AOS),
+            "aos-mcp-broker: identity already installed"
+        ),
+    }
+}
+
+#[inline]
+fn identity() -> &'static McpIdentity {
+    IDENTITY
+        .get()
+        .copied()
+        .expect("aos-mcp-broker: call install_aos before handling traffic")
+}
+
+#[inline]
+pub(crate) fn log_tag() -> &'static str {
+    identity().log_tag
+}
+
+#[inline]
+pub(crate) fn mcp_tool_prefix() -> &'static str {
+    identity().mcp_tool_prefix
+}
+
+#[inline]
+pub(crate) fn tools_list_topic() -> &'static str {
+    identity().tools_list_topic
+}
+
+#[inline]
+pub(crate) fn audit_topic(event: &str) -> String {
+    identity().audit_topic(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_is_idempotent_and_product_scoped() {
+        install_aos();
+        install_aos();
+        assert_eq!(identity().capsule_name, "aos-mcp");
+        assert_eq!(mcp_tool_prefix(), "mcp__aos__");
+    }
+}

--- a/crates/unicity-aos-bootstrap/Cargo.toml
+++ b/crates/unicity-aos-bootstrap/Cargo.toml
@@ -19,6 +19,14 @@ tokio.workspace = true
 toml.workspace = true
 uuid.workspace = true
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6.4"
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSAlert", "NSApplication", "NSButton", "NSControl", "NSResponder", "NSView"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSString"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_UI_WindowsAndMessaging"] }
+
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -1023,7 +1023,7 @@ mod tests {
         let encoded = materialize_manifest(&capsule_dir).expect("materialize manifest");
         let decoded: toml::Value = encoded.parse().expect("parse materialized TOML");
         let capsules = decoded["capsule"].as_array().expect("capsule array");
-        assert_eq!(capsules.len(), 20);
+        assert_eq!(capsules.len(), 21);
         assert!(capsules.iter().all(|capsule| {
             PathBuf::from(capsule["source"].as_str().expect("absolute source")).parent()
                 == Some(capsule_dir.as_path())

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -923,7 +923,7 @@ mod tests {
 
     use super::{
         ProductCli, ProductCommand, child_exit_code, handle_product_command, help_targets_product,
-        leading_owned_root, runtime_args_for_dispatch, runtime_stop_requested,
+        is_owned_root, leading_owned_root, runtime_args_for_dispatch, runtime_stop_requested,
     };
 
     #[test]
@@ -1166,6 +1166,30 @@ mod tests {
             panic!("expected product status command");
         };
         assert!(status.json);
+    }
+
+    #[test]
+    fn runtime_command_contract_matches_the_product_router() {
+        let contract: toml::Value = include_str!("../../../release/runtime-command-surface.toml")
+            .parse()
+            .expect("parse runtime command surface");
+        let roots = contract["roots"].as_table().expect("root classifications");
+
+        for root in roots["product-owned"]
+            .as_array()
+            .expect("product-owned roots")
+        {
+            assert!(is_owned_root(root.as_str().expect("runtime root")));
+        }
+        for bucket in ["inherited", "hidden-inherited"] {
+            for root in roots[bucket].as_array().expect("inherited roots") {
+                assert!(!is_owned_root(root.as_str().expect("runtime root")));
+            }
+        }
+        assert_eq!(
+            roots["shared"].as_array().expect("shared roots"),
+            &[toml::Value::String("help".to_owned())]
+        );
     }
 
     #[cfg(unix)]

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -700,9 +700,7 @@ fn refuse_distro_command(_arguments: &[OsString]) -> ExitCode {
     eprintln!(
         "aos: Unicity CE owns the distribution state for this AOS installation; `aos distro` cannot apply or replace it"
     );
-    eprintln!(
-        "Use the standalone `astrid distro ...` command with a separate Astrid Runtime home to manage another distribution."
-    );
+    eprintln!("AOS does not expose raw distribution mutation beneath another command namespace.");
     ExitCode::from(2)
 }
 

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -15,6 +15,7 @@ use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use unicity_aos_bootstrap::{AOS_WORKSPACE_STATE_DIR, AosHome};
 
 mod hook;
+mod mcp;
 
 // Product-owned commands are parsed here. Unknown roots bypass this parser and
 // are delegated byte-for-byte to the bundled runtime by `main`.
@@ -27,7 +28,7 @@ mod hook;
     after_help = "All other commands are inherited from the bundled runtime. Running `aos` without a command displays product help until the native AOS chat surface lands."
 )]
 struct ProductCli {
-    /// Authenticated runtime operator used to provision another principal.
+    /// Authenticated runtime principal for principal-scoped AOS commands.
     #[arg(
         long,
         value_name = "OPERATOR_PRINCIPAL",
@@ -56,8 +57,19 @@ enum ProductCommand {
     Distro(DistroArgs),
     /// Deliver a host hook through the authenticated AOS event bus.
     Hook(hook::HookArgs),
+    /// Expose this AOS installation to an MCP host over stdio.
+    Mcp {
+        #[command(subcommand)]
+        command: McpCommand,
+    },
     /// Serve the loopback-only product health endpoint.
     ServeHealth,
+}
+
+#[derive(Subcommand)]
+enum McpCommand {
+    /// Serve AOS tools and broker interactions over stdio.
+    Serve(mcp::ServeArgs),
 }
 
 #[derive(Args)]
@@ -280,11 +292,16 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
     if cli.principal.is_some()
         && !matches!(
             &cli.command,
-            Some(ProductCommand::Init(_) | ProductCommand::Distro(_) | ProductCommand::Hook(_))
+            Some(
+                ProductCommand::Init(_)
+                    | ProductCommand::Distro(_)
+                    | ProductCommand::Hook(_)
+                    | ProductCommand::Mcp { .. }
+            )
         )
     {
         eprintln!(
-            "aos: '--principal' is supported for `aos init` and `aos hook`; this AOS-owned command does not accept an operator principal"
+            "aos: '--principal' is supported for `aos init`, `aos hook`, and `aos mcp`; this AOS-owned command does not accept a runtime principal"
         );
         return Some(ExitCode::from(2));
     }
@@ -298,6 +315,9 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
         Some(ProductCommand::Update(args)) => Some(handle_self_update(&args)),
         Some(ProductCommand::Distro(args)) => Some(refuse_distro_command(&args.arguments)),
         Some(ProductCommand::Hook(args)) => Some(handle_hook(cli.principal, args)),
+        Some(ProductCommand::Mcp {
+            command: McpCommand::Serve(args),
+        }) => Some(mcp::handle_serve(cli.principal, args)),
         Some(ProductCommand::ServeHealth) => Some(handle_health_service()),
         None => Some(print_product_help()),
     }
@@ -515,6 +535,7 @@ fn is_owned_root(value: &str) -> bool {
             | "self_update"
             | "distro"
             | "hook"
+            | "mcp"
             | "serve-health"
     )
 }

--- a/crates/unicity-aos-bootstrap/src/mcp/interaction.rs
+++ b/crates/unicity-aos-bootstrap/src/mcp/interaction.rs
@@ -18,6 +18,12 @@ use serde_json::{Map, Value, json};
 const MAX_MESSAGE_BYTES: usize = 4096;
 const SAFE_APPROVAL_CHOICES: &[&str] =
     &["approve_once", "approve_session", "approve_always", "deny"];
+#[cfg(unix)]
+const GPG_ERR_CANCELED: u32 = 99;
+#[cfg(unix)]
+const GPG_ERR_NOT_CONFIRMED: u32 = 114;
+#[cfg(unix)]
+const GPG_ERR_CODE_MASK: u32 = 0xffff;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct InteractionRequest {
@@ -160,6 +166,11 @@ fn parse_request(request: &Value) -> Result<InteractionRequest, InteractionError
     let property = property
         .as_object()
         .ok_or(InteractionError::Invalid("form property must be an object"))?;
+    if property.get("format").and_then(Value::as_str) == Some("password") {
+        return Err(InteractionError::Unsupported(
+            "local interaction refuses password-shaped fields",
+        ));
+    }
 
     let (response, options) = match property.get("type").and_then(Value::as_str) {
         Some("boolean") => (
@@ -298,7 +309,7 @@ fn present_appkit(request: &InteractionRequest) -> Result<Option<usize>, Interac
 #[cfg(target_os = "windows")]
 fn present_platform(request: &InteractionRequest) -> Result<Option<usize>, InteractionError> {
     use windows_sys::Win32::UI::WindowsAndMessaging::{
-        IDYES, MB_ICONWARNING, MB_SETFOREGROUND, MB_TASKMODAL, MB_YESNO, MessageBoxW,
+        IDNO, IDYES, MB_ICONWARNING, MB_SETFOREGROUND, MB_TASKMODAL, MB_YESNO, MessageBoxW,
     };
 
     let affirmative = request
@@ -308,6 +319,11 @@ fn present_platform(request: &InteractionRequest) -> Result<Option<usize>, Inter
         .ok_or(InteractionError::Invalid(
             "interaction has no affirmative choice",
         ))?;
+    let deny = request
+        .options
+        .iter()
+        .position(|option| !option.affirmative)
+        .ok_or(InteractionError::Invalid("interaction has no deny choice"))?;
     let mut message = request.message.encode_utf16().collect::<Vec<_>>();
     message.push(0);
     let mut title = "Unicity AOS approval".encode_utf16().collect::<Vec<_>>();
@@ -322,7 +338,17 @@ fn present_platform(request: &InteractionRequest) -> Result<Option<usize>, Inter
             MB_YESNO | MB_ICONWARNING | MB_TASKMODAL | MB_SETFOREGROUND,
         )
     };
-    Ok((response == IDYES).then_some(affirmative))
+    match response {
+        IDYES => Ok(Some(affirmative)),
+        IDNO => Ok(Some(deny)),
+        0 => Err(InteractionError::Unavailable(format!(
+            "Windows approval dialog failed: {}",
+            std::io::Error::last_os_error()
+        ))),
+        other => Err(InteractionError::Unavailable(format!(
+            "Windows approval dialog returned unknown response {other}"
+        ))),
+    }
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -393,21 +419,35 @@ fn present_pinentry(request: &InteractionRequest) -> Result<Option<usize>, Inter
     pinentry_command(
         &mut stdin,
         &mut reader,
-        &format!(
-            "SETCANCEL {}",
-            pinentry_escape(&request.options[deny].label)
-        ),
+        &format!("SETNOTOK {}", pinentry_escape(&request.options[deny].label)),
     )?;
+    pinentry_command(&mut stdin, &mut reader, "SETCANCEL Cancel")?;
     stdin
         .write_all(b"CONFIRM\n")
         .and_then(|()| stdin.flush())
         .map_err(|error| {
             InteractionError::Unavailable(format!("pinentry write failed: {error}"))
         })?;
-    let accepted = read_pinentry_status(&mut reader)?;
+    let status = read_pinentry_status(&mut reader)?;
     let _ = stdin.write_all(b"BYE\n");
     let _ = child.wait();
-    Ok(accepted.then_some(affirmative))
+    pinentry_selection(status, affirmative, deny)
+}
+
+#[cfg(unix)]
+fn pinentry_selection(
+    status: PinentryStatus,
+    affirmative: usize,
+    deny: usize,
+) -> Result<Option<usize>, InteractionError> {
+    match status {
+        PinentryStatus::Ok => Ok(Some(affirmative)),
+        PinentryStatus::Error(GPG_ERR_NOT_CONFIRMED) => Ok(Some(deny)),
+        PinentryStatus::Error(GPG_ERR_CANCELED) => Ok(None),
+        PinentryStatus::Error(code) => Err(InteractionError::Unavailable(format!(
+            "pinentry confirmation failed with error code {code}"
+        ))),
+    }
 }
 
 #[cfg(unix)]
@@ -421,28 +461,33 @@ fn pinentry_command(
         .map_err(|error| {
             InteractionError::Unavailable(format!("pinentry write failed: {error}"))
         })?;
-    if read_pinentry_status(reader)? {
-        Ok(())
-    } else {
-        Err(InteractionError::Unavailable(
-            "pinentry rejected its setup command".into(),
-        ))
+    match read_pinentry_status(reader)? {
+        PinentryStatus::Ok => Ok(()),
+        PinentryStatus::Error(code) => Err(InteractionError::Unavailable(format!(
+            "pinentry rejected its setup command with error code {code}"
+        ))),
     }
 }
 
 #[cfg(unix)]
 fn expect_pinentry_ok(reader: &mut impl BufRead) -> Result<(), InteractionError> {
-    if read_pinentry_status(reader)? {
-        Ok(())
-    } else {
-        Err(InteractionError::Unavailable(
-            "pinentry rejected the connection".into(),
-        ))
+    match read_pinentry_status(reader)? {
+        PinentryStatus::Ok => Ok(()),
+        PinentryStatus::Error(code) => Err(InteractionError::Unavailable(format!(
+            "pinentry rejected the connection with error code {code}"
+        ))),
     }
 }
 
 #[cfg(unix)]
-fn read_pinentry_status(reader: &mut impl BufRead) -> Result<bool, InteractionError> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PinentryStatus {
+    Ok,
+    Error(u32),
+}
+
+#[cfg(unix)]
+fn read_pinentry_status(reader: &mut impl BufRead) -> Result<PinentryStatus, InteractionError> {
     let mut line = String::new();
     loop {
         line.clear();
@@ -455,10 +500,19 @@ fn read_pinentry_status(reader: &mut impl BufRead) -> Result<bool, InteractionEr
             ));
         }
         if line.starts_with("OK") {
-            return Ok(true);
+            return Ok(PinentryStatus::Ok);
         }
-        if line.starts_with("ERR") {
-            return Ok(false);
+        if let Some(error) = line.strip_prefix("ERR ") {
+            let encoded = error
+                .split_ascii_whitespace()
+                .next()
+                .and_then(|value| value.parse::<u32>().ok())
+                .ok_or_else(|| {
+                    InteractionError::Unavailable(
+                        "pinentry returned a malformed error status".into(),
+                    )
+                })?;
+            return Ok(PinentryStatus::Error(encoded & GPG_ERR_CODE_MASK));
         }
     }
 }
@@ -580,6 +634,11 @@ mod tests {
         for property in [
             json!({ "type": "string" }),
             json!({ "type": "string", "format": "password" }),
+            json!({
+                "type": "string",
+                "format": "password",
+                "enum": ["approve_once", "deny"]
+            }),
             json!({ "type": "string", "enum": ["yes", "no"] }),
         ] {
             let request = request(json!({
@@ -617,5 +676,42 @@ mod tests {
     fn pinentry_escaping_cannot_inject_commands() {
         assert_eq!(pinentry_escape("hello%\nBYE\r"), "hello%25%0ABYE%0D");
         assert_eq!(pinentry_escape("Autoriser ✓"), "Autoriser ✓");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pinentry_status_distinguishes_deny_cancel_and_failure() {
+        let mut denied = std::io::Cursor::new("ERR 83886194 Not confirmed <Pinentry>\n");
+        assert_eq!(
+            read_pinentry_status(&mut denied).expect("deny status"),
+            PinentryStatus::Error(GPG_ERR_NOT_CONFIRMED)
+        );
+
+        let mut cancelled = std::io::Cursor::new("ERR 83886179 Operation cancelled <Pinentry>\n");
+        assert_eq!(
+            read_pinentry_status(&mut cancelled).expect("cancel status"),
+            PinentryStatus::Error(GPG_ERR_CANCELED)
+        );
+
+        let mut failed = std::io::Cursor::new("ERR 83886140 Not supported <Pinentry>\n");
+        assert_eq!(
+            read_pinentry_status(&mut failed).expect("failure status"),
+            PinentryStatus::Error(60)
+        );
+
+        assert_eq!(
+            pinentry_selection(PinentryStatus::Error(GPG_ERR_NOT_CONFIRMED), 0, 1)
+                .expect("deny selection"),
+            Some(1)
+        );
+        assert_eq!(
+            pinentry_selection(PinentryStatus::Error(GPG_ERR_CANCELED), 0, 1)
+                .expect("cancel selection"),
+            None
+        );
+        assert!(matches!(
+            pinentry_selection(PinentryStatus::Error(60), 0, 1),
+            Err(InteractionError::Unavailable(_))
+        ));
     }
 }

--- a/crates/unicity-aos-bootstrap/src/mcp/interaction.rs
+++ b/crates/unicity-aos-bootstrap/src/mcp/interaction.rs
@@ -1,0 +1,621 @@
+//! Product-native interaction handling for MCP hosts that cannot render forms.
+//!
+//! This boundary deliberately accepts only constrained decisions. Arbitrary
+//! strings, password-shaped schemas, and URL elicitations are never collected
+//! here, so a secret cannot be reflected into the MCP transport or agent
+//! context by this compatibility bridge.
+
+use std::fmt;
+#[cfg(unix)]
+use std::io::{BufRead, BufReader, Write as _};
+#[cfg(unix)]
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process::{Command, Stdio};
+
+use serde_json::{Map, Value, json};
+
+const MAX_MESSAGE_BYTES: usize = 4096;
+const SAFE_APPROVAL_CHOICES: &[&str] =
+    &["approve_once", "approve_session", "approve_always", "deny"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct InteractionRequest {
+    message: String,
+    field: String,
+    response: ResponseKind,
+    options: Vec<OptionValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ResponseKind {
+    Boolean,
+    String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OptionValue {
+    label: String,
+    value: Value,
+    affirmative: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum InteractionError {
+    Unsupported(&'static str),
+    Invalid(&'static str),
+    Unavailable(String),
+}
+
+impl fmt::Display for InteractionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unsupported(message) | Self::Invalid(message) => formatter.write_str(message),
+            Self::Unavailable(message) => formatter.write_str(message),
+        }
+    }
+}
+
+pub(super) trait Presenter {
+    /// Return the selected option index, or `None` when the user cancelled.
+    fn present(&mut self, request: &InteractionRequest) -> Result<Option<usize>, InteractionError>;
+}
+
+/// Resolve one MCP form elicitation through a trusted local decision surface.
+///
+/// Every parse, provider, or cancellation failure produces the MCP `cancel`
+/// action. Nothing in this function can synthesize consent.
+pub(super) fn resolve(
+    request: &Value,
+    presenter: &mut dyn Presenter,
+) -> Result<Value, InteractionError> {
+    let id = request
+        .get("id")
+        .cloned()
+        .ok_or(InteractionError::Invalid("elicitation request has no id"))?;
+    let parsed = parse_request(request)?;
+    let selected = presenter.present(&parsed)?;
+    let Some(index) = selected else {
+        return Ok(response(id, "cancel", None));
+    };
+    let Some(selected) = parsed.options.get(index) else {
+        return Err(InteractionError::Invalid(
+            "interaction provider returned an invalid choice",
+        ));
+    };
+    let mut content = Map::new();
+    content.insert(parsed.field, selected.value.clone());
+    Ok(response(id, "accept", Some(Value::Object(content))))
+}
+
+pub(super) fn cancelled_response(request: &Value) -> Option<Value> {
+    request
+        .get("id")
+        .cloned()
+        .map(|id| response(id, "cancel", None))
+}
+
+fn response(id: Value, action: &str, content: Option<Value>) -> Value {
+    let mut result = Map::new();
+    result.insert("action".to_owned(), Value::String(action.to_owned()));
+    if let Some(content) = content {
+        result.insert("content".to_owned(), content);
+    }
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result,
+    })
+}
+
+fn parse_request(request: &Value) -> Result<InteractionRequest, InteractionError> {
+    let params =
+        request
+            .get("params")
+            .and_then(Value::as_object)
+            .ok_or(InteractionError::Invalid(
+                "elicitation params must be an object",
+            ))?;
+    if params.get("mode").and_then(Value::as_str).unwrap_or("form") != "form" {
+        return Err(InteractionError::Unsupported(
+            "local interaction only handles non-secret form decisions",
+        ));
+    }
+    let message =
+        params
+            .get("message")
+            .and_then(Value::as_str)
+            .ok_or(InteractionError::Invalid(
+                "elicitation message must be a string",
+            ))?;
+    if message.is_empty() || message.len() > MAX_MESSAGE_BYTES {
+        return Err(InteractionError::Invalid(
+            "elicitation message is empty or too large",
+        ));
+    }
+    let schema = params
+        .get("requestedSchema")
+        .and_then(Value::as_object)
+        .ok_or(InteractionError::Invalid(
+            "form elicitation has no requested schema",
+        ))?;
+    if schema.get("type").and_then(Value::as_str) != Some("object") {
+        return Err(InteractionError::Invalid(
+            "form elicitation schema must be an object",
+        ));
+    }
+    let properties =
+        schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .ok_or(InteractionError::Invalid(
+                "form elicitation has no properties",
+            ))?;
+    if properties.len() != 1 {
+        return Err(InteractionError::Unsupported(
+            "local interaction accepts exactly one constrained decision",
+        ));
+    }
+    let (field, property) = properties.iter().next().expect("length checked");
+    let property = property
+        .as_object()
+        .ok_or(InteractionError::Invalid("form property must be an object"))?;
+
+    let (response, options) = match property.get("type").and_then(Value::as_str) {
+        Some("boolean") => (
+            ResponseKind::Boolean,
+            vec![
+                OptionValue {
+                    label: affirmative_label(field).to_owned(),
+                    value: Value::Bool(true),
+                    affirmative: true,
+                },
+                OptionValue {
+                    label: "Deny".to_owned(),
+                    value: Value::Bool(false),
+                    affirmative: false,
+                },
+            ],
+        ),
+        Some("string") => (ResponseKind::String, parse_safe_enum(property.get("enum"))?),
+        _ => {
+            return Err(InteractionError::Unsupported(
+                "local interaction refuses free-form or non-decision fields",
+            ));
+        }
+    };
+
+    Ok(InteractionRequest {
+        message: message.to_owned(),
+        field: field.to_owned(),
+        response,
+        options,
+    })
+}
+
+fn parse_safe_enum(value: Option<&Value>) -> Result<Vec<OptionValue>, InteractionError> {
+    let values = value
+        .and_then(Value::as_array)
+        .ok_or(InteractionError::Unsupported(
+            "local interaction refuses unconstrained strings",
+        ))?;
+    if values.is_empty() || values.len() > SAFE_APPROVAL_CHOICES.len() {
+        return Err(InteractionError::Unsupported(
+            "approval choice set is empty or too large",
+        ));
+    }
+    let mut options = Vec::with_capacity(values.len());
+    for value in values {
+        let choice = value.as_str().ok_or(InteractionError::Unsupported(
+            "approval choices must be strings",
+        ))?;
+        if !SAFE_APPROVAL_CHOICES.contains(&choice) {
+            return Err(InteractionError::Unsupported(
+                "local interaction refuses an unknown approval choice",
+            ));
+        }
+        options.push(OptionValue {
+            label: choice_label(choice).to_owned(),
+            value: Value::String(choice.to_owned()),
+            affirmative: choice != "deny",
+        });
+    }
+    if !options.iter().any(|option| !option.affirmative) {
+        return Err(InteractionError::Unsupported(
+            "approval choice set has no deny option",
+        ));
+    }
+    Ok(options)
+}
+
+fn affirmative_label(field: &str) -> &'static str {
+    match field {
+        "grant" => "Grant",
+        "allow" => "Allow",
+        _ => "Approve",
+    }
+}
+
+fn choice_label(choice: &str) -> &'static str {
+    match choice {
+        "approve_once" => "Approve Once",
+        "approve_session" => "Approve for Session",
+        "approve_always" => "Always Approve",
+        "deny" => "Deny",
+        _ => "Deny",
+    }
+}
+
+pub(super) struct NativePresenter;
+
+impl Presenter for NativePresenter {
+    fn present(&mut self, request: &InteractionRequest) -> Result<Option<usize>, InteractionError> {
+        present_platform(request)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn present_platform(request: &InteractionRequest) -> Result<Option<usize>, InteractionError> {
+    present_appkit(request).or_else(|appkit_error| {
+        present_pinentry(request).map_err(|pinentry_error| {
+            InteractionError::Unavailable(format!(
+                "AppKit unavailable ({appkit_error}); fallback unavailable ({pinentry_error})"
+            ))
+        })
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn present_appkit(request: &InteractionRequest) -> Result<Option<usize>, InteractionError> {
+    use objc2::rc::autoreleasepool;
+    use objc2::{MainThreadMarker, MainThreadOnly};
+    use objc2_app_kit::{NSAlert, NSAlertFirstButtonReturn, NSApplication};
+    use objc2_foundation::NSString;
+
+    let main_thread = MainThreadMarker::new().ok_or_else(|| {
+        InteractionError::Unavailable("AppKit interaction was not run on the main thread".into())
+    })?;
+    autoreleasepool(|_| {
+        let _application = NSApplication::sharedApplication(main_thread);
+        let alert = NSAlert::init(NSAlert::alloc(main_thread));
+        alert.setMessageText(&NSString::from_str("Unicity AOS approval"));
+        alert.setInformativeText(&NSString::from_str(&request.message));
+        for option in &request.options {
+            alert.addButtonWithTitle(&NSString::from_str(&option.label));
+        }
+        let response = alert.runModal();
+        let offset = response - NSAlertFirstButtonReturn;
+        usize::try_from(offset)
+            .ok()
+            .filter(|index| *index < request.options.len())
+            .map(Some)
+            .ok_or_else(|| {
+                InteractionError::Unavailable("AppKit returned an unknown response".into())
+            })
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn present_platform(request: &InteractionRequest) -> Result<Option<usize>, InteractionError> {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        IDYES, MB_ICONWARNING, MB_SETFOREGROUND, MB_TASKMODAL, MB_YESNO, MessageBoxW,
+    };
+
+    let affirmative = request
+        .options
+        .iter()
+        .position(|option| option.affirmative)
+        .ok_or(InteractionError::Invalid(
+            "interaction has no affirmative choice",
+        ))?;
+    let mut message = request.message.encode_utf16().collect::<Vec<_>>();
+    message.push(0);
+    let mut title = "Unicity AOS approval".encode_utf16().collect::<Vec<_>>();
+    title.push(0);
+    // SAFETY: Both UTF-16 buffers are NUL-terminated and remain alive for the
+    // duration of the modal call. A null owner is permitted by MessageBoxW.
+    let response = unsafe {
+        MessageBoxW(
+            std::ptr::null_mut(),
+            message.as_ptr(),
+            title.as_ptr(),
+            MB_YESNO | MB_ICONWARNING | MB_TASKMODAL | MB_SETFOREGROUND,
+        )
+    };
+    Ok((response == IDYES).then_some(affirmative))
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn present_platform(request: &InteractionRequest) -> Result<Option<usize>, InteractionError> {
+    present_pinentry(request)
+}
+
+#[cfg(not(any(unix, target_os = "windows")))]
+fn present_platform(_request: &InteractionRequest) -> Result<Option<usize>, InteractionError> {
+    Err(InteractionError::Unavailable(
+        "this platform has no trusted local interaction provider".into(),
+    ))
+}
+
+#[cfg(unix)]
+fn present_pinentry(request: &InteractionRequest) -> Result<Option<usize>, InteractionError> {
+    let executable = pinentry_path().ok_or_else(|| {
+        InteractionError::Unavailable("no trusted native provider or pinentry was found".into())
+    })?;
+    let mut child = Command::new(&executable)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| {
+            InteractionError::Unavailable(format!(
+                "failed to start {}: {error}",
+                executable.display()
+            ))
+        })?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| InteractionError::Unavailable("pinentry did not expose stdout".into()))?;
+    let mut reader = BufReader::new(stdout);
+    expect_pinentry_ok(&mut reader)?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| InteractionError::Unavailable("pinentry did not expose stdin".into()))?;
+
+    pinentry_command(&mut stdin, &mut reader, "SETTITLE Unicity AOS approval")?;
+    pinentry_command(
+        &mut stdin,
+        &mut reader,
+        &format!("SETDESC {}", pinentry_escape(&request.message)),
+    )?;
+    let affirmative = request
+        .options
+        .iter()
+        .position(|option| option.affirmative)
+        .ok_or(InteractionError::Invalid(
+            "interaction has no affirmative choice",
+        ))?;
+    let deny = request
+        .options
+        .iter()
+        .position(|option| !option.affirmative)
+        .ok_or(InteractionError::Invalid("interaction has no deny choice"))?;
+    pinentry_command(
+        &mut stdin,
+        &mut reader,
+        &format!(
+            "SETOK {}",
+            pinentry_escape(&request.options[affirmative].label)
+        ),
+    )?;
+    pinentry_command(
+        &mut stdin,
+        &mut reader,
+        &format!(
+            "SETCANCEL {}",
+            pinentry_escape(&request.options[deny].label)
+        ),
+    )?;
+    stdin
+        .write_all(b"CONFIRM\n")
+        .and_then(|()| stdin.flush())
+        .map_err(|error| {
+            InteractionError::Unavailable(format!("pinentry write failed: {error}"))
+        })?;
+    let accepted = read_pinentry_status(&mut reader)?;
+    let _ = stdin.write_all(b"BYE\n");
+    let _ = child.wait();
+    Ok(accepted.then_some(affirmative))
+}
+
+#[cfg(unix)]
+fn pinentry_command(
+    stdin: &mut impl std::io::Write,
+    reader: &mut impl BufRead,
+    command: &str,
+) -> Result<(), InteractionError> {
+    writeln!(stdin, "{command}")
+        .and_then(|()| stdin.flush())
+        .map_err(|error| {
+            InteractionError::Unavailable(format!("pinentry write failed: {error}"))
+        })?;
+    if read_pinentry_status(reader)? {
+        Ok(())
+    } else {
+        Err(InteractionError::Unavailable(
+            "pinentry rejected its setup command".into(),
+        ))
+    }
+}
+
+#[cfg(unix)]
+fn expect_pinentry_ok(reader: &mut impl BufRead) -> Result<(), InteractionError> {
+    if read_pinentry_status(reader)? {
+        Ok(())
+    } else {
+        Err(InteractionError::Unavailable(
+            "pinentry rejected the connection".into(),
+        ))
+    }
+}
+
+#[cfg(unix)]
+fn read_pinentry_status(reader: &mut impl BufRead) -> Result<bool, InteractionError> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).map_err(|error| {
+            InteractionError::Unavailable(format!("pinentry read failed: {error}"))
+        })? == 0
+        {
+            return Err(InteractionError::Unavailable(
+                "pinentry closed without a response".into(),
+            ));
+        }
+        if line.starts_with("OK") {
+            return Ok(true);
+        }
+        if line.starts_with("ERR") {
+            return Ok(false);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn pinentry_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '%' => escaped.push_str("%25"),
+            '\n' => escaped.push_str("%0A"),
+            '\r' => escaped.push_str("%0D"),
+            character if character.is_control() => escaped.push(' '),
+            character => escaped.push(character),
+        }
+    }
+    escaped
+}
+
+#[cfg(unix)]
+fn pinentry_path() -> Option<PathBuf> {
+    pinentry_candidates().find(|path| path.is_file())
+}
+
+#[cfg(unix)]
+fn pinentry_candidates() -> impl Iterator<Item = PathBuf> {
+    #[cfg(target_os = "macos")]
+    const PATHS: &[&str] = &[
+        "/opt/homebrew/bin/pinentry-mac",
+        "/usr/local/bin/pinentry-mac",
+        "/opt/homebrew/bin/pinentry",
+        "/usr/local/bin/pinentry",
+    ];
+    #[cfg(target_os = "linux")]
+    const PATHS: &[&str] = &[
+        "/usr/bin/pinentry-gnome3",
+        "/usr/bin/pinentry-qt",
+        "/usr/bin/pinentry",
+        "/usr/bin/pinentry-curses",
+    ];
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    const PATHS: &[&str] = &[];
+
+    PATHS.iter().map(Path::new).map(Path::to_path_buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakePresenter(Option<usize>);
+
+    impl Presenter for FakePresenter {
+        fn present(
+            &mut self,
+            _request: &InteractionRequest,
+        ) -> Result<Option<usize>, InteractionError> {
+            Ok(self.0)
+        }
+    }
+
+    fn request(schema: Value) -> Value {
+        json!({
+            "jsonrpc": "2.0",
+            "id": 17,
+            "method": "elicitation/create",
+            "params": {
+                "mode": "form",
+                "message": "A capsule is requesting approval.",
+                "requestedSchema": schema
+            }
+        })
+    }
+
+    #[test]
+    fn boolean_accept_returns_only_the_constrained_field() {
+        let request = request(json!({
+            "type": "object",
+            "properties": { "grant": { "type": "boolean" } },
+            "required": ["grant"]
+        }));
+        let resolved = resolve(&request, &mut FakePresenter(Some(0))).expect("resolve");
+        assert_eq!(resolved["result"]["action"], "accept");
+        assert_eq!(resolved["result"]["content"], json!({ "grant": true }));
+    }
+
+    #[test]
+    fn approval_enum_preserves_explicit_choice() {
+        let request = request(json!({
+            "type": "object",
+            "properties": {
+                "choice": {
+                    "type": "string",
+                    "enum": ["approve_once", "approve_session", "approve_always", "deny"]
+                }
+            },
+            "required": ["choice"]
+        }));
+        let resolved = resolve(&request, &mut FakePresenter(Some(1))).expect("resolve");
+        assert_eq!(
+            resolved["result"]["content"],
+            json!({ "choice": "approve_session" })
+        );
+    }
+
+    #[test]
+    fn cancellation_never_synthesizes_content() {
+        let request = request(json!({
+            "type": "object",
+            "properties": { "allow": { "type": "boolean" } }
+        }));
+        let resolved = resolve(&request, &mut FakePresenter(None)).expect("resolve");
+        assert_eq!(resolved["result"]["action"], "cancel");
+        assert!(resolved["result"].get("content").is_none());
+    }
+
+    #[test]
+    fn free_form_and_secret_shaped_strings_are_refused() {
+        for property in [
+            json!({ "type": "string" }),
+            json!({ "type": "string", "format": "password" }),
+            json!({ "type": "string", "enum": ["yes", "no"] }),
+        ] {
+            let request = request(json!({
+                "type": "object",
+                "properties": { "secret": property }
+            }));
+            assert!(matches!(
+                resolve(&request, &mut FakePresenter(Some(0))),
+                Err(InteractionError::Unsupported(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn url_elicitation_is_not_opened_by_the_local_form_bridge() {
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": "url-1",
+            "method": "elicitation/create",
+            "params": {
+                "mode": "url",
+                "message": "Authenticate",
+                "url": "https://example.invalid/",
+                "elicitationId": "e1"
+            }
+        });
+        assert!(matches!(
+            resolve(&request, &mut FakePresenter(Some(0))),
+            Err(InteractionError::Unsupported(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pinentry_escaping_cannot_inject_commands() {
+        assert_eq!(pinentry_escape("hello%\nBYE\r"), "hello%25%0ABYE%0D");
+        assert_eq!(pinentry_escape("Autoriser ✓"), "Autoriser ✓");
+    }
+}

--- a/crates/unicity-aos-bootstrap/src/mcp/mod.rs
+++ b/crates/unicity-aos-bootstrap/src/mcp/mod.rs
@@ -1,0 +1,450 @@
+//! Product-owned MCP endpoint and local interaction bridge.
+//!
+//! The pinned runtime's MCP shim remains a compatibility transport for this
+//! release. AOS owns the externally visible command, server identity, and
+//! interaction policy. That lets hosts without MCP form elicitation use a
+//! trusted local decision surface without weakening or forking the runtime.
+
+mod interaction;
+
+use std::ffi::OsString;
+use std::process::{ExitCode, Stdio};
+
+use clap::{Args, ValueEnum};
+use serde_json::{Map, Value};
+use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+
+use unicity_aos_bootstrap::AosHome;
+
+#[derive(Debug, Args)]
+pub(crate) struct ServeArgs {
+    /// Choose where constrained approval forms are presented.
+    #[arg(long, value_enum, default_value_t = InteractionMode::Auto)]
+    interaction: InteractionMode,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+enum InteractionMode {
+    /// Prefer the MCP client, falling back to the trusted local AOS provider.
+    #[default]
+    Auto,
+    /// Require the MCP client to present interactions.
+    Client,
+    /// Always present constrained decisions through the local AOS provider.
+    Native,
+    /// Refuse interactive requests.
+    Deny,
+}
+
+pub(crate) fn handle_serve(principal: Option<String>, args: ServeArgs) -> ExitCode {
+    let home = match AosHome::resolve() {
+        Ok(home) => home,
+        Err(error) => {
+            eprintln!("aos mcp serve: failed to resolve product home: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("aos mcp serve: failed to start async runtime: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    match runtime.block_on(serve(&home, principal.as_deref(), args.interaction)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("aos mcp serve: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn serve(
+    home: &AosHome,
+    principal: Option<&str>,
+    mode: InteractionMode,
+) -> Result<(), String> {
+    let mut runtime_args = Vec::<OsString>::new();
+    if let Some(principal) = principal {
+        runtime_args.push(OsString::from("--principal"));
+        runtime_args.push(OsString::from(principal));
+    }
+    runtime_args.extend([OsString::from("mcp"), OsString::from("serve")]);
+
+    let mut standard_command = home
+        .runtime_command_with_args(&runtime_args)
+        .map_err(|error| format!("failed to prepare bundled runtime: {error}"))?;
+    standard_command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    let mut command = tokio::process::Command::from(standard_command);
+    command.kill_on_drop(true);
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("failed to start bundled MCP compatibility transport: {error}"))?;
+    let child_stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "bundled MCP transport did not expose stdin".to_owned())?;
+    let child_stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "bundled MCP transport did not expose stdout".to_owned())?;
+
+    let mut upstream = BufReader::new(tokio::io::stdin()).lines();
+    let mut downstream = BufReader::new(child_stdout).lines();
+    let mut upstream_out = tokio::io::stdout();
+    let mut downstream_in = Some(child_stdin);
+    let mut client_supports_form = false;
+    let mut presenter = interaction::NativePresenter;
+    let mut upstream_open = true;
+
+    loop {
+        tokio::select! {
+            line = upstream.next_line(), if upstream_open => {
+                let Some(line) = line.map_err(|error| format!("failed to read MCP client: {error}"))? else {
+                    downstream_in.take();
+                    upstream_open = false;
+                    continue;
+                };
+                let forwarded = prepare_client_message(&line, mode, &mut client_supports_form);
+                write_frame(
+                    downstream_in
+                        .as_mut()
+                        .ok_or_else(|| "bundled MCP transport input is closed".to_owned())?,
+                    &forwarded,
+                )
+                    .await
+                    .map_err(|error| format!("failed to write bundled MCP transport: {error}"))?;
+            },
+            line = downstream.next_line() => {
+                let Some(line) = line.map_err(|error| format!("failed to read bundled MCP transport: {error}"))? else {
+                    break;
+                };
+                let mut message = serde_json::from_str::<Value>(&line).ok();
+                let handling = message
+                    .as_ref()
+                    .map_or(ElicitationHandling::Forward, |value| {
+                        elicitation_handling(value, mode, client_supports_form)
+                    });
+                if handling != ElicitationHandling::Forward {
+                    let request = message.as_ref().expect("handling requires parsed JSON");
+                    let response = match handling {
+                        ElicitationHandling::Present => {
+                            match interaction::resolve(request, &mut presenter) {
+                                Ok(response) => response,
+                                Err(error) => {
+                                    eprintln!("aos mcp serve: local interaction denied: {error}");
+                                    interaction::cancelled_response(request).ok_or_else(|| {
+                                        "elicitation request did not carry a response id".to_owned()
+                                    })?
+                                },
+                            }
+                        },
+                        ElicitationHandling::Cancel => {
+                            interaction::cancelled_response(request).ok_or_else(|| {
+                                "elicitation request did not carry a response id".to_owned()
+                            })?
+                        },
+                        ElicitationHandling::Forward => unreachable!("handled above"),
+                    };
+                    let response = serde_json::to_string(&response)
+                        .map_err(|error| format!("failed to encode local interaction: {error}"))?;
+                    write_frame(
+                        downstream_in
+                            .as_mut()
+                            .ok_or_else(|| "bundled MCP transport input is closed".to_owned())?,
+                        &response,
+                    )
+                        .await
+                        .map_err(|error| format!("failed to answer local interaction: {error}"))?;
+                    continue;
+                }
+                if let Some(value) = message.as_mut() {
+                    rewrite_server_identity(value);
+                }
+                let forwarded = message
+                    .as_ref()
+                    .and_then(|value| serde_json::to_string(value).ok())
+                    .unwrap_or(line);
+                write_frame(&mut upstream_out, &forwarded)
+                    .await
+                    .map_err(|error| format!("failed to write MCP client: {error}"))?;
+            },
+        }
+    }
+
+    drop(downstream_in);
+    let status = child
+        .wait()
+        .await
+        .map_err(|error| format!("failed waiting for bundled MCP transport: {error}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("bundled MCP transport exited with {status}"))
+    }
+}
+
+async fn write_frame(
+    output: &mut (impl tokio::io::AsyncWrite + Unpin),
+    frame: &str,
+) -> std::io::Result<()> {
+    output.write_all(frame.as_bytes()).await?;
+    output.write_all(b"\n").await?;
+    output.flush().await
+}
+
+fn prepare_client_message(
+    line: &str,
+    mode: InteractionMode,
+    client_supports_form: &mut bool,
+) -> String {
+    let Ok(mut value) = serde_json::from_str::<Value>(line) else {
+        return line.to_owned();
+    };
+    if value.get("method").and_then(Value::as_str) != Some("initialize") {
+        return line.to_owned();
+    }
+    *client_supports_form = supports_form_elicitation(&value);
+    if matches!(mode, InteractionMode::Auto | InteractionMode::Native)
+        && (mode == InteractionMode::Native || !*client_supports_form)
+    {
+        advertise_form_elicitation(&mut value);
+    }
+    serde_json::to_string(&value).unwrap_or_else(|_| line.to_owned())
+}
+
+fn supports_form_elicitation(initialize: &Value) -> bool {
+    initialize
+        .pointer("/params/capabilities/elicitation/form")
+        .is_some_and(Value::is_object)
+}
+
+fn advertise_form_elicitation(initialize: &mut Value) {
+    let Some(params) = initialize.get_mut("params").and_then(Value::as_object_mut) else {
+        return;
+    };
+    let Some(capabilities) = object_entry(params, "capabilities") else {
+        return;
+    };
+    let Some(elicitation) = object_entry(capabilities, "elicitation") else {
+        return;
+    };
+    elicitation
+        .entry("form".to_owned())
+        .or_insert_with(|| Value::Object(Map::new()));
+}
+
+fn object_entry<'a>(
+    object: &'a mut Map<String, Value>,
+    key: &str,
+) -> Option<&'a mut Map<String, Value>> {
+    let value = object
+        .entry(key.to_owned())
+        .or_insert_with(|| Value::Object(Map::new()));
+    value.as_object_mut()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ElicitationHandling {
+    Forward,
+    Present,
+    Cancel,
+}
+
+fn elicitation_handling(
+    message: &Value,
+    mode: InteractionMode,
+    client_supports_form: bool,
+) -> ElicitationHandling {
+    if message.get("method").and_then(Value::as_str) != Some("elicitation/create") {
+        return ElicitationHandling::Forward;
+    }
+    if mode == InteractionMode::Deny {
+        return ElicitationHandling::Cancel;
+    }
+    if message
+        .pointer("/params/mode")
+        .and_then(Value::as_str)
+        .unwrap_or("form")
+        != "form"
+    {
+        return ElicitationHandling::Forward;
+    }
+    match mode {
+        InteractionMode::Auto if !client_supports_form => ElicitationHandling::Present,
+        InteractionMode::Native => ElicitationHandling::Present,
+        InteractionMode::Auto | InteractionMode::Client => ElicitationHandling::Forward,
+        InteractionMode::Deny => unreachable!("handled above"),
+    }
+}
+
+fn rewrite_server_identity(message: &mut Value) {
+    if message.pointer("/result/protocolVersion").is_none()
+        || message.pointer("/result/capabilities").is_none()
+    {
+        return;
+    }
+    let Some(info) = message
+        .pointer_mut("/result/serverInfo")
+        .and_then(Value::as_object_mut)
+    else {
+        return;
+    };
+    info.insert("name".to_owned(), Value::String("unicity-aos".to_owned()));
+    info.insert("title".to_owned(), Value::String("Unicity AOS".to_owned()));
+    info.insert(
+        "version".to_owned(),
+        Value::String(env!("CARGO_PKG_VERSION").to_owned()),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn initialize(capabilities: Value) -> String {
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": capabilities,
+                "clientInfo": { "name": "test", "version": "1" }
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn auto_advertises_form_only_when_client_cannot_present_it() {
+        let mut supported = false;
+        let forwarded = prepare_client_message(
+            &initialize(json!({ "roots": {} })),
+            InteractionMode::Auto,
+            &mut supported,
+        );
+        let forwarded: Value = serde_json::from_str(&forwarded).expect("json");
+        assert!(!supported);
+        assert!(
+            forwarded
+                .pointer("/params/capabilities/elicitation/form")
+                .is_some()
+        );
+
+        let mut supported = false;
+        let forwarded = prepare_client_message(
+            &initialize(json!({ "elicitation": { "form": {} } })),
+            InteractionMode::Auto,
+            &mut supported,
+        );
+        let forwarded: Value = serde_json::from_str(&forwarded).expect("json");
+        assert!(supported);
+        assert!(
+            forwarded
+                .pointer("/params/capabilities/elicitation/form")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn client_and_deny_modes_never_invent_capabilities() {
+        for mode in [InteractionMode::Client, InteractionMode::Deny] {
+            let mut supported = false;
+            let forwarded = prepare_client_message(&initialize(json!({})), mode, &mut supported);
+            let forwarded: Value = serde_json::from_str(&forwarded).expect("json");
+            assert!(
+                forwarded
+                    .pointer("/params/capabilities/elicitation/form")
+                    .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_initialize_capabilities_are_not_rewritten() {
+        let malformed = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": { "capabilities": "not-an-object" }
+        })
+        .to_string();
+        let mut supported = false;
+        let forwarded = prepare_client_message(&malformed, InteractionMode::Auto, &mut supported);
+        let forwarded: Value = serde_json::from_str(&forwarded).expect("json");
+        assert_eq!(forwarded["params"]["capabilities"], "not-an-object");
+        assert!(!supported);
+    }
+
+    #[test]
+    fn auto_intercepts_only_when_the_client_lacks_form_support() {
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "elicitation/create",
+            "params": { "mode": "form" }
+        });
+        assert_eq!(
+            elicitation_handling(&request, InteractionMode::Auto, false),
+            ElicitationHandling::Present
+        );
+        assert_eq!(
+            elicitation_handling(&request, InteractionMode::Auto, true),
+            ElicitationHandling::Forward
+        );
+        assert_eq!(
+            elicitation_handling(&request, InteractionMode::Native, true),
+            ElicitationHandling::Present
+        );
+    }
+
+    #[test]
+    fn url_elicitation_is_never_intercepted_as_a_local_form() {
+        let request = json!({
+            "method": "elicitation/create",
+            "params": { "mode": "url" }
+        });
+        assert_eq!(
+            elicitation_handling(&request, InteractionMode::Native, false),
+            ElicitationHandling::Forward
+        );
+    }
+
+    #[test]
+    fn deny_mode_cancels_form_and_url_elicitation() {
+        for request in [
+            json!({ "method": "elicitation/create", "params": { "mode": "form" } }),
+            json!({ "method": "elicitation/create", "params": { "mode": "url" } }),
+        ] {
+            assert_eq!(
+                elicitation_handling(&request, InteractionMode::Deny, true),
+                ElicitationHandling::Cancel
+            );
+        }
+    }
+
+    #[test]
+    fn initialize_response_is_product_branded() {
+        let mut response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "serverInfo": { "name": "astrid", "version": "0.10.4" }
+            }
+        });
+        rewrite_server_identity(&mut response);
+        assert_eq!(response["result"]["serverInfo"]["name"], "unicity-aos");
+        assert_eq!(response["result"]["serverInfo"]["title"], "Unicity AOS");
+    }
+}

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -350,40 +350,16 @@ fn bare_aos_shows_product_help_instead_of_claiming_native_chat() {
 fn runtime_verbs_are_first_class_aos_roots_without_a_nested_namespace() {
     let fixture = Fixture::new("direct-runtime-roots");
     fixture.install_runtime(RECORDING_RUNTIME);
+    let contract: toml::Value = include_str!("../../../release/runtime-command-surface.toml")
+        .parse()
+        .expect("parse runtime command surface");
+    let roots = contract["roots"].as_table().expect("root classifications");
+    let direct_roots = ["inherited", "hidden-inherited"]
+        .into_iter()
+        .flat_map(|bucket| roots[bucket].as_array().expect("root classification list"))
+        .map(|root| root.as_str().expect("runtime root string"));
 
-    for root in [
-        "chat",
-        "run",
-        "agent",
-        "group",
-        "caps",
-        "quota",
-        "invite",
-        "keypair",
-        "pair-device",
-        "secret",
-        "voucher",
-        "trust",
-        "audit",
-        "budget",
-        "session",
-        "capsule",
-        "build",
-        "config",
-        "wit",
-        "gc",
-        "start",
-        "stop",
-        "restart",
-        "logs",
-        "ps",
-        "top",
-        "who",
-        "doctor",
-        "setup",
-        "version",
-        "completions",
-    ] {
+    for root in direct_roots {
         let output = fixture
             .command()
             .args([root, "--aos-direct-root-probe"])

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -347,21 +347,56 @@ fn bare_aos_shows_product_help_instead_of_claiming_native_chat() {
 }
 
 #[test]
-fn runtime_is_an_inherited_root_not_a_special_alias() {
-    let fixture = Fixture::new("runtime-root");
+fn runtime_verbs_are_first_class_aos_roots_without_a_nested_namespace() {
+    let fixture = Fixture::new("direct-runtime-roots");
     fixture.install_runtime(RECORDING_RUNTIME);
 
-    let output = fixture
-        .command()
-        .args(["runtime", "status", "--json"])
-        .output()
-        .expect("run aos");
+    for root in [
+        "chat",
+        "run",
+        "agent",
+        "group",
+        "caps",
+        "quota",
+        "invite",
+        "keypair",
+        "pair-device",
+        "secret",
+        "voucher",
+        "trust",
+        "audit",
+        "budget",
+        "session",
+        "capsule",
+        "build",
+        "config",
+        "wit",
+        "gc",
+        "start",
+        "stop",
+        "restart",
+        "logs",
+        "ps",
+        "top",
+        "who",
+        "doctor",
+        "setup",
+        "version",
+        "completions",
+    ] {
+        let output = fixture
+            .command()
+            .args([root, "--aos-direct-root-probe"])
+            .output()
+            .expect("run direct AOS root");
 
-    assert!(output.status.success());
-    assert_eq!(
-        fs::read_to_string(&fixture.args).expect("read delegated args"),
-        "<runtime>\n<status>\n<--json>\n"
-    );
+        assert!(output.status.success(), "direct root failed: {root}");
+        assert_eq!(
+            fs::read_to_string(&fixture.args).expect("read delegated args"),
+            format!("<{root}>\n<--aos-direct-root-probe>\n")
+        );
+        fs::remove_file(&fixture.args).expect("reset delegated args");
+    }
 }
 
 #[test]
@@ -678,7 +713,8 @@ fn product_owns_and_refuses_distro_mutation() {
         assert!(!fixture.args.exists());
         let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
         assert!(stderr.contains("Unicity CE owns the distribution state"));
-        assert!(stderr.contains("standalone `astrid distro ...`"));
+        assert!(stderr.contains("does not expose raw distribution mutation"));
+        assert!(!stderr.contains("astrid distro"));
     }
 }
 

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -2,10 +2,11 @@
 
 use std::ffi::OsStr;
 use std::fs;
+use std::io::Write as _;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 struct Fixture {
@@ -155,6 +156,71 @@ fn unowned_root_passes_through_with_argv_home_and_exit_code() {
         std::env::split_paths(OsStr::new(child_path.trim())).next(),
         fixture.runtime.parent().map(Path::to_path_buf)
     );
+}
+
+#[test]
+fn product_mcp_bridge_adds_local_form_support_and_rebrands_the_server() {
+    let fixture = Fixture::new("product-mcp");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+printf '<%s>\n' "$@" > "$AOS_TEST_ARGS"
+IFS= read -r initialize
+printf '%s\n' "$initialize" > "$AOS_TEST_BOOTSTRAP_ARGS"
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},"serverInfo":{"name":"astrid","version":"0.10.4"}}}'
+while IFS= read -r _line; do :; done
+"#,
+    );
+
+    let mut child = fixture
+        .command()
+        .args(["--principal", "grok-code", "mcp", "serve"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("start product MCP bridge");
+    let mut stdin = child.stdin.take().expect("bridge stdin");
+    writeln!(
+        stdin,
+        "{}",
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "grok", "version": "1" }
+            }
+        })
+    )
+    .expect("write initialize");
+    drop(stdin);
+    let output = child.wait_with_output().expect("wait for MCP bridge");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.args).expect("read runtime args"),
+        "<--principal>\n<grok-code>\n<mcp>\n<serve>\n"
+    );
+    let forwarded: serde_json::Value = serde_json::from_str(
+        fs::read_to_string(&fixture.bootstrap_args)
+            .expect("read forwarded initialize")
+            .trim(),
+    )
+    .expect("forwarded initialize JSON");
+    assert!(
+        forwarded
+            .pointer("/params/capabilities/elicitation/form")
+            .is_some()
+    );
+    let response: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("product initialize response");
+    assert_eq!(response["result"]["serverInfo"]["name"], "unicity-aos");
+    assert_eq!(response["result"]["serverInfo"]["title"], "Unicity AOS");
 }
 
 #[test]
@@ -440,7 +506,7 @@ fn offline_init_keeps_the_runtime_offline_flag_and_uses_only_local_capsules() {
         .parse()
         .expect("parse materialized manifest");
     let capsules = manifest["capsule"].as_array().expect("capsule entries");
-    assert_eq!(capsules.len(), 20);
+    assert_eq!(capsules.len(), 21);
     let expected_root = fixture
         .home
         .join("releases")

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -41,6 +41,12 @@ version = "0.2.0"
 role = "uplink"
 
 [[capsule]]
+name = "aos-mcp"
+source = "capsules/aos-mcp.capsule"
+version = "0.1.0"
+role = "uplink"
+
+[[capsule]]
 name = "aos-registry"
 source = "capsules/aos-registry.capsule"
 version = "0.2.0"

--- a/release/community-capsules.txt
+++ b/release/community-capsules.txt
@@ -3,6 +3,7 @@
 # Keep this in distro order. Published artifact identities come from each
 # capsule's Cargo.toml/Capsule.toml and remain aos-*.
 capsule-cli
+capsule-mcp
 capsule-registry
 capsule-openai-compat
 capsule-react

--- a/release/runtime-command-surface.toml
+++ b/release/runtime-command-surface.toml
@@ -1,0 +1,51 @@
+schema-version = 1
+runtime-version = "0.10.4"
+
+[roots]
+# Public runtime roots delegated byte-for-byte as `aos <verb>`.
+inherited = [
+  "chat",
+  "run",
+  "agent",
+  "group",
+  "caps",
+  "quota",
+  "invite",
+  "keypair",
+  "pair-device",
+  "secret",
+  "voucher",
+  "trust",
+  "audit",
+  "budget",
+  "session",
+  "capsule",
+  "config",
+  "gc",
+  "start",
+  "stop",
+  "restart",
+  "logs",
+  "ps",
+  "top",
+  "who",
+  "doctor",
+  "setup",
+  "version",
+  "completions",
+]
+
+# Public runtime roots replaced at the same location by an AOS implementation.
+product-owned = [
+  "mcp",
+  "distro",
+  "init",
+  "status",
+  "update",
+]
+
+# `aos help <runtime-root>` delegates while AOS owns its own root help.
+shared = ["help"]
+
+# Hidden compatibility roots remain direct even though runtime `--help` omits them.
+hidden-inherited = ["build", "wit"]

--- a/scripts/test-clean-home-init.sh
+++ b/scripts/test-clean-home-init.sh
@@ -94,8 +94,8 @@ expected = sorted(
     for line in assets_path.read_text(encoding="utf-8").splitlines()
     if line
 )
-if len(expected) != 20 or len(set(expected)) != 20:
-    raise SystemExit("release capsule inventory is not the exact 20-capsule CE set")
+if len(expected) != 21 or len(set(expected)) != 21:
+    raise SystemExit("release capsule inventory is not the exact 21-capsule CE set")
 with lock_path.open("rb") as file:
     lock = tomllib.load(file)
 with profile_path.open("rb") as file:

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -251,7 +251,7 @@ release_dir="$work/home/.aos/releases/2026.1.3"
 test -f "$release_dir/release-manifest.json"
 test -f "$release_dir/Distro.toml"
 test -f "$release_dir/capsule-assets.txt"
-test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 20
+test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 21
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"
@@ -608,7 +608,7 @@ for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
   test "$("$destination")" = "old-$binary"
 done
 test "$(cat "$release_dir/release-manifest.json")" = old-release-manifest
-test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 20
+test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 21
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -69,7 +69,7 @@ tar -tzf "$archive" > "$work/files"
 grep -q '/bin/aos$' "$work/files"
 grep -q '/libexec/install.sh$' "$work/files"
 grep -q '/runtime/bin/astrid-daemon$' "$work/files"
-test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 20
+test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 21
 grep -q '/capsule-assets.txt$' "$work/files"
 grep -q '/Distro.toml$' "$work/files"
 grep -q '/release-manifest.json$' "$work/files"
@@ -77,7 +77,7 @@ grep -q '/release-manifest.json$' "$work/files"
 tar -xzf "$archive" -C "$work"
 manifest=$(find "$work" -path '*/release-manifest.json' -print -quit)
 bundle_root=$(dirname "$manifest")
-test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 20
+test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 21
 if grep -F '@unicity-aos/capsule-' "$bundle_root/Distro.toml" >/dev/null; then
   echo "release archive retained a legacy capsule repository source" >&2
   exit 1
@@ -99,9 +99,9 @@ assert manifest["contracts"]["repository"] == "astrid-runtime/wit"
 assert manifest["contracts"]["commit"] == "278dbca3e32f327d0f2358644fc86559779ba0fd"
 assert manifest["contracts"]["sdk_rust_version"] == "0.7.1"
 assert manifest["contracts"]["sdk_rust_commit"] == "bbbc61c8821d6c536fb25d2068b6b646e759ad35"
-assert manifest["capsules"]["count"] == 20
-assert len(manifest["capsules"]["assets"]) == 20
-assert len(set(manifest["capsules"]["assets"])) == 20
+assert manifest["capsules"]["count"] == 21
+assert len(manifest["capsules"]["assets"]) == 21
+assert len(set(manifest["capsules"]["assets"])) == 21
 PY
 
 unsafe_root="$work/unsafe-runtime"

--- a/scripts/test-pinned-runtime-command-surface.sh
+++ b/scripts/test-pinned-runtime-command-surface.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+contract="$repo_root/release/runtime-command-surface.toml"
+
+read -r runtime_version runtime_tag runtime_repository runtime_identity < <(
+  python3 - "$repo_root/release/runtime-compatibility.toml" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+with pathlib.Path(sys.argv[1]).open("rb") as file:
+    runtime = tomllib.load(file)["runtime"]
+print(
+    runtime["version"],
+    runtime["tag"],
+    runtime["repository"],
+    runtime["release-workflow-identity"],
+)
+PY
+)
+
+if [[ -n "${AOS_TEST_RUNTIME_BINARY:-}" ]]; then
+  runtime_binary=$AOS_TEST_RUNTIME_BINARY
+  [[ -x "$runtime_binary" ]] || {
+    echo "test runtime binary is not executable: $runtime_binary" >&2
+    exit 1
+  }
+  python3 "$repo_root/scripts/validate-runtime-command-surface.py" \
+    "$runtime_binary" "$contract" --runtime-version "$runtime_version"
+  exit
+fi
+
+for command in curl b3sum cosign tar; do
+  command -v "$command" >/dev/null || {
+    echo "$command is required to validate the pinned runtime command surface" >&2
+    exit 1
+  }
+done
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+case "$(uname -s):$(uname -m)" in
+  Linux:x86_64) target=x86_64-unknown-linux-gnu ;;
+  Linux:aarch64 | Linux:arm64) target=aarch64-unknown-linux-gnu ;;
+  Darwin:x86_64) target=x86_64-apple-darwin ;;
+  Darwin:aarch64 | Darwin:arm64) target=aarch64-apple-darwin ;;
+  *)
+    echo "unsupported host for runtime command validation: $(uname -s) $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+asset="astrid-${runtime_version}-${target}.tar.gz"
+base="https://github.com/${runtime_repository}/releases/download/${runtime_tag}"
+
+curl --proto '=https' --tlsv1.2 -fsSLo "$work/$asset" "$base/$asset"
+curl --proto '=https' --tlsv1.2 -fsSLo "$work/BLAKE3SUMS.txt" "$base/BLAKE3SUMS.txt"
+curl --proto '=https' --tlsv1.2 -fsSLo "$work/$asset.sigstore.json" \
+  "$base/$asset.sigstore.json"
+expected=$(awk -v asset="$asset" '$2 == asset { print $1; exit }' "$work/BLAKE3SUMS.txt")
+[[ "$expected" =~ ^[0-9a-f]{64}$ ]]
+[[ "$(b3sum -- "$work/$asset" | awk '{print $1}')" == "$expected" ]]
+cosign verify-blob \
+  --bundle "$work/$asset.sigstore.json" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity "$runtime_identity" \
+  "$work/$asset" >/dev/null
+
+root="astrid-${runtime_version}-${target}"
+python3 "$repo_root/scripts/validate-runtime-archive.py" "$work/$asset" "$root" astrid
+tar -xzf "$work/$asset" -C "$work"
+python3 "$repo_root/scripts/validate-runtime-command-surface.py" \
+  "$work/$root/astrid" "$contract" --runtime-version "$runtime_version"

--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -85,15 +85,15 @@ class CapsuleReleaseTests(unittest.TestCase):
             write_fixture(directory / spec.asset, spec)
 
     def test_source_contract_has_exact_community_set(self) -> None:
-        self.assertEqual(len(self.specs), 20)
-        self.assertEqual(len({spec.asset for spec in self.specs}), 20)
+        self.assertEqual(len(self.specs), 21)
+        self.assertEqual(len({spec.asset for spec in self.specs}), 21)
         assets = {spec.asset for spec in self.specs}
         self.assertIn("aos-forge.capsule", assets)
         self.assertNotIn("aos-telegram.capsule", assets)
         distro = Path(__file__).resolve().parent.parent / "distros/community/unicity-ce/Distro.toml"
         text = distro.read_text(encoding="utf-8")
         self.assertNotIn("@unicity-aos/", text)
-        self.assertEqual(text.count('source = "capsules/'), 20)
+        self.assertEqual(text.count('source = "capsules/'), 21)
         for spec in self.specs:
             self.assertIn(f'source = "capsules/{spec.asset}"', text)
 

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -113,7 +113,7 @@ class ReleasePublicationTests(unittest.TestCase):
             artifacts, compatibility = self.fixture(Path(temp))
             payloads = self.validate(artifacts, compatibility)
             self.assertIn(f"unicity-aos-{VERSION}-release.toml", payloads)
-            self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 20)
+            self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 21)
 
     def test_rejects_missing_asset(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/test_runtime_command_surface.py
+++ b/scripts/test_runtime_command_surface.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Regression tests for the pinned runtime root-command contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate-runtime-command-surface.py")
+SPEC = importlib.util.spec_from_file_location("runtime_command_surface", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("could not load runtime command surface validator")
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+
+
+class RuntimeCommandSurfaceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.contract_path = Path(self.temporary_directory.name) / "surface.toml"
+
+    def write_contract(self, extra: str = "") -> Path:
+        self.contract_path.write_text(
+            'schema-version = 1\nruntime-version = "0.10.4"\n'
+            "[roots]\n"
+            'inherited = ["agent"]\n'
+            'product-owned = ["mcp"]\n'
+            'shared = ["help"]\n'
+            f'hidden-inherited = ["build"]\n{extra}',
+            encoding="utf-8",
+        )
+        return self.contract_path
+
+    def test_help_parser_ignores_wrapped_descriptions(self) -> None:
+        parsed = VALIDATOR.parse_help(
+            "Commands:\n"
+            "  agent  Manage agents with a description\n"
+            "         that wraps onto another line\n"
+            "  help   Print help\n\n"
+            "Options:\n  -h, --help  Print help\n"
+        )
+        self.assertEqual(parsed, {"agent", "help"})
+
+    def test_new_runtime_root_fails_until_classified(self) -> None:
+        contract = VALIDATOR.load_contract(self.write_contract(), "0.10.4")
+        with self.assertRaisesRegex(VALIDATOR.SurfaceError, "unclassified.*quota"):
+            VALIDATOR.validate({"agent", "help", "mcp", "quota"}, contract)
+
+    def test_removed_runtime_root_is_reported(self) -> None:
+        contract = VALIDATOR.load_contract(self.write_contract(), "0.10.4")
+        with self.assertRaisesRegex(VALIDATOR.SurfaceError, "missing.*agent"):
+            VALIDATOR.validate({"help", "mcp"}, contract)
+
+    def test_contract_is_bound_to_the_runtime_version(self) -> None:
+        with self.assertRaisesRegex(VALIDATOR.SurfaceError, "version"):
+            VALIDATOR.load_contract(self.write_contract(), "0.10.5")
+
+    def test_roots_cannot_be_classified_twice(self) -> None:
+        path = self.write_contract().read_text(encoding="utf-8").replace(
+            'product-owned = ["mcp"]', 'product-owned = ["agent"]'
+        )
+        self.contract_path.write_text(path, encoding="utf-8")
+        with self.assertRaisesRegex(VALIDATOR.SurfaceError, "more than once"):
+            VALIDATOR.load_contract(self.contract_path, "0.10.4")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-runtime-command-surface.py
+++ b/scripts/validate-runtime-command-surface.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Validate AOS's root command contract against a pinned runtime binary."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 release fallback
+    import tomli as tomllib
+
+
+ROOT_NAME = re.compile(r"^[a-z][a-z0-9-]*$")
+COMMAND_LINE = re.compile(r"^  ([a-z][a-z0-9-]*) {2,}\S")
+PUBLIC_BUCKETS = ("inherited", "product-owned", "shared")
+ALL_BUCKETS = (*PUBLIC_BUCKETS, "hidden-inherited")
+
+
+class SurfaceError(ValueError):
+    """The runtime command surface and AOS contract disagree."""
+
+
+def load_contract(path: Path, runtime_version: str) -> dict[str, list[str]]:
+    """Load and validate the version-bound AOS command classification."""
+    with path.open("rb") as file:
+        value = tomllib.load(file)
+    if value.get("schema-version") != 1:
+        raise SurfaceError("runtime command surface schema-version must be 1")
+    if value.get("runtime-version") != runtime_version:
+        raise SurfaceError(
+            "runtime command surface version does not match runtime-compatibility"
+        )
+    roots = value.get("roots")
+    if not isinstance(roots, dict) or set(roots) != set(ALL_BUCKETS):
+        raise SurfaceError(
+            "runtime command surface must define exactly inherited, product-owned, shared, and hidden-inherited roots"
+        )
+
+    parsed: dict[str, list[str]] = {}
+    seen: set[str] = set()
+    for bucket in ALL_BUCKETS:
+        entries = roots.get(bucket)
+        if not isinstance(entries, list) or not entries:
+            raise SurfaceError(f"runtime command surface {bucket} must be a non-empty list")
+        for entry in entries:
+            if not isinstance(entry, str) or ROOT_NAME.fullmatch(entry) is None:
+                raise SurfaceError(f"invalid runtime command root in {bucket}: {entry!r}")
+            if entry in seen:
+                raise SurfaceError(f"runtime command root is classified more than once: {entry}")
+            seen.add(entry)
+        parsed[bucket] = entries
+    return parsed
+
+
+def parse_help(text: str) -> set[str]:
+    """Extract public root commands from Clap's stable Commands section."""
+    inside = False
+    commands: set[str] = set()
+    for line in text.splitlines():
+        if line == "Commands:":
+            inside = True
+            continue
+        if inside and line == "Options:":
+            break
+        if inside and (match := COMMAND_LINE.match(line)):
+            commands.add(match.group(1))
+    if not inside or not commands:
+        raise SurfaceError("runtime --help did not contain a parseable Commands section")
+    return commands
+
+
+def validate(actual: set[str], contract: dict[str, list[str]]) -> None:
+    """Require the actual public runtime inventory to match the contract exactly."""
+    expected = {
+        root for bucket in PUBLIC_BUCKETS for root in contract[bucket]
+    }
+    if actual == expected:
+        return
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    details = []
+    if missing:
+        details.append(f"missing from runtime: {', '.join(missing)}")
+    if unexpected:
+        details.append(f"new or unclassified runtime roots: {', '.join(unexpected)}")
+    raise SurfaceError("runtime command surface changed; " + "; ".join(details))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("runtime", type=Path)
+    parser.add_argument("contract", type=Path)
+    parser.add_argument("--runtime-version", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    contract = load_contract(args.contract, args.runtime_version)
+    result = subprocess.run(
+        [args.runtime, "--help"],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise SurfaceError(
+            f"runtime --help failed with exit {result.returncode}: {result.stderr.strip()}"
+        )
+    validate(parse_help(result.stdout), contract)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, subprocess.SubprocessError, SurfaceError) as error:
+        print(f"runtime command surface error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error


### PR DESCRIPTION
## Summary

- make AOS CE own the host-facing `aos mcp serve` command, MCP server identity, and interaction policy
- move the shared `aos-mcp` broker and installable capsule into the AOS CE source and signed release inventory
- add trusted local approval presentation for MCP hosts without form elicitation support
- preserve the full runtime command surface directly as `aos <verb>`, with no `aos astrid` or `aos runtime` namespace

## Why

MCP and cross-host interaction are AOS product concerns, not Oracle host-adapter concerns. Codex and Claude can present MCP forms themselves, while Grok currently cannot. AOS needs one product-owned edge that negotiates the client capability and supplies a local decision surface when the host lacks it.

The runtime remains the neutral security and execution engine. This change gives AOS ownership of presentation, policy, product identity, packaging, and the broker capsule without putting product logic into that engine.

## Interaction and security

- `--interaction auto` leaves form elicitation with capable MCP clients and falls back locally otherwise
- `client` requires the host, `native` forces the local provider, and `deny` cancels every form or URL elicitation
- local presentation uses AppKit on macOS, a native Windows confirmation, and Pinentry on Linux
- the local bridge accepts only one boolean decision or the fixed approval enum
- free-form strings, password-shaped schemas, malformed choices, and URL authentication are never collected locally
- cancellation, parser failures, and provider failures never synthesize consent

## CLI boundary

AOS-owned roots such as `init`, `status`, `update`, and `mcp` replace their lower-level equivalents at the same root. Every other runtime verb is delegated byte-for-byte as `aos <verb>`.

The release contract classifies every public root in the exact pinned Astrid binary as inherited, product-owned, or shared. CI downloads the signed runtime release, verifies its Sigstore workflow identity and BLAKE3 digest, and compares its live `--help` inventory with that contract. A newly added or removed Astrid root therefore fails before an AOS release until its ownership is explicit. Separate router and boundary tests prove the classification matches actual dispatch and that inherited commands remain direct roots.

## Compatibility

The pinned runtime's existing MCP shim remains an internal compatibility transport for this release. AOS owns the public command, identity, negotiation, and policy. Removing the inner transport can happen later as a coordinated runtime change without breaking older installations.

## Validation

- `cargo fmt --all -- --check`
- native and WASM `cargo clippy` with warnings denied
- bootstrap and complete capsule workspace tests
- full Python release-contract suite
- signed pinned-runtime command inventory validation on macOS and Linux CI
- capsule release planning and installable `aos-mcp.capsule` build
- package, install, upgrade/self-heal, runtime boot, channel, and extraction harnesses
- end-to-end stdio bridge test with capability negotiation and product identity rewriting
