### PR TITLE
fix(release): enforce Linux glibc baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,53 @@ env:
   B3SUM_VERSION: 1.8.5
 
 jobs:
+  linux-release-smoke:
+    name: Linux release smoke (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - name: Build against the Linux release baseline
+        env:
+          TARGET: ${{ matrix.target }}
+          # Keep this digest synchronized with release.yml.
+          LINUX_BUILD_IMAGE: docker.io/library/rust:1.95.0-bullseye@sha256:646e8ceea789b00c5cfa339816a3ed44940dbf1651dc167b78f3c0aefcae0025
+        run: |
+          docker run --rm \
+            --env TARGET \
+            --volume "$PWD:/workspace" \
+            --workdir /workspace \
+            "$LINUX_BUILD_IMAGE" \
+            bash -euxo pipefail -c '
+              if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
+                rustup target add aarch64-unknown-linux-gnu
+                apt-get update
+                apt-get install -y --no-install-recommends \
+                  gcc-aarch64-linux-gnu \
+                  libc6-dev-arm64-cross
+                export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+              fi
+              export CARGO_TARGET_DIR=/workspace/target/glibc-2.31
+              cargo build --locked --release --target "$TARGET" -p unicity-aos-bootstrap
+            '
+      - name: Enforce the Linux glibc compatibility ceiling
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          python3 scripts/check_glibc.py --max-version 2.34 \
+            "target/glibc-2.31/${TARGET}/release/aos"
+
   format:
     name: Format
     runs-on: ubuntu-latest
@@ -44,6 +91,7 @@ jobs:
       - run: cargo install b3sum --locked --version "$B3SUM_VERSION"
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - run: sh -n install.sh
+      - run: python3 scripts/test_check_glibc.py
       - run: python3 scripts/validate-release-contract.py
       - run: python3 scripts/test_validate_release_contract.py
       - run: python3 scripts/test_release_metadata.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,7 @@ jobs:
       - run: python3 scripts/test_capsule_release.py
       - run: python3 scripts/test_validate_runtime_archive.py
       - run: bash scripts/test-extract-runtime-tool.sh
+      - run: python3 scripts/test_check_glibc.py
       - run: sh -n install.sh
 
   build:
@@ -167,12 +168,8 @@ jobs:
         with:
           toolchain: '1.95.0'
           targets: ${{ matrix.target }}
-      - name: Install Linux ARM linker
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: ${{ !endsWith(matrix.target, 'linux-gnu') }}
         with:
           key: aos-release-${{ matrix.target }}
       - name: Install pinned BLAKE3 checksum tool
@@ -189,9 +186,36 @@ jobs:
           print(f"RUNTIME_IDENTITY={metadata['release-workflow-identity']}")
           PY
       - name: Build product binary
+        if: ${{ !endsWith(matrix.target, 'linux-gnu') }}
+        run: |
+          cargo build --locked --release --target "${{ matrix.target }}" -p unicity-aos-bootstrap
+          echo "AOS_BINARY=target/${{ matrix.target }}/release/aos" >> "$GITHUB_ENV"
+      - name: Build Linux product binary against glibc 2.31
+        if: ${{ endsWith(matrix.target, 'linux-gnu') }}
         env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-        run: cargo build --locked --release --target "${{ matrix.target }}" -p unicity-aos-bootstrap
+          LINUX_BUILD_IMAGE: docker.io/library/rust:1.95.0-bullseye@sha256:646e8ceea789b00c5cfa339816a3ed44940dbf1651dc167b78f3c0aefcae0025
+          TARGET: ${{ matrix.target }}
+        run: |
+          docker run --rm \
+            -e TARGET \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            "$LINUX_BUILD_IMAGE" \
+            bash -euxo pipefail -c '
+              if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
+                rustup target add aarch64-unknown-linux-gnu
+                apt-get update
+                apt-get install -y --no-install-recommends \
+                  gcc-aarch64-linux-gnu \
+                  libc6-dev-arm64-cross
+                export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+              fi
+              export CARGO_TARGET_DIR=/workspace/target/glibc-2.31
+              cargo build --locked --release --target "$TARGET" -p unicity-aos-bootstrap
+            '
+          AOS_BINARY="target/glibc-2.31/${{ matrix.target }}/release/aos"
+          python3 scripts/check_glibc.py --max-version 2.34 "$AOS_BINARY"
+          echo "AOS_BINARY=$AOS_BINARY" >> "$GITHUB_ENV"
       - name: Download pinned runtime release
         run: |
           ASSET="astrid-${RUNTIME_VERSION}-${{ matrix.target }}.tar.gz"
@@ -212,6 +236,22 @@ jobs:
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             --certificate-identity "$RUNTIME_IDENTITY" \
             "$RUNTIME_ASSET"
+      - name: Verify Linux runtime glibc compatibility
+        if: ${{ endsWith(matrix.target, 'linux-gnu') }}
+        run: |
+          RUNTIME_ROOT="astrid-${RUNTIME_VERSION}-${{ matrix.target }}"
+          CHECK_ROOT="$RUNNER_TEMP/runtime-glibc-check"
+          python3 scripts/validate-runtime-archive.py \
+            "$RUNTIME_ASSET" \
+            "$RUNTIME_ROOT" \
+            astrid astrid-daemon astrid-build astrid-emit
+          mkdir "$CHECK_ROOT"
+          tar -xzf "$RUNTIME_ASSET" -C "$CHECK_ROOT"
+          python3 scripts/check_glibc.py --max-version 2.34 \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid-daemon" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid-build" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid-emit"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: capsule-artifacts
@@ -221,7 +261,7 @@ jobs:
           python3 scripts/capsule_release.py --artifacts capsule-artifacts
           scripts/package-release.sh \
             "${{ matrix.target }}" \
-            "target/${{ matrix.target }}/release/aos" \
+            "$AOS_BINARY" \
             "$RUNTIME_ASSET" \
             "$RUNTIME_BLAKE3" \
             capsule-artifacts \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,12 @@
   lock is available; all other inherited runtime failures retain their output
   and exit status.
 
+### Fixed
+
+- Build Linux product binaries on a pinned glibc 2.31 baseline and reject AOS
+  or bundled Astrid executables that require glibc newer than 2.34, restoring
+  support for RHEL, Oracle Linux, Rocky Linux, and AlmaLinux 9. Closes #58.
+
 ### Removed
 
 - The vendored `capsules/capsule-telegram` copy. The capsule is maintained in

--- a/scripts/check_glibc.py
+++ b/scripts/check_glibc.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Reject ELF binaries that require a newer glibc than the release baseline."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+
+
+GLIBC_VERSION = re.compile(r"\bGLIBC_(\d+)\.(\d+)(?:\.(\d+))?\b")
+
+
+def parse_version(value: str) -> tuple[int, ...]:
+    parts = value.split(".")
+    if len(parts) < 2 or any(not part.isdigit() for part in parts):
+        raise ValueError(f"invalid glibc version {value!r}")
+    return tuple(int(part) for part in parts)
+
+
+def required_versions(version_info: str) -> set[tuple[int, ...]]:
+    return {
+        tuple(int(part) for part in match.groups() if part is not None)
+        for match in GLIBC_VERSION.finditer(version_info)
+    }
+
+
+def check_binary(path: pathlib.Path, ceiling: tuple[int, ...]) -> None:
+    if not path.is_file() or path.is_symlink():
+        raise ValueError(f"binary is missing or not a regular file: {path}")
+    try:
+        result = subprocess.run(
+            ["readelf", "--version-info", "--wide", "--", str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise ValueError("readelf is required to validate glibc compatibility") from error
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() if error.stderr else "unknown readelf error"
+        raise ValueError(f"could not inspect {path}: {stderr}") from error
+
+    versions = required_versions(result.stdout)
+    if versions and max(versions) > ceiling:
+        required = ".".join(str(part) for part in max(versions))
+        maximum = ".".join(str(part) for part in ceiling)
+        raise ValueError(f"{path} requires GLIBC_{required}, newer than GLIBC_{maximum}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-version", required=True)
+    parser.add_argument("binary", nargs="+", type=pathlib.Path)
+    args = parser.parse_args()
+
+    try:
+        ceiling = parse_version(args.max_version)
+        for binary in args.binary:
+            check_binary(binary, ceiling)
+    except ValueError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_glibc.py
+++ b/scripts/test_check_glibc.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+import pathlib
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+import check_glibc
+
+
+class GlibcCompatibilityTests(unittest.TestCase):
+    def test_extracts_unique_required_versions(self) -> None:
+        versions = check_glibc.required_versions(
+            """
+            0x0010: Name: GLIBC_2.17  Flags: none
+            0x0020: Name: GLIBC_2.34  Flags: none
+            0x0030: Name: GLIBC_2.17  Flags: none
+            """
+        )
+        self.assertEqual(versions, {(2, 17), (2, 34)})
+
+    def test_ignores_similar_non_glibc_symbols(self) -> None:
+        self.assertEqual(
+            check_glibc.required_versions("GLIBCXX_3.4 CXXABI_1.3"),
+            set(),
+        )
+
+    def test_rejects_malformed_ceiling(self) -> None:
+        for value in ("2", "2.x", "v2.34"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                check_glibc.parse_version(value)
+
+    def test_check_binary_enforces_ceiling_and_reports_readelf_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            binary = pathlib.Path(directory) / "aos"
+            binary.write_bytes(b"ELF fixture")
+            with mock.patch.object(
+                check_glibc.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(
+                    args=[],
+                    returncode=0,
+                    stdout="Name: GLIBC_2.30",
+                    stderr="",
+                ),
+            ):
+                check_glibc.check_binary(binary, (2, 34))
+
+            with mock.patch.object(
+                check_glibc.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(
+                    args=[],
+                    returncode=0,
+                    stdout="Name: GLIBC_2.39",
+                    stderr="",
+                ),
+            ), self.assertRaisesRegex(ValueError, "newer than GLIBC_2.34"):
+                check_glibc.check_binary(binary, (2, 34))
+
+            failure = subprocess.CalledProcessError(
+                1,
+                ["readelf"],
+                stderr="invalid ELF",
+            )
+            with mock.patch.object(
+                check_glibc.subprocess,
+                "run",
+                side_effect=failure,
+            ), self.assertRaisesRegex(ValueError, "invalid ELF"):
+                check_glibc.check_binary(binary, (2, 34))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #58

## Summary

Linux AOS GNU release binaries are built in a digest-pinned Debian Bullseye
environment, and packaging rejects AOS or bundled Astrid executables that
require glibc newer than 2.34.

## Changes

- build x86_64 and ARM64 GNU AOS binaries with the qualified, digest-pinned
  official Rust 1.95.0 Bullseye image
- install the explicit ARM64 development sysroot as well as the cross compiler
- validate the AOS executable before packaging
- safely inspect the downloaded, signed runtime archive and validate all four
  Astrid executables
- run non-publishing x86_64 and ARM64 GNU product release-smoke builds in
  ordinary CI
- retain the fail-closed runtime compatibility gate

## Verification

Exact head `f06819b68e1a25a97c1c4f43cca8d0160d0349ad` on
`238b9edcd8f352612ddf929bc149e6d54993ea1c`.

- GPG: good signature from Joshua J. Bouw `<jjb@unicity-labs.com>`
- DCO: `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`
- `python3 scripts/test_check_glibc.py`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check`
- GitHub CI at this head is in progress

## Residuals and claim limits

- Product version remains 2026.1.3. This PR does not bump release metadata.
- Astrid remains the signed 0.10.4 identity in `release/runtime-compatibility.toml`.
  The GNU runtime archive currently requires GLIBC_2.39, so the new fail-closed
  packaging check will block publication until a later, separately pinned
  compatible runtime exists.
- Musl targets, Distro Apply layout, and live install journeys are out of scope.
- Local GNU container smoke was not re-run on this reconstruction host.

## AI / tool disclosure

Codex was used to reconstruct this change onto current `main`.
