### PR TITLE
fix(status): honor the selected principal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@
 - Parse AOS-owned commands with Clap-generated validation and help while
   preserving byte-for-byte delegation of inherited runtime commands and their
   help surfaces.
+- Authenticate native `aos status` requests as the principal selected by
+  `--principal`, while preserving the single-user `default` when the flag is
+  omitted.
 - Initialize against the operator-enforced Community Edition manifest and ask
   the runtime to grant its installed capsule set to the resolved target
   principal.

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -781,9 +781,9 @@ fn handle_hook(principal: Option<String>, args: hook::HookArgs) -> ExitCode {
 
 fn status_principal(
     leading_principal: Option<String>,
-    status_principal: Option<String>,
+    trailing_principal: Option<String>,
 ) -> Result<PrincipalId, String> {
-    let principal = match (leading_principal, status_principal) {
+    let principal = match (leading_principal, trailing_principal) {
         (Some(_), Some(_)) => {
             return Err(
                 "'--principal' was provided both before and after `status`; provide it once"

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -11,6 +11,7 @@ use std::process::ExitStatus;
 use std::process::{Command, ExitCode};
 use std::time::Duration;
 
+use astrid_core::PrincipalId;
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use unicity_aos_bootstrap::{AOS_WORKSPACE_STATE_DIR, AosHome};
 
@@ -81,6 +82,14 @@ struct DistroArgs {
 
 #[derive(Args)]
 struct StatusArgs {
+    /// Authenticated runtime principal for this status request.
+    #[arg(
+        id = "status-principal",
+        long = "principal",
+        value_name = "PRINCIPAL",
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
+    principal: Option<String>,
     /// Print a machine-readable JSON status object.
     #[arg(long)]
     json: bool,
@@ -297,18 +306,21 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
                     | ProductCommand::Distro(_)
                     | ProductCommand::Hook(_)
                     | ProductCommand::Mcp { .. }
+                    | ProductCommand::Status(_)
             )
         )
     {
         eprintln!(
-            "aos: '--principal' is supported for `aos init`, `aos hook`, and `aos mcp`; this AOS-owned command does not accept a runtime principal"
+            "aos: '--principal' is supported for `aos init`, `aos status`, `aos hook`, and `aos mcp`; this AOS-owned command does not accept a runtime principal"
         );
         return Some(ExitCode::from(2));
     }
 
     match cli.command {
         Some(ProductCommand::Init(_)) => None,
-        Some(ProductCommand::Status(args)) => Some(handle_status(args.json)),
+        Some(ProductCommand::Status(args)) => {
+            Some(handle_status(cli.principal, args.principal, args.json))
+        }
         Some(ProductCommand::Migrate {
             command: MigrateCommand::Runtime { from },
         }) => Some(handle_migrate_runtime(&from)),
@@ -767,7 +779,41 @@ fn handle_hook(principal: Option<String>, args: hook::HookArgs) -> ExitCode {
     }
 }
 
-fn handle_status(json: bool) -> ExitCode {
+fn status_principal(
+    leading_principal: Option<String>,
+    status_principal: Option<String>,
+) -> Result<PrincipalId, String> {
+    let principal = match (leading_principal, status_principal) {
+        (Some(_), Some(_)) => {
+            return Err(
+                "'--principal' was provided both before and after `status`; provide it once"
+                    .to_owned(),
+            );
+        }
+        (Some(principal), None) | (None, Some(principal)) => Some(principal),
+        (None, None) => None,
+    };
+    principal.map_or_else(
+        || Ok(PrincipalId::default()),
+        |principal| {
+            PrincipalId::new(principal)
+                .map_err(|error| format!("invalid status principal: {error}"))
+        },
+    )
+}
+
+fn handle_status(
+    leading_principal: Option<String>,
+    command_principal: Option<String>,
+    json: bool,
+) -> ExitCode {
+    let principal = match status_principal(leading_principal, command_principal) {
+        Ok(principal) => principal,
+        Err(error) => {
+            eprintln!("aos: {error}");
+            return ExitCode::from(2);
+        }
+    };
     let home = match resolve_home() {
         Ok(home) => home,
         Err(code) => return code,
@@ -783,7 +829,9 @@ fn handle_status(json: bool) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    let status = match runtime.block_on(unicity_aos_bootstrap::status::read(&home)) {
+    let status = match runtime.block_on(unicity_aos_bootstrap::status::read_for_principal(
+        &home, principal,
+    )) {
         Ok(status) => status,
         Err(error) => {
             eprintln!("aos: runtime status unavailable: {error}");
@@ -924,6 +972,7 @@ mod tests {
     use super::{
         ProductCli, ProductCommand, child_exit_code, handle_product_command, help_targets_product,
         is_owned_root, leading_owned_root, runtime_args_for_dispatch, runtime_stop_requested,
+        status_principal,
     };
 
     #[test]
@@ -955,6 +1004,46 @@ mod tests {
         assert!(init.allow_unsigned);
         assert!(init.accept_new_key);
         assert_eq!(init.vars, ["model=gpt-5"]);
+    }
+
+    #[test]
+    fn product_cli_parses_and_validates_status_principal() {
+        let cli = ProductCli::try_parse_from(["aos", "--principal", "alice", "status"])
+            .expect("parse principal-scoped product status");
+        assert_eq!(cli.principal.as_deref(), Some("alice"));
+        let Some(ProductCommand::Status(status)) = cli.command else {
+            panic!("expected status");
+        };
+        assert!(status.principal.is_none());
+
+        let cli = ProductCli::try_parse_from(["aos", "status", "--principal", "bob"])
+            .expect("parse status-local principal");
+        assert!(cli.principal.is_none());
+        let Some(ProductCommand::Status(status)) = cli.command else {
+            panic!("expected status");
+        };
+        assert_eq!(status.principal.as_deref(), Some("bob"));
+
+        assert_eq!(
+            status_principal(Some("alice".to_owned()), None)
+                .expect("valid explicit principal")
+                .as_str(),
+            "alice"
+        );
+        assert_eq!(
+            status_principal(None, Some("bob".to_owned()))
+                .expect("valid status-local principal")
+                .as_str(),
+            "bob"
+        );
+        assert_eq!(
+            status_principal(None, None)
+                .expect("omitted principal keeps compatibility default")
+                .as_str(),
+            "default"
+        );
+        assert!(status_principal(None, Some("not/a/principal".to_owned())).is_err());
+        assert!(status_principal(Some("alice".to_owned()), Some("bob".to_owned())).is_err());
     }
 
     #[test]

--- a/crates/unicity-aos-bootstrap/src/status.rs
+++ b/crates/unicity-aos-bootstrap/src/status.rs
@@ -64,17 +64,24 @@ impl AosStatus {
     }
 }
 
-/// Read status through the typed authenticated local control client.
+/// Read status through the typed authenticated local control client using the
+/// single-user compatibility principal.
 pub async fn read(home: &AosHome) -> Result<AosStatus, String> {
-    let connection = tokio::time::timeout(
-        STATUS_TIMEOUT,
-        KernelClient::connect(PrincipalId::default()),
-    )
-    .await
-    .map_err(|_| "connection timed out".to_owned())
-    .and_then(|result| {
-        result.map_err(|error| format!("could not connect to the local runtime: {error}"))
-    });
+    read_for_principal(home, PrincipalId::default()).await
+}
+
+/// Read status through the typed authenticated local control client as
+/// `principal`.
+pub async fn read_for_principal(
+    home: &AosHome,
+    principal: PrincipalId,
+) -> Result<AosStatus, String> {
+    let connection = tokio::time::timeout(STATUS_TIMEOUT, KernelClient::connect(principal))
+        .await
+        .map_err(|_| "connection timed out".to_owned())
+        .and_then(|result| {
+            result.map_err(|error| format!("could not connect to the local runtime: {error}"))
+        });
     let mut client = match connection {
         Ok(client) => client,
         Err(connection_error) => {

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -630,7 +630,6 @@ fn unsupported_leading_globals_cannot_bypass_product_roots() {
     fixture.install_runtime(RECORDING_RUNTIME);
 
     for args in [
-        vec!["--principal", "alice", "status"],
         vec!["--format", "json", "init"],
         vec!["-p", "prompt text", "init"],
         vec!["--principal", "alice", "update"],
@@ -644,6 +643,65 @@ fn unsupported_leading_globals_cannot_bypass_product_roots() {
         assert_eq!(output.status.code(), Some(2));
         assert!(!fixture.args.exists());
     }
+}
+
+#[test]
+fn explicit_principal_is_accepted_in_either_product_status_position() {
+    let fixture = Fixture::new("principal-status");
+    fixture.install_runtime(RECORDING_RUNTIME);
+
+    for args in [
+        ["--principal", "alice", "status", "--json"],
+        ["status", "--principal", "alice", "--json"],
+    ] {
+        let output = fixture
+            .command()
+            .args(args)
+            .output()
+            .expect("run principal-scoped product status");
+
+        assert!(
+            output.status.success(),
+            "args: {args:?}; stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let status: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("parse product status JSON");
+        assert_eq!(status["state"], "stopped");
+    }
+    assert!(
+        !fixture.args.exists(),
+        "product status must not delegate to the runtime binary"
+    );
+
+    let invalid = fixture
+        .command()
+        .args(["status", "--principal", "not/a/principal"])
+        .output()
+        .expect("reject invalid product status principal");
+    assert_eq!(invalid.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&invalid.stderr).contains("invalid status principal"),
+        "stderr: {}",
+        String::from_utf8_lossy(&invalid.stderr)
+    );
+
+    let conflict = fixture
+        .command()
+        .args(["--principal", "alice", "status", "--principal", "bob"])
+        .output()
+        .expect("reject duplicate product status principals");
+    assert_eq!(conflict.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&conflict.stderr)
+            .contains("'--principal' was provided both before and after `status`"),
+        "stderr: {}",
+        String::from_utf8_lossy(&conflict.stderr)
+    );
+    assert!(
+        !fixture.args.exists(),
+        "invalid product status invocations must not delegate"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Linked issue

Closes #60

## Summary

Authenticate AOS-owned runtime status requests as the principal explicitly
selected by the operator, while preserving `default` when no flag is supplied.

## Changes

- accept both `aos --principal alice status` and
  `aos status --principal alice`
- reject malformed principals and duplicate pre/post-root specifications before
  resolving the AOS home or opening a runtime connection
- pass the validated `PrincipalId` directly to `KernelClient::connect`
- retain `status::read(&AosHome)` as a source-compatible default-principal
  wrapper and add the principal-aware API additively
- keep status product-owned and never delegate it to the Astrid binary
- preserve the existing status response shape and no-flag behavior

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p unicity-aos-bootstrap --all-targets`
- `cargo clippy -p unicity-aos-bootstrap --all-targets --all-features -- -D warnings`
- `git diff --check`
- independent CLI-boundary, authority, and compatibility review

Regression coverage exercises both flag positions, omission, malformed values,
duplicate specifications, and the product/runtime delegation boundary.

