### PR TITLE
feat(daemon): add foreground supervisor command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- A product-owned `aos daemon foreground` supervisor path that runs the
+  persistent bundled daemon under the enforced CE distro, private runtime home,
+  `.aos` workspace layout, and stderr logging environment. On Unix the daemon
+  replaces the AOS process so it directly owns signals and exit status. Closes
+  #64.
 - The `aos` product command and product-owned `~/.aos` state boundary.
 - A pinned Unicity CE distribution manifest over Astrid Runtime 0.10.4, emplaced
   as the bundled runtime's operator-enforced distro.

--- a/README.md
+++ b/README.md
@@ -41,13 +41,21 @@ generated runtime coordination state.
 ## Command boundary
 
 AOS owns its product roots, including `init`, `status`, `migrate`, `update`,
-`distro`, `mcp`, and `serve-health`:
+`distro`, `mcp`, `daemon`, and `serve-health`:
 
 ```sh
 aos status
 aos status --json
 aos --principal codex-code mcp serve
+aos daemon foreground --workspace /workspace
 ```
+
+On Unix, `aos daemon foreground` replaces the AOS process with the persistent
+bundled daemon, preserving direct signal and exit-status ownership for process
+supervisors. On other hosts it waits for the daemon and preserves its exit
+status. Both paths apply the product-owned runtime home, `.aos` workspace
+layout, enforced Community Edition distro, and stderr logging environment.
+Neither path enables ephemeral lifetime.
 
 Every other runtime root is part of the AOS CLI directly. Arguments, exit
 codes, and signals pass through unchanged; there is no nested `aos astrid` or

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -243,6 +243,13 @@ impl AosHome {
         self.runtime_binary_with(|name| std::env::var_os(name))
     }
 
+    /// The daemon executable installed beside the bundled runtime CLI.
+    #[must_use]
+    pub fn runtime_daemon_binary(&self) -> PathBuf {
+        self.runtime_binary()
+            .with_file_name(runtime_daemon_binary_name())
+    }
+
     fn runtime_binary_with<F>(&self, get: F) -> PathBuf
     where
         F: Fn(&str) -> Option<OsString>,
@@ -315,13 +322,21 @@ impl AosHome {
         S: AsRef<OsStr>,
     {
         let runtime_binary = self.runtime_binary();
-        let runtime_bin = runtime_binary.parent().ok_or_else(|| {
+        self.runtime_executable_command(&runtime_binary, args)
+    }
+
+    fn runtime_executable_command<I, S>(&self, executable: &Path, args: I) -> io::Result<Command>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let runtime_bin = executable.parent().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "bundled runtime executable must have a parent directory",
             )
         })?;
-        let mut command = Command::new(&runtime_binary);
+        let mut command = Command::new(executable);
         command
             .env("ASTRID_HOME", self.runtime_home())
             .env("ASTRID_WORKSPACE_STATE_DIR", AOS_WORKSPACE_STATE_DIR)
@@ -331,6 +346,37 @@ impl AosHome {
                 Self::runtime_child_path(runtime_bin, std::env::var_os("PATH"))?,
             );
         command.args(args);
+        Ok(command)
+    }
+
+    /// Build a foreground command for the bundled daemon.
+    ///
+    /// The command receives the same product-owned runtime home, workspace
+    /// state directory, enforced distro, and `PATH` as ordinary AOS runtime
+    /// dispatch. Daemon diagnostics are routed to stderr for process
+    /// supervisors; this does not alter daemon lifetime.
+    ///
+    /// # Errors
+    /// Returns an error when the bundled daemon or product capsule set is
+    /// unavailable, or the child `PATH` cannot be represented safely.
+    pub fn foreground_daemon_command(
+        &self,
+        workspace: Option<&Path>,
+        verbose: bool,
+    ) -> io::Result<Command> {
+        let daemon_binary = self.runtime_daemon_binary();
+        self.ensure_runtime_executable(&daemon_binary, "daemon")?;
+        self.ensure_unicity_ce_manifest()?;
+        let mut args = Vec::new();
+        if let Some(workspace) = workspace {
+            args.push(OsString::from("--workspace"));
+            args.push(workspace.as_os_str().to_owned());
+        }
+        if verbose {
+            args.push(OsString::from("--verbose"));
+        }
+        let mut command = self.runtime_executable_command(&daemon_binary, args)?;
+        command.env("ASTRID_DAEMON_LOG_TARGET", "stderr");
         Ok(command)
     }
 
@@ -390,6 +436,27 @@ impl AosHome {
         Err(self.runtime_command_with_args(args)?.exec())
     }
 
+    /// Replace the current Unix process with the persistent bundled daemon.
+    ///
+    /// This is the process-supervisor path: the daemon receives signals
+    /// directly and owns the final exit status. Callers decide the workspace
+    /// argument, while AOS fixes the product home, distro, and workspace-state
+    /// layout.
+    ///
+    /// # Errors
+    /// Returns an error when the bundled daemon or product assets are
+    /// unavailable, or the process cannot be replaced.
+    #[cfg(unix)]
+    pub fn exec_foreground_daemon(
+        &self,
+        workspace: Option<&Path>,
+        verbose: bool,
+    ) -> io::Result<()> {
+        use std::os::unix::process::CommandExt;
+
+        Err(self.foreground_daemon_command(workspace, verbose)?.exec())
+    }
+
     /// Run a bundled-runtime command.
     ///
     /// The runtime remains the authority for socket authentication and local
@@ -408,16 +475,21 @@ impl AosHome {
 
     fn ensure_runtime_available(&self) -> io::Result<()> {
         let binary = self.runtime_binary();
+        self.ensure_runtime_executable(&binary, "runtime")?;
+        self.ensure_unicity_ce_manifest().map(drop)
+    }
+
+    fn ensure_runtime_executable(&self, binary: &Path, label: &str) -> io::Result<()> {
         if !binary.is_file() {
             return Err(io::Error::new(
                 io::ErrorKind::NotFound,
                 format!(
-                    "bundled runtime executable not found at {}",
+                    "bundled {label} executable not found at {}",
                     binary.display()
                 ),
             ));
         }
-        self.ensure_unicity_ce_manifest().map(drop)
+        Ok(())
     }
 }
 
@@ -502,6 +574,10 @@ const fn default_home_name() -> &'static str {
 
 const fn runtime_binary_name() -> &'static str {
     RUNTIME_EXECUTABLE_NAMES[0]
+}
+
+const fn runtime_daemon_binary_name() -> &'static str {
+    RUNTIME_EXECUTABLE_NAMES[1]
 }
 
 fn capsule_assets_from_manifest() -> io::Result<Vec<String>> {
@@ -674,7 +750,7 @@ fn materialize_manifest(capsule_dir: &Path) -> io::Result<String> {
 mod tests {
     use super::{
         AosHome, UNICITY_CE_MANIFEST, capsule_assets_from_manifest, materialize_manifest,
-        runtime_binary_name,
+        runtime_binary_name, runtime_daemon_binary_name,
     };
     use std::ffi::OsString;
     use std::fs;
@@ -716,6 +792,12 @@ mod tests {
         assert_eq!(
             home.runtime_binary(),
             home.runtime_home().join("bin").join(runtime_binary_name())
+        );
+        assert_eq!(
+            home.runtime_daemon_binary(),
+            home.runtime_home()
+                .join("bin")
+                .join(runtime_daemon_binary_name())
         );
     }
 
@@ -781,6 +863,45 @@ mod tests {
 
         assert_eq!(args, ["status", "--json"]);
         assert_eq!(command.get_program(), home.runtime_binary());
+    }
+
+    #[test]
+    fn foreground_daemon_uses_the_product_environment_without_ephemeral_mode() {
+        let fixture = temporary_home();
+        let home = AosHome::from_root(&fixture);
+        install_capsule_fixtures(home.root());
+        let runtime_bin = home.runtime_home().join("bin");
+        fs::create_dir_all(&runtime_bin).expect("create runtime bin");
+        fs::write(home.runtime_daemon_binary(), b"daemon").expect("write daemon fixture");
+
+        let command = home
+            .foreground_daemon_command(Some(std::path::Path::new("/workspace")), true)
+            .expect("build foreground daemon command");
+
+        assert_eq!(command.get_program(), home.runtime_daemon_binary());
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            ["--workspace", "/workspace", "--verbose"]
+        );
+        assert!(
+            command.get_args().all(|argument| argument != "--ephemeral"),
+            "foreground daemon must retain persistent lifetime"
+        );
+        let env_value = |target: &str| {
+            command
+                .get_envs()
+                .find_map(|(name, value)| (name == target).then_some(value))
+                .flatten()
+                .expect("foreground daemon sets product environment")
+        };
+        assert_eq!(env_value("ASTRID_HOME"), home.runtime_home());
+        assert_eq!(env_value("ASTRID_WORKSPACE_STATE_DIR"), ".aos");
+        assert_eq!(env_value("ASTRID_DAEMON_LOG_TARGET"), "stderr");
+        assert_eq!(
+            env_value("ASTRID_ENFORCED_DISTRO"),
+            home.unicity_ce_manifest_path()
+        );
+        fs::remove_dir_all(fixture).expect("remove foreground daemon fixture");
     }
 
     #[test]

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -333,7 +333,7 @@ impl AosHome {
         let runtime_bin = executable.parent().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "bundled runtime executable must have a parent directory",
+                "bundled executable must have a parent directory",
             )
         })?;
         let mut command = Command::new(executable);
@@ -480,7 +480,20 @@ impl AosHome {
     }
 
     fn ensure_runtime_executable(&self, binary: &Path, label: &str) -> io::Result<()> {
-        if !binary.is_file() {
+        let metadata = fs::metadata(binary).map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!(
+                        "bundled {label} executable not found at {}",
+                        binary.display()
+                    ),
+                )
+            } else {
+                error
+            }
+        })?;
+        if !metadata.is_file() {
             return Err(io::Error::new(
                 io::ErrorKind::NotFound,
                 format!(
@@ -488,6 +501,19 @@ impl AosHome {
                     binary.display()
                 ),
             ));
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if metadata.permissions().mode() & 0o111 == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!(
+                        "bundled {label} executable is not executable at {}",
+                        binary.display()
+                    ),
+                ));
+            }
         }
         Ok(())
     }
@@ -873,6 +899,16 @@ mod tests {
         let runtime_bin = home.runtime_home().join("bin");
         fs::create_dir_all(&runtime_bin).expect("create runtime bin");
         fs::write(home.runtime_daemon_binary(), b"daemon").expect("write daemon fixture");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let daemon = home.runtime_daemon_binary();
+            let mut permissions = fs::metadata(&daemon)
+                .expect("read daemon fixture metadata")
+                .permissions();
+            permissions.set_mode(0o700);
+            fs::set_permissions(&daemon, permissions).expect("make daemon fixture executable");
+        }
 
         let command = home
             .foreground_daemon_command(Some(std::path::Path::new("/workspace")), true)
@@ -900,6 +936,29 @@ mod tests {
         assert_eq!(
             env_value("ASTRID_ENFORCED_DISTRO"),
             home.unicity_ce_manifest_path()
+        );
+        fs::remove_dir_all(fixture).expect("remove foreground daemon fixture");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn foreground_daemon_rejects_a_non_executable_fixture() {
+        let fixture = temporary_home();
+        let home = AosHome::from_root(&fixture);
+        install_capsule_fixtures(home.root());
+        let runtime_bin = home.runtime_home().join("bin");
+        fs::create_dir_all(&runtime_bin).expect("create runtime bin");
+        fs::write(home.runtime_daemon_binary(), b"daemon").expect("write daemon fixture");
+
+        let error = home
+            .foreground_daemon_command(None, false)
+            .expect_err("non-executable daemon must fail before spawn");
+
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        assert!(
+            error
+                .to_string()
+                .contains("daemon executable is not executable")
         );
         fs::remove_dir_all(fixture).expect("remove foreground daemon fixture");
     }

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -65,6 +65,27 @@ enum ProductCommand {
     },
     /// Serve the loopback-only product health endpoint.
     ServeHealth,
+    /// Run the bundled runtime daemon in the foreground.
+    Daemon {
+        #[command(subcommand)]
+        command: DaemonCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum DaemonCommand {
+    /// Run the persistent bundled daemon in the foreground.
+    Foreground(ForegroundDaemonArgs),
+}
+
+#[derive(Args)]
+struct ForegroundDaemonArgs {
+    /// Project workspace owned by this daemon.
+    #[arg(long, value_name = "PATH")]
+    workspace: Option<std::path::PathBuf>,
+    /// Enable debug-level daemon logging.
+    #[arg(short, long)]
+    verbose: bool,
 }
 
 #[derive(Subcommand)]
@@ -331,7 +352,40 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
             command: McpCommand::Serve(args),
         }) => Some(mcp::handle_serve(cli.principal, args)),
         Some(ProductCommand::ServeHealth) => Some(handle_health_service()),
+        Some(ProductCommand::Daemon {
+            command: DaemonCommand::Foreground(args),
+        }) => Some(handle_foreground_daemon(&args)),
         None => Some(print_product_help()),
+    }
+}
+
+fn handle_foreground_daemon(args: &ForegroundDaemonArgs) -> ExitCode {
+    let home = match resolve_home() {
+        Ok(home) => home,
+        Err(code) => return code,
+    };
+    #[cfg(unix)]
+    {
+        match home.exec_foreground_daemon(args.workspace.as_deref(), args.verbose) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(error) => {
+                eprintln!("aos: failed to run foreground daemon: {error}");
+                ExitCode::FAILURE
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        match home
+            .foreground_daemon_command(args.workspace.as_deref(), args.verbose)
+            .and_then(|mut command| command.status())
+        {
+            Ok(status) => child_exit_code(status),
+            Err(error) => {
+                eprintln!("aos: failed to run foreground daemon: {error}");
+                ExitCode::FAILURE
+            }
+        }
     }
 }
 
@@ -548,6 +602,7 @@ fn is_owned_root(value: &str) -> bool {
             | "distro"
             | "hook"
             | "mcp"
+            | "daemon"
             | "serve-health"
     )
 }
@@ -970,9 +1025,9 @@ mod tests {
     use std::ffi::OsString;
 
     use super::{
-        ProductCli, ProductCommand, child_exit_code, handle_product_command, help_targets_product,
-        is_owned_root, leading_owned_root, runtime_args_for_dispatch, runtime_stop_requested,
-        status_principal,
+        DaemonCommand, ProductCli, ProductCommand, child_exit_code, handle_product_command,
+        help_targets_product, is_owned_root, leading_owned_root, runtime_args_for_dispatch,
+        runtime_stop_requested, status_principal,
     };
 
     #[test]
@@ -1004,6 +1059,30 @@ mod tests {
         assert!(init.allow_unsigned);
         assert!(init.accept_new_key);
         assert_eq!(init.vars, ["model=gpt-5"]);
+    }
+
+    #[test]
+    fn product_cli_parses_persistent_foreground_daemon() {
+        let cli = ProductCli::try_parse_from([
+            "aos",
+            "daemon",
+            "foreground",
+            "--workspace",
+            "/workspace",
+            "--verbose",
+        ])
+        .expect("parse foreground daemon");
+        let Some(ProductCommand::Daemon {
+            command: DaemonCommand::Foreground(args),
+        }) = cli.command
+        else {
+            panic!("expected foreground daemon command");
+        };
+        assert_eq!(
+            args.workspace.as_deref(),
+            Some(std::path::Path::new("/workspace"))
+        );
+        assert!(args.verbose);
     }
 
     #[test]
@@ -1170,13 +1249,14 @@ mod tests {
             "migrate",
             "update",
             "distro",
+            "daemon",
             "serve-health",
         ] {
             let args = [OsString::from("help"), OsString::from(root)];
             assert!(help_targets_product(&args));
             assert!(handle_product_command(&args).is_some());
         }
-        for root in ["doctor", "capsule", "daemon", "completion"] {
+        for root in ["doctor", "capsule", "completion"] {
             let args = [OsString::from("help"), OsString::from(root)];
             assert!(!help_targets_product(&args));
             assert!(handle_product_command(&args).is_none());

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -72,11 +72,19 @@ impl Fixture {
 
     fn install_runtime(&self, body: &str) {
         fs::write(&self.runtime, body).expect("write fake runtime");
-        let mut permissions = fs::metadata(&self.runtime)
-            .expect("runtime metadata")
-            .permissions();
+        Self::make_executable(&self.runtime);
+    }
+
+    fn install_daemon(&self, body: &str) {
+        let daemon = self.runtime.with_file_name("astrid-daemon");
+        fs::write(&daemon, body).expect("write fake daemon");
+        Self::make_executable(&daemon);
+    }
+
+    fn make_executable(path: &Path) {
+        let mut permissions = fs::metadata(path).expect("runtime metadata").permissions();
         permissions.set_mode(0o700);
-        fs::set_permissions(&self.runtime, permissions).expect("make runtime executable");
+        fs::set_permissions(path, permissions).expect("make fixture executable");
     }
 
     fn command(&self) -> Command {
@@ -115,6 +123,81 @@ printf '%s\n' "$ASTRID_ENFORCED_DISTRO" > "$AOS_TEST_DISTRO"
 printf '%s\n' "$PATH" > "$AOS_TEST_PATH"
 exit "${AOS_TEST_EXIT:-0}"
 "#;
+
+const RECORDING_DAEMON: &str = r#"#!/bin/sh
+for arg in "$@"; do
+    printf '<%s>\n' "$arg"
+done > "$AOS_TEST_ARGS"
+printf '%s\n' "$ASTRID_HOME" > "$AOS_TEST_HOME"
+printf '%s\n' "$ASTRID_WORKSPACE_STATE_DIR" > "$AOS_TEST_WORKSPACE"
+printf '%s\n' "$ASTRID_ENFORCED_DISTRO" > "$AOS_TEST_DISTRO"
+printf '%s\n' "$ASTRID_DAEMON_LOG_TARGET" > "$AOS_TEST_LOG_TARGET"
+exit "${AOS_TEST_EXIT:-0}"
+"#;
+
+#[test]
+fn foreground_daemon_replaces_aos_with_the_persistent_product_runtime() {
+    let fixture = Fixture::new("foreground-daemon");
+    fixture.install_daemon(RECORDING_DAEMON);
+    let workspace = fixture.root.join("workspace");
+    let log_target = fixture.root.join("log-target");
+
+    let output = fixture
+        .command()
+        .env("AOS_TEST_EXIT", "23")
+        .env("AOS_TEST_LOG_TARGET", &log_target)
+        .args([
+            OsStr::new("daemon"),
+            OsStr::new("foreground"),
+            OsStr::new("--workspace"),
+            workspace.as_os_str(),
+            OsStr::new("--verbose"),
+        ])
+        .output()
+        .expect("run foreground daemon");
+
+    assert_eq!(
+        output.status.code(),
+        Some(23),
+        "the daemon must directly own the supervisor-visible exit status"
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.args).expect("read daemon args"),
+        format!("<--workspace>\n<{}>\n<--verbose>\n", workspace.display())
+    );
+    assert!(
+        !fs::read_to_string(&fixture.args)
+            .expect("read daemon args")
+            .contains("--ephemeral")
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("child-home"))
+            .expect("read runtime home")
+            .trim(),
+        fixture.home.join("runtime").to_string_lossy()
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("child-workspace"))
+            .expect("read workspace state")
+            .trim(),
+        ".aos"
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("child-distro"))
+            .expect("read enforced distro")
+            .trim(),
+        fixture
+            .home
+            .join("distributions/unicity-ce/Distro.toml")
+            .to_string_lossy()
+    );
+    assert_eq!(
+        fs::read_to_string(&log_target)
+            .expect("read daemon log target")
+            .trim(),
+        "stderr"
+    );
+}
 
 #[test]
 fn unowned_root_passes_through_with_argv_home_and_exit_code() {
@@ -380,11 +463,7 @@ fn inherited_help_dispatches_byte_for_byte_while_product_help_stays_owned() {
     let fixture = Fixture::new("help-inheritance");
     fixture.install_runtime(RECORDING_RUNTIME);
 
-    for args in [
-        vec!["help", "doctor"],
-        vec!["help", "capsule"],
-        vec!["help", "daemon", "start"],
-    ] {
+    for args in [vec!["help", "doctor"], vec!["help", "capsule"]] {
         let output = fixture
             .command()
             .args(&args)
@@ -402,7 +481,12 @@ fn inherited_help_dispatches_byte_for_byte_while_product_help_stays_owned() {
         fs::remove_file(&fixture.args).expect("reset delegated args");
     }
 
-    for args in [vec!["help"], vec!["help", "init"], vec!["help", "status"]] {
+    for args in [
+        vec!["help"],
+        vec!["help", "init"],
+        vec!["help", "status"],
+        vec!["help", "daemon"],
+    ] {
         let output = fixture
             .command()
             .args(args)


### PR DESCRIPTION
Closes #64

## Summary

Add a product-owned `aos daemon foreground` command for process supervisors.
On Unix it replaces the AOS process with the persistent bundled daemon, so the
daemon directly owns PID, signals, and exit status. Other hosts wait for the
daemon and preserve its exit code.

## Changes

- select the bundled `astrid-daemon` companion rather than the Astrid CLI
- apply the AOS runtime home, `.aos` workspace state, enforced CE distro, and
  runtime `PATH`
- set `ASTRID_DAEMON_LOG_TARGET=stderr` only for the daemon process
- accept only typed workspace and verbose inputs; the API cannot enable
  `--ephemeral`
- preserve the caller's working directory when `--workspace` is omitted
- document the foreground supervisor and persistent-lifetime contract

## Verification

- `cargo test --locked -p unicity-aos-bootstrap` (55 library, 33 binary, 26
  CLI-boundary tests)
- `cargo clippy --locked -p unicity-aos-bootstrap --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- fake-daemon integration test proving exact argv/environment, direct exit-code
  ownership, and absence of `--ephemeral`
- `git diff --check`
- independent lifecycle/security review

## Dependencies and scope

Stderr routing becomes effective with astrid-runtime/astrid#1342 and a later
release-only AOS runtime pin. This PR intentionally does not add OCI files,
fresh-volume initialization, release workflows, or version changes.
