### PR TITLE
feat(release): authenticate Linux musl installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
       - run: python3 scripts/validate-release-contract.py
       - run: python3 scripts/test_validate_release_contract.py
       - run: python3 scripts/test_release_metadata.py
+      - run: python3 scripts/test_musl_release_metadata.py
       - run: python3 scripts/test_nightly_version.py
       - run: python3 scripts/test_channel_transaction.py
       - run: python3 scripts/test_channel_publication.py
@@ -105,6 +106,8 @@ jobs:
       - run: python3 scripts/test_create_astrid_094_fixture.py
       - run: bash scripts/test-package-release.sh
       - run: bash scripts/test-install.sh
+      - run: bash scripts/test-libc-detection.sh
+      - run: bash scripts/test-install-musl.sh
       - run: python3 scripts/capsule_release.py
       - run: python3 scripts/test_capsule_release.py
       - run: python3 scripts/test_validate_runtime_archive.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,53 @@ env:
   B3SUM_VERSION: 1.8.5
 
 jobs:
+  linux-release-smoke:
+    name: Linux release smoke (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - name: Build against the Linux release baseline
+        env:
+          TARGET: ${{ matrix.target }}
+          # Keep this digest synchronized with release.yml.
+          LINUX_BUILD_IMAGE: docker.io/library/rust@sha256:646e8ceea789b00c5cfa339816a3ed44940dbf1651dc167b78f3c0aefcae0025
+        run: |
+          docker run --rm \
+            --env TARGET \
+            --volume "$PWD:/workspace" \
+            --workdir /workspace \
+            "$LINUX_BUILD_IMAGE" \
+            bash -euxo pipefail -c '
+              if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
+                rustup target add aarch64-unknown-linux-gnu
+                apt-get update
+                apt-get install -y --no-install-recommends \
+                  gcc-aarch64-linux-gnu \
+                  libc6-dev-arm64-cross
+                export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+              fi
+              export CARGO_TARGET_DIR=/workspace/target/glibc-2.31
+              cargo build --locked --release --target "$TARGET" -p unicity-aos-bootstrap
+            '
+      - name: Enforce the Linux glibc compatibility ceiling
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          python3 scripts/check_glibc.py --max-version 2.34 \
+            "target/glibc-2.31/${TARGET}/release/aos"
+
   format:
     name: Format
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
           # Keep this digest synchronized with release.yml.
-          LINUX_BUILD_IMAGE: docker.io/library/rust@sha256:646e8ceea789b00c5cfa339816a3ed44940dbf1651dc167b78f3c0aefcae0025
+          LINUX_BUILD_IMAGE: docker.io/library/rust:1.95.0-bullseye@sha256:646e8ceea789b00c5cfa339816a3ed44940dbf1651dc167b78f3c0aefcae0025
         run: |
           docker run --rm \
             --env TARGET \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - run: cargo install b3sum --locked --version "$B3SUM_VERSION"
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - run: sh -n install.sh
+      - run: python3 scripts/test_check_glibc.py
       - run: python3 scripts/validate-release-contract.py
       - run: python3 scripts/test_validate_release_contract.py
       - run: python3 scripts/test_release_metadata.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Build Linux product binary against glibc 2.31
         if: ${{ endsWith(matrix.target, 'linux-gnu') }}
         env:
-          LINUX_BUILD_IMAGE: docker.io/library/rust@sha256:646e8ceea789b00c5cfa339816a3ed44940dbf1651dc167b78f3c0aefcae0025
+          LINUX_BUILD_IMAGE: docker.io/library/rust:1.95.0-bullseye@sha256:646e8ceea789b00c5cfa339816a3ed44940dbf1651dc167b78f3c0aefcae0025
           TARGET: ${{ matrix.target }}
         run: |
           docker run --rm \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,9 @@ jobs:
           test "$PRODUCT" = "$GITHUB_REF_NAME"
       - run: bash scripts/test-package-release.sh
       - run: bash scripts/test-install.sh
+      - run: bash scripts/test-libc-detection.sh
+      - run: bash scripts/test-install-musl.sh
+      - run: python3 scripts/test_musl_release_metadata.py
       - run: python3 scripts/test_create_astrid_094_fixture.py
       - run: python3 scripts/capsule_release.py
       - run: python3 scripts/test_capsule_release.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,9 @@ jobs:
               if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
                 rustup target add aarch64-unknown-linux-gnu
                 apt-get update
-                apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
+                apt-get install -y --no-install-recommends \
+                  gcc-aarch64-linux-gnu \
+                  libc6-dev-arm64-cross
                 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
               fi
               export CARGO_TARGET_DIR=/workspace/target/glibc-2.31

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,7 @@ jobs:
       - run: python3 scripts/test_capsule_release.py
       - run: python3 scripts/test_validate_runtime_archive.py
       - run: bash scripts/test-extract-runtime-tool.sh
+      - run: python3 scripts/test_check_glibc.py
       - run: sh -n install.sh
 
   build:
@@ -167,12 +168,8 @@ jobs:
         with:
           toolchain: '1.95.0'
           targets: ${{ matrix.target }}
-      - name: Install Linux ARM linker
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: ${{ !endsWith(matrix.target, 'linux-gnu') }}
         with:
           key: aos-release-${{ matrix.target }}
       - name: Install pinned BLAKE3 checksum tool
@@ -189,9 +186,34 @@ jobs:
           print(f"RUNTIME_IDENTITY={metadata['release-workflow-identity']}")
           PY
       - name: Build product binary
+        if: ${{ !endsWith(matrix.target, 'linux-gnu') }}
+        run: |
+          cargo build --locked --release --target "${{ matrix.target }}" -p unicity-aos-bootstrap
+          echo "AOS_BINARY=target/${{ matrix.target }}/release/aos" >> "$GITHUB_ENV"
+      - name: Build Linux product binary against glibc 2.31
+        if: ${{ endsWith(matrix.target, 'linux-gnu') }}
         env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-        run: cargo build --locked --release --target "${{ matrix.target }}" -p unicity-aos-bootstrap
+          LINUX_BUILD_IMAGE: docker.io/library/rust@sha256:646e8ceea789b00c5cfa339816a3ed44940dbf1651dc167b78f3c0aefcae0025
+          TARGET: ${{ matrix.target }}
+        run: |
+          docker run --rm \
+            -e TARGET \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            "$LINUX_BUILD_IMAGE" \
+            bash -euxo pipefail -c '
+              if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
+                rustup target add aarch64-unknown-linux-gnu
+                apt-get update
+                apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
+                export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+              fi
+              export CARGO_TARGET_DIR=/workspace/target/glibc-2.31
+              cargo build --locked --release --target "$TARGET" -p unicity-aos-bootstrap
+            '
+          AOS_BINARY="target/glibc-2.31/${{ matrix.target }}/release/aos"
+          python3 scripts/check_glibc.py --max-version 2.34 "$AOS_BINARY"
+          echo "AOS_BINARY=$AOS_BINARY" >> "$GITHUB_ENV"
       - name: Download pinned runtime release
         run: |
           ASSET="astrid-${RUNTIME_VERSION}-${{ matrix.target }}.tar.gz"
@@ -212,6 +234,22 @@ jobs:
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             --certificate-identity "$RUNTIME_IDENTITY" \
             "$RUNTIME_ASSET"
+      - name: Verify Linux runtime glibc compatibility
+        if: ${{ endsWith(matrix.target, 'linux-gnu') }}
+        run: |
+          RUNTIME_ROOT="astrid-${RUNTIME_VERSION}-${{ matrix.target }}"
+          CHECK_ROOT="$RUNNER_TEMP/runtime-glibc-check"
+          python3 scripts/validate-runtime-archive.py \
+            "$RUNTIME_ASSET" \
+            "$RUNTIME_ROOT" \
+            astrid astrid-daemon astrid-build astrid-emit
+          mkdir "$CHECK_ROOT"
+          tar -xzf "$RUNTIME_ASSET" -C "$CHECK_ROOT"
+          python3 scripts/check_glibc.py --max-version 2.34 \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid-daemon" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid-build" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid-emit"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: capsule-artifacts
@@ -221,7 +259,7 @@ jobs:
           python3 scripts/capsule_release.py --artifacts capsule-artifacts
           scripts/package-release.sh \
             "${{ matrix.target }}" \
-            "target/${{ matrix.target }}/release/aos" \
+            "$AOS_BINARY" \
             "$RUNTIME_ASSET" \
             "$RUNTIME_BLAKE3" \
             capsule-artifacts \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@
   Astrid compatibility pins, protected publication and promotion, and
   idempotent recovery after interrupted release or pointer updates. It is
   disabled by default; merging `main` never publishes a release.
+- A separately signed, immutable Linux musl metadata extension that preserves
+  the established four-target release and channel documents, binds back to the
+  authenticated legacy release, and pins the exact Astrid musl metadata.
+  Installers detect libc without requiring `ldd` and fail closed when the Linux
+  libc cannot be identified. Closes #62.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,12 @@
   lock is available; all other inherited runtime failures retain their output
   and exit status.
 
+### Fixed
+
+- Build Linux product binaries on a pinned glibc 2.31 baseline and reject AOS
+  or bundled Astrid executables that require glibc newer than 2.34, restoring
+  support for RHEL, Oracle Linux, Rocky Linux, and AlmaLinux 9. Closes #58.
+
 ### Removed
 
 - The vendored `capsules/capsule-telegram` copy. The capsule is maintained in

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -39,6 +39,28 @@ two release-readiness gates. The exact accepted identity is:
 https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/<version>
 ```
 
+Linux musl support does not widen either strict document. A release that ships
+musl archives also publishes
+`unicity-aos-<version>-musl-release.toml` and its Sigstore bundle from the same
+immutable tag workflow. That extension contains exactly the x86-64 and ARM64
+musl targets, the exact Astrid musl metadata pin, and a SHA-256 binding to the
+legacy four-target AOS release metadata. There is no second mutable channel
+pointer.
+
+On Linux, the installer identifies libc in order from
+`getconf GNU_LIBC_VERSION`, `ldd --version` when `ldd` exists, and canonical
+musl loader paths. It refuses an unknown libc rather than selecting a GNU
+archive by default. For a musl install it authenticates the normal channel and
+legacy release first, then downloads and authenticates the exact-tag musl
+extension before selecting an archive. Direct `--version` installs follow the
+same immutable release-then-extension chain without consulting a channel.
+
+`release/runtime-musl-compatibility.toml` is a separate publication gate and
+must name the exact signed Astrid legacy and musl metadata assets and BLAKE3
+digests. Its false gate on `main` is intentional until the corresponding Astrid
+release exists; changing the runtime pin and product version remains separate
+release work.
+
 The channel pointer is a strict TOML document with a channel name, monotonically
 increasing generation, publication and expiry times, the immutable release
 metadata digest, and the same four target records. Its exact accepted identity

--- a/install.sh
+++ b/install.sh
@@ -498,6 +498,163 @@ validate_release_metadata() {
   done
 }
 
+validate_musl_release_metadata() {
+  metadata=$1
+  legacy_metadata=$2
+  expected_version=$3
+  expected_identity=$4
+  awk '
+    function mark(name) { if (seen[name]++) bad = 1 }
+    /^$/ { next }
+    /^\[/ {
+      section = $0
+      if (section ~ /^\[(legacy-release|runtime-musl)\]$/) mark(section)
+      else if (section ~ /^\[targets\.(aarch64-unknown-linux-musl|x86_64-unknown-linux-musl)\]$/) mark(section)
+      else bad = 1
+      next
+    }
+    {
+      key = $1
+      if ($2 != "=") { bad = 1; next }
+      if (section == "") {
+        if (key !~ /^(schema-version|kind|product|repository|version|tag|source-commit|release-workflow-identity)$/) bad = 1
+      } else if (section == "[legacy-release]") {
+        if (key !~ /^(metadata-asset|metadata-sha256)$/) bad = 1
+      } else if (section == "[runtime-musl]") {
+        if (key !~ /^(repository|version|tag|source-commit|release-workflow-identity|legacy-release-metadata-asset|legacy-release-metadata-blake3|musl-release-metadata-asset|musl-release-metadata-blake3)$/) bad = 1
+      } else if (section ~ /^\[targets\./) {
+        if (key !~ /^(asset|sha256|blake3|sigstore-bundle|size)$/) bad = 1
+      } else bad = 1
+      mark(section SUBSEP key)
+    }
+    END {
+      split("schema-version kind product repository version tag source-commit release-workflow-identity", top)
+      for (i in top) if (seen[SUBSEP top[i]] != 1) bad = 1
+      tables[1] = "[legacy-release]|metadata-asset metadata-sha256"
+      tables[2] = "[runtime-musl]|repository version tag source-commit release-workflow-identity legacy-release-metadata-asset legacy-release-metadata-blake3 musl-release-metadata-asset musl-release-metadata-blake3"
+      for (t in tables) {
+        split(tables[t], parts, "|")
+        if (seen[parts[1]] != 1) bad = 1
+        split(parts[2], keys)
+        for (i in keys) if (seen[parts[1] SUBSEP keys[i]] != 1) bad = 1
+      }
+      targets[1] = "aarch64-unknown-linux-musl"
+      targets[2] = "x86_64-unknown-linux-musl"
+      split("asset sha256 blake3 sigstore-bundle size", target_keys)
+      for (t in targets) {
+        target_section = "[targets." targets[t] "]"
+        if (seen[target_section] != 1) bad = 1
+        for (i in target_keys) if (seen[target_section SUBSEP target_keys[i]] != 1) bad = 1
+      }
+      exit bad ? 1 : 0
+    }
+  ' "$metadata" || {
+    echo "signed musl release metadata does not match schema 1" >&2
+    return 1
+  }
+  require_toml_integer "$metadata" "" schema-version '^1$' || return 1
+  for key in kind product repository version tag source-commit release-workflow-identity; do
+    require_toml_string "$metadata" "" "$key" || return 1
+  done
+  for key in metadata-asset metadata-sha256; do
+    require_toml_string "$metadata" "[legacy-release]" "$key" || return 1
+  done
+  for key in repository version tag source-commit release-workflow-identity legacy-release-metadata-asset legacy-release-metadata-blake3 musl-release-metadata-asset musl-release-metadata-blake3; do
+    require_toml_string "$metadata" "[runtime-musl]" "$key" || return 1
+  done
+  for lexical_target in aarch64-unknown-linux-musl x86_64-unknown-linux-musl; do
+    lexical_section="[targets.${lexical_target}]"
+    for key in asset sha256 blake3 sigstore-bundle; do
+      require_toml_string "$metadata" "$lexical_section" "$key" || return 1
+    done
+    require_toml_integer "$metadata" "$lexical_section" size '^[1-9][0-9]*$' || return 1
+  done
+
+  [ "$(toml_value "$metadata" "" schema-version)" = 1 ] || return 1
+  [ "$(toml_value "$metadata" "" kind)" = aos-release-musl-extension ] || return 1
+  [ "$(toml_value "$metadata" "" product)" = unicity-aos-ce ] || return 1
+  [ "$(toml_value "$metadata" "" repository)" = "$AOS_TRUSTED_RELEASE_REPO" ] || return 1
+  [ "$(toml_value "$metadata" "" version)" = "$expected_version" ] || return 1
+  [ "$(toml_value "$metadata" "" tag)" = "$expected_version" ] || return 1
+  [ "$(toml_value "$metadata" "" release-workflow-identity)" = "$expected_identity" ] || {
+    echo "signed musl release metadata does not name the exact tag workflow identity" >&2
+    return 1
+  }
+  musl_source_commit=$(toml_value "$metadata" "" source-commit)
+  printf '%s\n' "$musl_source_commit" | grep -Eq '^[0-9a-f]{40}$' || return 1
+  [ "$musl_source_commit" = "$(toml_value "$legacy_metadata" "" source-commit)" ] || {
+    echo "signed musl release metadata source commit differs from the legacy release" >&2
+    return 1
+  }
+  if is_aos_nightly_version "$expected_version"; then
+    [ "${expected_version##*.g}" = "$musl_source_commit" ] || return 1
+  fi
+  [ "$(toml_value "$metadata" "[legacy-release]" metadata-asset)" = "unicity-aos-${expected_version}-release.toml" ] || return 1
+  legacy_sha256=$(toml_value "$metadata" "[legacy-release]" metadata-sha256)
+  printf '%s\n' "$legacy_sha256" | grep -Eq '^[0-9a-f]{64}$' || return 1
+  [ "$legacy_sha256" = "$(sha256_file "$legacy_metadata")" ] || {
+    echo "signed musl release metadata does not bind the authenticated legacy release" >&2
+    return 1
+  }
+
+  runtime_version=$(toml_value "$metadata" "[runtime-musl]" version)
+  runtime_tag=$(toml_value "$metadata" "[runtime-musl]" tag)
+  runtime_source_commit=$(toml_value "$metadata" "[runtime-musl]" source-commit)
+  runtime_identity=$(toml_value "$metadata" "[runtime-musl]" release-workflow-identity)
+  [ "$(toml_value "$metadata" "[runtime-musl]" repository)" = astrid-runtime/astrid ] || return 1
+  printf '%s\n' "$runtime_version" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' || return 1
+  [ "$runtime_tag" = "v${runtime_version}" ] || return 1
+  printf '%s\n' "$runtime_source_commit" | grep -Eq '^[0-9a-f]{40}$' || return 1
+  [ "$runtime_identity" = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v${runtime_version}" ] || return 1
+  [ "$(toml_value "$metadata" "[runtime-musl]" legacy-release-metadata-asset)" = "astrid-${runtime_version}-release.toml" ] || return 1
+  [ "$(toml_value "$metadata" "[runtime-musl]" musl-release-metadata-asset)" = "astrid-${runtime_version}-musl-release.toml" ] || return 1
+  for key in legacy-release-metadata-blake3 musl-release-metadata-blake3; do
+    printf '%s\n' "$(toml_value "$metadata" "[runtime-musl]" "$key")" | grep -Eq '^[0-9a-f]{64}$' || return 1
+  done
+
+  for metadata_target in aarch64-unknown-linux-musl x86_64-unknown-linux-musl; do
+    metadata_section="[targets.${metadata_target}]"
+    metadata_target_asset=$(toml_value "$metadata" "$metadata_section" asset)
+    metadata_target_sha=$(toml_value "$metadata" "$metadata_section" sha256)
+    metadata_target_blake3=$(toml_value "$metadata" "$metadata_section" blake3)
+    metadata_target_bundle=$(toml_value "$metadata" "$metadata_section" sigstore-bundle)
+    metadata_target_size=$(toml_value "$metadata" "$metadata_section" size)
+    [ "$metadata_target_asset" = "unicity-aos-${expected_version}-${metadata_target}.tar.gz" ] || return 1
+    [ "$metadata_target_bundle" = "${metadata_target_asset}.sigstore.json" ] || return 1
+    printf '%s\n' "$metadata_target_sha" | grep -Eq '^[0-9a-f]{64}$' || return 1
+    printf '%s\n' "$metadata_target_blake3" | grep -Eq '^[0-9a-f]{64}$' || return 1
+    printf '%s\n' "$metadata_target_size" | grep -Eq '^[1-9][0-9]*$' || return 1
+  done
+}
+
+detect_linux_libc() {
+  loader_root=${1:-}
+  if command -v getconf >/dev/null 2>&1; then
+    getconf_output=$(getconf GNU_LIBC_VERSION 2>/dev/null || :)
+    case "$getconf_output" in
+      glibc\ [0-9]*.[0-9]*) printf '%s\n' gnu; return 0 ;;
+    esac
+  fi
+  if command -v ldd >/dev/null 2>&1; then
+    ldd_output=$(ldd --version 2>&1 || :)
+    ldd_lower=$(printf '%s\n' "$ldd_output" | tr '[:upper:]' '[:lower:]')
+    case "$ldd_lower" in
+      *musl*) printf '%s\n' musl; return 0 ;;
+      *glibc*|*"gnu libc"*|*"free software foundation"*)
+        printf '%s\n' gnu
+        return 0
+        ;;
+    esac
+  fi
+  for loader in "$loader_root"/lib/ld-musl-*.so.1 "$loader_root"/usr/lib/ld-musl-*.so.1; do
+    if [ -e "$loader" ]; then
+      printf '%s\n' musl
+      return 0
+    fi
+  done
+  return 1
+}
+
 validate_accepted_channel() {
   [ -n "$channel_root" ] || return 0
   for state_parent in "$AOS_HOME" "$AOS_HOME/update" "$AOS_HOME/update/channels" "$channel_root" "$channel_root/generations"; do
@@ -555,6 +712,7 @@ validate_accepted_channel() {
 
 os=$(uname -s)
 arch=$(uname -m)
+libc_family=
 case "$os:$arch" in
   Darwin:arm64|Darwin:aarch64)
     target=aarch64-apple-darwin
@@ -567,12 +725,20 @@ case "$os:$arch" in
     cosign_sha256=14d2678dfbfde18798151e86fbd91ebdadbb7424b18412a42a155dd8a2df4c7a
     ;;
   Linux:aarch64|Linux:arm64)
-    target=aarch64-unknown-linux-gnu
+    libc_family=$(detect_linux_libc) || {
+      echo "could not determine the Linux libc; refusing to guess a release target" >&2
+      exit 1
+    }
+    target="aarch64-unknown-linux-${libc_family}"
     cosign_asset=cosign-linux-arm64
     cosign_sha256=2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11
     ;;
   Linux:x86_64|Linux:amd64)
-    target=x86_64-unknown-linux-gnu
+    libc_family=$(detect_linux_libc) || {
+      echo "could not determine the Linux libc; refusing to guess a release target" >&2
+      exit 1
+    }
+    target="x86_64-unknown-linux-${libc_family}"
     cosign_asset=cosign-linux-amd64
     cosign_sha256=ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc
     ;;
@@ -696,11 +862,30 @@ if [ -n "$release_metadata_sha256" ] && [ "$(sha256_file "$work/$release_metadat
 fi
 validate_release_metadata "$work/$release_metadata_asset" "$AOS_VERSION" "$release_identity"
 
+target_metadata="$work/$release_metadata_asset"
+if [ "$libc_family" = musl ]; then
+  musl_metadata_asset="unicity-aos-${AOS_VERSION}-musl-release.toml"
+  curl --proto '=https' --tlsv1.2 -fsSL "$release_base/$musl_metadata_asset" -o "$work/$musl_metadata_asset"
+  curl --proto '=https' --tlsv1.2 -fsSL "$release_base/$musl_metadata_asset.sigstore.json" -o "$work/$musl_metadata_asset.sigstore.json"
+  "$COSIGN_BIN" verify-blob \
+    --bundle "$work/$musl_metadata_asset.sigstore.json" \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-identity "$release_identity" \
+    --use-signed-timestamps \
+    "$work/$musl_metadata_asset" >/dev/null
+  validate_musl_release_metadata \
+    "$work/$musl_metadata_asset" \
+    "$work/$release_metadata_asset" \
+    "$AOS_VERSION" \
+    "$release_identity"
+  target_metadata="$work/$musl_metadata_asset"
+fi
+
 target_section="[targets.${target}]"
-asset=$(toml_value "$work/$release_metadata_asset" "$target_section" asset)
-asset_sha256=$(toml_value "$work/$release_metadata_asset" "$target_section" sha256)
-asset_blake3=$(toml_value "$work/$release_metadata_asset" "$target_section" blake3)
-asset_bundle=$(toml_value "$work/$release_metadata_asset" "$target_section" sigstore-bundle)
+asset=$(toml_value "$target_metadata" "$target_section" asset)
+asset_sha256=$(toml_value "$target_metadata" "$target_section" sha256)
+asset_blake3=$(toml_value "$target_metadata" "$target_section" blake3)
+asset_bundle=$(toml_value "$target_metadata" "$target_section" sigstore-bundle)
 expected_asset="unicity-aos-${AOS_VERSION}-${target}.tar.gz"
 [ "$asset" = "$expected_asset" ] || { echo "release metadata selected a non-canonical target asset" >&2; exit 1; }
 [ "$asset_bundle" = "$asset.sigstore.json" ] || { echo "release metadata selected a non-canonical signature bundle" >&2; exit 1; }
@@ -725,12 +910,14 @@ if [ -f "$work/channel.toml" ]; then
     echo "signed channel source commit does not match immutable release metadata" >&2
     exit 1
   }
-  for key in asset sha256 blake3 sigstore-bundle size; do
-    [ "$(toml_value "$work/channel.toml" "$target_section" "$key")" = "$(toml_value "$work/$release_metadata_asset" "$target_section" "$key")" ] || {
-      echo "signed channel target does not match immutable release metadata: $key" >&2
-      exit 1
-    }
-  done
+  if [ "$libc_family" != musl ]; then
+    for key in asset sha256 blake3 sigstore-bundle size; do
+      [ "$(toml_value "$work/channel.toml" "$target_section" "$key")" = "$(toml_value "$work/$release_metadata_asset" "$target_section" "$key")" ] || {
+        echo "signed channel target does not match immutable release metadata: $key" >&2
+        exit 1
+      }
+    done
+  fi
 fi
 
 echo "Downloading Unicity AOS $AOS_VERSION for $target..."

--- a/release/runtime-musl-compatibility.toml
+++ b/release/runtime-musl-compatibility.toml
@@ -1,0 +1,17 @@
+schema-version = 1
+
+# Linux musl runtime provenance is intentionally separate from the legacy
+# four-target runtime compatibility contract. A release-only pin update flips
+# this gate after Astrid publishes and authenticates the matching immutable
+# two-target musl extension.
+[runtime]
+repository = "astrid-runtime/astrid"
+release-ready = false
+version = "0.10.4"
+tag = "v0.10.4"
+release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v0.10.4"
+source-commit = "b6bf5d1d579915eb5d3c944857d84e62a4fcc878"
+legacy-release-metadata-asset = "astrid-0.10.4-release.toml"
+legacy-release-metadata-blake3 = "25f4de92aa2db9db81e84902db479adf8bae68256fe3656db2c1673dfb302c0b"
+musl-release-metadata-asset = ""
+musl-release-metadata-blake3 = ""

--- a/scripts/check_glibc.py
+++ b/scripts/check_glibc.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Reject ELF binaries that require a newer glibc than the release baseline."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+
+
+GLIBC_VERSION = re.compile(r"\bGLIBC_(\d+)\.(\d+)(?:\.(\d+))?\b")
+
+
+def parse_version(value: str) -> tuple[int, ...]:
+    parts = value.split(".")
+    if len(parts) < 2 or any(not part.isdigit() for part in parts):
+        raise ValueError(f"invalid glibc version {value!r}")
+    return tuple(int(part) for part in parts)
+
+
+def required_versions(version_info: str) -> set[tuple[int, ...]]:
+    return {
+        tuple(int(part) for part in match.groups() if part is not None)
+        for match in GLIBC_VERSION.finditer(version_info)
+    }
+
+
+def check_binary(path: pathlib.Path, ceiling: tuple[int, ...]) -> None:
+    if not path.is_file() or path.is_symlink():
+        raise ValueError(f"binary is missing or not a regular file: {path}")
+    try:
+        result = subprocess.run(
+            ["readelf", "--version-info", "--wide", "--", str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise ValueError("readelf is required to validate glibc compatibility") from error
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() if error.stderr else "unknown readelf error"
+        raise ValueError(f"could not inspect {path}: {stderr}") from error
+
+    versions = required_versions(result.stdout)
+    if versions and max(versions) > ceiling:
+        required = ".".join(str(part) for part in max(versions))
+        maximum = ".".join(str(part) for part in ceiling)
+        raise ValueError(f"{path} requires GLIBC_{required}, newer than GLIBC_{maximum}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-version", required=True)
+    parser.add_argument("binary", nargs="+", type=pathlib.Path)
+    args = parser.parse_args()
+
+    try:
+        ceiling = parse_version(args.max_version)
+        for binary in args.binary:
+            check_binary(binary, ceiling)
+    except ValueError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/musl_release_metadata.py
+++ b/scripts/musl_release_metadata.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Render and validate AOS's immutable Linux musl metadata extension."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import release_metadata
+
+
+KIND = "aos-release-musl-extension"
+MUSL_TARGETS = (
+    "aarch64-unknown-linux-musl",
+    "x86_64-unknown-linux-musl",
+)
+ROOT_KEYS = {
+    "schema-version",
+    "kind",
+    "product",
+    "repository",
+    "version",
+    "tag",
+    "source-commit",
+    "release-workflow-identity",
+    "legacy-release",
+    "runtime-musl",
+    "targets",
+}
+LEGACY_KEYS = {"metadata-asset", "metadata-sha256"}
+RUNTIME_KEYS = {
+    "repository",
+    "version",
+    "tag",
+    "source-commit",
+    "release-workflow-identity",
+    "legacy-release-metadata-asset",
+    "legacy-release-metadata-blake3",
+    "musl-release-metadata-asset",
+    "musl-release-metadata-blake3",
+}
+TARGET_KEYS = {"asset", "sha256", "blake3", "sigstore-bundle", "size"}
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def metadata_name(version: str) -> str:
+    return f"unicity-aos-{version}-musl-release.toml"
+
+
+def legacy_metadata_name(version: str) -> str:
+    return f"unicity-aos-{version}-release.toml"
+
+
+def validate_runtime_pin(value: Any, *, require_ready: bool) -> dict[str, Any]:
+    root = release_metadata.exact_keys(
+        value, {"schema-version", "runtime"}, "musl runtime compatibility"
+    )
+    release_metadata.require(
+        type(root["schema-version"]) is int and root["schema-version"] == 1,
+        "musl runtime compatibility schema-version must be integer 1",
+    )
+    runtime = release_metadata.exact_keys(
+        root["runtime"], RUNTIME_KEYS | {"release-ready"}, "musl runtime compatibility.runtime"
+    )
+    release_metadata.require(
+        type(runtime["release-ready"]) is bool,
+        "musl runtime compatibility release-ready must be a boolean",
+    )
+    if require_ready:
+        release_metadata.require(
+            runtime["release-ready"],
+            "musl runtime compatibility release-ready gate is false",
+        )
+    release_metadata.require(
+        runtime["repository"] == "astrid-runtime/astrid",
+        "musl runtime repository must be astrid-runtime/astrid",
+    )
+    version = release_metadata.string(runtime["version"], "musl runtime version")
+    release_metadata.require(
+        release_metadata.SEMVER.fullmatch(version) is not None,
+        "musl runtime version must be canonical semver",
+    )
+    release_metadata.require(
+        runtime["tag"] == f"v{version}", "musl runtime tag/version mismatch"
+    )
+    release_metadata.require(
+        release_metadata.COMMIT.fullmatch(
+            release_metadata.string(runtime["source-commit"], "musl runtime source-commit")
+        )
+        is not None,
+        "musl runtime source commit is malformed",
+    )
+    expected_identity = (
+        "https://github.com/astrid-runtime/astrid/.github/workflows/"
+        f"release.yml@refs/tags/v{version}"
+    )
+    release_metadata.require(
+        runtime["release-workflow-identity"] == expected_identity,
+        "musl runtime workflow identity is not the exact tag identity",
+    )
+    release_metadata.require(
+        runtime["legacy-release-metadata-asset"]
+        == f"astrid-{version}-release.toml",
+        "musl runtime legacy metadata asset is not canonical",
+    )
+    release_metadata.require(
+        release_metadata.HEX_64.fullmatch(
+            release_metadata.string(
+                runtime["legacy-release-metadata-blake3"],
+                "musl runtime legacy metadata BLAKE3",
+            )
+        )
+        is not None,
+        "musl runtime legacy metadata BLAKE3 is malformed",
+    )
+    if runtime["release-ready"]:
+        release_metadata.require(
+            runtime["musl-release-metadata-asset"]
+            == f"astrid-{version}-musl-release.toml",
+            "musl runtime extension metadata asset is not canonical",
+        )
+        release_metadata.require(
+            release_metadata.HEX_64.fullmatch(
+                release_metadata.string(
+                    runtime["musl-release-metadata-blake3"],
+                    "musl runtime extension metadata BLAKE3",
+                )
+            )
+            is not None,
+            "musl runtime extension metadata BLAKE3 is malformed",
+        )
+    else:
+        release_metadata.require(
+            runtime["musl-release-metadata-asset"]
+            == runtime["musl-release-metadata-blake3"]
+            == "",
+            "unready musl runtime extension fields must remain empty",
+        )
+    return runtime
+
+
+def validate_target_table(
+    value: Any, *, version: str, context: str
+) -> dict[str, dict[str, Any]]:
+    table = release_metadata.exact_keys(value, set(MUSL_TARGETS), context)
+    for target in MUSL_TARGETS:
+        item = release_metadata.exact_keys(
+            table[target], TARGET_KEYS, f"{context}.{target}"
+        )
+        asset = release_metadata.string(item["asset"], f"{context}.{target}.asset")
+        expected = f"unicity-aos-{version}-{target}.tar.gz"
+        release_metadata.require(
+            asset == expected, f"{context}.{target}.asset must be {expected}"
+        )
+        release_metadata.require(
+            item["sigstore-bundle"] == f"{asset}.sigstore.json",
+            f"{context}.{target}.sigstore-bundle must name the asset bundle",
+        )
+        for algorithm in ("sha256", "blake3"):
+            release_metadata.require(
+                isinstance(item[algorithm], str)
+                and release_metadata.HEX_64.fullmatch(item[algorithm]) is not None,
+                f"{context}.{target}.{algorithm} is malformed",
+            )
+        release_metadata.require(
+            type(item["size"]) is int and item["size"] > 0,
+            f"{context}.{target}.size must be positive",
+        )
+    return table
+
+
+def validate_extension(
+    value: Any,
+    *,
+    legacy: dict[str, Any] | None = None,
+    legacy_bytes: bytes | None = None,
+) -> dict[str, Any]:
+    root = release_metadata.exact_keys(value, ROOT_KEYS, "musl release metadata")
+    release_metadata.require(
+        type(root["schema-version"]) is int and root["schema-version"] == 1,
+        "musl release metadata schema-version must be integer 1",
+    )
+    release_metadata.require(root["kind"] == KIND, f"musl release metadata kind must be {KIND}")
+    release_metadata.require(
+        root["product"] == release_metadata.PRODUCT,
+        f"musl release metadata product must be {release_metadata.PRODUCT}",
+    )
+    release_metadata.require(
+        root["repository"] == release_metadata.REPOSITORY,
+        f"musl release metadata repository must be {release_metadata.REPOSITORY}",
+    )
+    version = release_metadata.string(root["version"], "musl release metadata version")
+    release_metadata.require(
+        release_metadata.VERSION.fullmatch(version) is not None,
+        "musl release metadata version must be calendar semver",
+    )
+    release_metadata.require(root["tag"] == version, "musl release metadata tag must equal version")
+    release_metadata.require(
+        release_metadata.COMMIT.fullmatch(
+            release_metadata.string(root["source-commit"], "musl release metadata source-commit")
+        )
+        is not None,
+        "musl release metadata source-commit is malformed",
+    )
+    if release_metadata.is_nightly_version(version):
+        release_metadata.require(
+            release_metadata.nightly_source_commit(version) == root["source-commit"],
+            "musl release metadata nightly version must embed its source commit",
+        )
+    release_metadata.require(
+        root["release-workflow-identity"]
+        == release_metadata.release_workflow_identity(version, root["tag"]),
+        "musl release metadata workflow identity is not the exact tag identity",
+    )
+    legacy_link = release_metadata.exact_keys(
+        root["legacy-release"], LEGACY_KEYS, "musl release metadata.legacy-release"
+    )
+    release_metadata.require(
+        legacy_link["metadata-asset"] == legacy_metadata_name(version),
+        "musl release metadata legacy asset is not canonical",
+    )
+    release_metadata.require(
+        isinstance(legacy_link["metadata-sha256"], str)
+        and release_metadata.HEX_64.fullmatch(legacy_link["metadata-sha256"]) is not None,
+        "musl release metadata legacy SHA-256 is malformed",
+    )
+    release_metadata.exact_keys(
+        root["runtime-musl"], RUNTIME_KEYS, "musl release metadata.runtime-musl"
+    )
+    runtime_pin = {
+        "schema-version": 1,
+        "runtime": {**root["runtime-musl"], "release-ready": True},
+    }
+    validate_runtime_pin(runtime_pin, require_ready=True)
+    validate_target_table(root["targets"], version=version, context="musl release metadata.targets")
+
+    if legacy is not None:
+        release_metadata.validate_release(legacy)
+        for key in (
+            "product",
+            "version",
+            "tag",
+            "source-commit",
+            "release-workflow-identity",
+        ):
+            release_metadata.require(
+                root[key] == legacy[key],
+                f"musl release metadata {key} differs from the legacy release",
+            )
+        release_metadata.require(
+            legacy_bytes is not None
+            and legacy_link["metadata-sha256"]
+            == hashlib.sha256(legacy_bytes).hexdigest(),
+            "musl release metadata does not bind the authenticated legacy release",
+        )
+    return root
+
+
+def build_extension(
+    *,
+    artifacts: Path,
+    legacy_path: Path,
+    compatibility_path: Path,
+) -> dict[str, Any]:
+    legacy_bytes = legacy_path.read_bytes()
+    legacy = release_metadata.validate_release(release_metadata.load(legacy_path))
+    version = legacy["version"]
+    release_metadata.require(
+        legacy_path.name == legacy_metadata_name(version),
+        f"legacy release metadata must be named {legacy_metadata_name(version)}",
+    )
+    runtime = validate_runtime_pin(
+        release_metadata.load(compatibility_path), require_ready=True
+    )
+    sha256 = release_metadata.checksum_manifest(artifacts / "SHA256SUMS.txt")
+    blake3 = release_metadata.checksum_manifest(artifacts / "BLAKE3SUMS.txt")
+    expected_archives = {
+        f"unicity-aos-{version}-{target}.tar.gz"
+        for target in (*release_metadata.TARGETS, *MUSL_TARGETS)
+    }
+    sha_archives = {name for name in sha256 if name.endswith(".tar.gz")}
+    blake_archives = {name for name in blake3 if name.endswith(".tar.gz")}
+    release_metadata.require(
+        sha_archives == expected_archives and blake_archives == expected_archives,
+        "musl metadata requires checksums for exactly all six release archives",
+    )
+    targets: dict[str, dict[str, Any]] = {}
+    for target in MUSL_TARGETS:
+        asset = f"unicity-aos-{version}-{target}.tar.gz"
+        path = artifacts / asset
+        release_metadata.require(
+            path.is_file() and not path.is_symlink(),
+            f"missing regular musl release asset: {asset}",
+        )
+        targets[target] = {
+            "asset": asset,
+            "sha256": sha256[asset],
+            "blake3": blake3[asset],
+            "sigstore-bundle": f"{asset}.sigstore.json",
+            "size": path.stat().st_size,
+        }
+    extension = {
+        "schema-version": 1,
+        "kind": KIND,
+        "product": legacy["product"],
+        "repository": release_metadata.REPOSITORY,
+        "version": version,
+        "tag": legacy["tag"],
+        "source-commit": legacy["source-commit"],
+        "release-workflow-identity": legacy["release-workflow-identity"],
+        "legacy-release": {
+            "metadata-asset": legacy_path.name,
+            "metadata-sha256": hashlib.sha256(legacy_bytes).hexdigest(),
+        },
+        "runtime-musl": {
+            key: runtime[key] for key in RUNTIME_KEYS
+        },
+        "targets": targets,
+    }
+    validate_extension(extension, legacy=legacy, legacy_bytes=legacy_bytes)
+    return extension
+
+
+def render_extension(value: dict[str, Any]) -> str:
+    root = validate_extension(value)
+    quote = release_metadata.quoted
+    lines = [
+        "schema-version = 1",
+        f"kind = {quote(root['kind'])}",
+        f"product = {quote(root['product'])}",
+        f"repository = {quote(root['repository'])}",
+        f"version = {quote(root['version'])}",
+        f"tag = {quote(root['tag'])}",
+        f"source-commit = {quote(root['source-commit'])}",
+        f"release-workflow-identity = {quote(root['release-workflow-identity'])}",
+        "",
+        "[legacy-release]",
+        f"metadata-asset = {quote(root['legacy-release']['metadata-asset'])}",
+        f"metadata-sha256 = {quote(root['legacy-release']['metadata-sha256'])}",
+        "",
+        "[runtime-musl]",
+    ]
+    for key in (
+        "repository",
+        "version",
+        "tag",
+        "source-commit",
+        "release-workflow-identity",
+        "legacy-release-metadata-asset",
+        "legacy-release-metadata-blake3",
+        "musl-release-metadata-asset",
+        "musl-release-metadata-blake3",
+    ):
+        lines.append(f"{key} = {quote(root['runtime-musl'][key])}")
+    for target in MUSL_TARGETS:
+        item = root["targets"][target]
+        lines.extend(
+            [
+                "",
+                f"[targets.{target}]",
+                f"asset = {quote(item['asset'])}",
+                f"sha256 = {quote(item['sha256'])}",
+                f"blake3 = {quote(item['blake3'])}",
+                f"sigstore-bundle = {quote(item['sigstore-bundle'])}",
+                f"size = {item['size']}",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command", required=True)
+    render = commands.add_parser("render")
+    render.add_argument("--artifacts", type=Path, required=True)
+    render.add_argument("--legacy-release", type=Path, required=True)
+    render.add_argument("--runtime-compatibility", type=Path, required=True)
+    render.add_argument("--output", type=Path, required=True)
+    validate = commands.add_parser("validate")
+    validate.add_argument("path", type=Path)
+    validate.add_argument("--legacy-release", type=Path, required=True)
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    if args.command == "render":
+        value = build_extension(
+            artifacts=args.artifacts,
+            legacy_path=args.legacy_release,
+            compatibility_path=args.runtime_compatibility,
+        )
+        args.output.write_text(render_extension(value), encoding="utf-8")
+        return 0
+    legacy_bytes = args.legacy_release.read_bytes()
+    validate_extension(
+        release_metadata.load(args.path),
+        legacy=release_metadata.load(args.legacy_release),
+        legacy_bytes=legacy_bytes,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (KeyError, OSError, ValueError) as error:
+        print(f"musl release metadata: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 6 ]]; then
-  echo "usage: $0 <target> <aos-binary> <runtime-archive> <runtime-blake3> <capsule-artifacts> <output-dir>" >&2
+if [[ $# -ne 6 && $# -ne 8 ]]; then
+  echo "usage: $0 <target> <aos-binary> <runtime-archive> <runtime-blake3> <capsule-artifacts> <output-dir> [--musl-runtime-compatibility <path>]" >&2
   exit 2
 fi
 
@@ -12,6 +12,14 @@ runtime_archive=$3
 runtime_blake3=$4
 capsule_artifacts=$5
 output_dir=$6
+musl_runtime_compatibility=
+if [[ $# -eq 8 ]]; then
+  [[ "$7" == --musl-runtime-compatibility ]] || {
+    echo "unknown package-release option: $7" >&2
+    exit 2
+  }
+  musl_runtime_compatibility=$8
+fi
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 toml_value() {
@@ -32,10 +40,33 @@ PY
 }
 
 product_version=$(toml_value "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" package version)
-runtime_version=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime version)
-runtime_tag=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime tag)
-runtime_repository=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime repository)
-runtime_identity=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime release-workflow-identity)
+runtime_compatibility="$repo_root/release/runtime-compatibility.toml"
+if [[ "$target" == *-unknown-linux-musl ]]; then
+  runtime_compatibility="${musl_runtime_compatibility:-$repo_root/release/runtime-musl-compatibility.toml}"
+  PYTHONPATH="$repo_root/scripts" python3 - "$runtime_compatibility" <<'PY'
+import pathlib
+import sys
+
+import musl_release_metadata
+import release_metadata
+
+path = pathlib.Path(sys.argv[1])
+try:
+    musl_release_metadata.validate_runtime_pin(
+        release_metadata.load(path),
+        require_ready=True,
+    )
+except (KeyError, OSError, ValueError) as error:
+    raise SystemExit(f"musl runtime compatibility: {error}") from error
+PY
+elif [[ -n "$musl_runtime_compatibility" ]]; then
+  echo "--musl-runtime-compatibility is valid only for a Linux musl target" >&2
+  exit 2
+fi
+runtime_version=$(toml_value "$runtime_compatibility" runtime version)
+runtime_tag=$(toml_value "$runtime_compatibility" runtime tag)
+runtime_repository=$(toml_value "$runtime_compatibility" runtime repository)
+runtime_identity=$(toml_value "$runtime_compatibility" runtime release-workflow-identity)
 wit_repository=$(toml_value "$repo_root/release/runtime-compatibility.toml" contracts repository)
 wit_commit=$(toml_value "$repo_root/release/runtime-compatibility.toml" contracts commit)
 sdk_rust_version=$(toml_value "$repo_root/release/runtime-compatibility.toml" contracts sdk-rust-version)
@@ -101,6 +132,9 @@ done < "$work/$root/capsule-assets.txt"
 python3 "$repo_root/scripts/capsule_release.py" --artifacts "$work/$root/capsules"
 
 install -m 0644 "$repo_root/release/runtime-compatibility.toml" "$work/$root/runtime-compatibility.toml"
+if [[ "$target" == *-unknown-linux-musl ]]; then
+  install -m 0644 "$runtime_compatibility" "$work/$root/runtime-musl-compatibility.toml"
+fi
 install -m 0644 "$repo_root/distros/community/unicity-ce/Distro.toml" "$work/$root/Distro.toml"
 install -m 0644 "$repo_root/README.md" "$work/$root/README.md"
 

--- a/scripts/release_publication.py
+++ b/scripts/release_publication.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 import capsule_release
+import musl_release_metadata
 import release_metadata
 
 
@@ -40,6 +41,7 @@ def validate_release_assets(
     version: str,
     source_commit: str,
     compatibility_path: Path | None = None,
+    musl_compatibility_path: Path | None = None,
 ) -> list[str]:
     require(directory.is_dir() and not directory.is_symlink(), "release assets must be a directory")
     entries = list(directory.iterdir())
@@ -65,8 +67,29 @@ def validate_release_assets(
     specs = capsule_release.source_contract()
     capsules = {spec.asset for spec in specs}
     targets = {item["asset"] for item in metadata["targets"].values()}
-    checksummed = targets | capsules
-    payloads = checksummed | set(FIXED_PAYLOADS) | {metadata_name}
+
+    musl_compatibility_path = (
+        musl_compatibility_path
+        or ROOT / "release" / "runtime-musl-compatibility.toml"
+    )
+    musl_pin = musl_release_metadata.validate_runtime_pin(
+        release_metadata.load(musl_compatibility_path), require_ready=False
+    )
+    musl_ready = musl_pin["release-ready"]
+    musl_metadata_name = musl_release_metadata.metadata_name(version)
+    musl_targets: set[str] = set()
+    extra_payloads: set[str] = set()
+    musl_metadata: dict[str, object] | None = None
+    if musl_ready:
+        musl_compatibility_name = "runtime-musl-compatibility.toml"
+        musl_targets = {
+            f"unicity-aos-{version}-{target}.tar.gz"
+            for target in musl_release_metadata.MUSL_TARGETS
+        }
+        extra_payloads = {musl_compatibility_name, musl_metadata_name}
+
+    checksummed = targets | musl_targets | capsules
+    payloads = checksummed | set(FIXED_PAYLOADS) | {metadata_name} | extra_payloads
     expected = payloads | {f"{name}.sigstore.json" for name in payloads}
     actual = {path.name for path in entries}
     require(
@@ -74,6 +97,25 @@ def validate_release_assets(
         f"release asset set differs; missing={sorted(expected - actual)}, "
         f"unexpected={sorted(actual - expected)}",
     )
+    if musl_ready:
+        require(
+            (directory / musl_compatibility_name).read_bytes()
+            == musl_compatibility_path.read_bytes(),
+            "published musl runtime compatibility does not match the tagged source",
+        )
+        musl_metadata_path = directory / musl_metadata_name
+        musl_metadata = musl_release_metadata.validate_extension(
+            release_metadata.load(musl_metadata_path),
+            legacy=metadata,
+            legacy_bytes=metadata_path.read_bytes(),
+        )
+        expected_runtime = {
+            key: musl_pin[key] for key in musl_release_metadata.RUNTIME_KEYS
+        }
+        require(
+            musl_metadata["runtime-musl"] == expected_runtime,
+            "musl release metadata runtime pin does not match the tagged source",
+        )
 
     sha256 = release_metadata.checksum_manifest(directory / "SHA256SUMS.txt")
     blake3 = release_metadata.checksum_manifest(directory / "BLAKE3SUMS.txt")
@@ -91,6 +133,21 @@ def validate_release_assets(
         require(item["sha256"] == sha256[name], f"release metadata SHA-256 mismatch for {name}")
         require(item["blake3"] == blake3[name], f"release metadata BLAKE3 mismatch for {name}")
         require(item["size"] == (directory / name).stat().st_size, f"release metadata size mismatch for {name}")
+    if musl_metadata is not None:
+        for item in musl_metadata["targets"].values():
+            name = item["asset"]
+            require(
+                item["sha256"] == sha256[name],
+                f"musl release metadata SHA-256 mismatch for {name}",
+            )
+            require(
+                item["blake3"] == blake3[name],
+                f"musl release metadata BLAKE3 mismatch for {name}",
+            )
+            require(
+                item["size"] == (directory / name).stat().st_size,
+                f"musl release metadata size mismatch for {name}",
+            )
 
     compatibility_path = compatibility_path or ROOT / "release" / "runtime-compatibility.toml"
     require(

--- a/scripts/test-install-musl.sh
+++ b/scripts/test-install-musl.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+fixture="$work/fixture"
+fake_bin="$work/fake-bin"
+capsules="$work/capsules"
+mkdir -p "$fixture" "$fake_bin" "$capsules"
+
+read -r product_version runtime_version < <(
+  python3 - "$repo_root" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+root = pathlib.Path(sys.argv[1])
+with (root / "crates/unicity-aos-bootstrap/Cargo.toml").open("rb") as source:
+    product = tomllib.load(source)["package"]["version"]
+with (root / "release/runtime-compatibility.toml").open("rb") as source:
+    runtime = tomllib.load(source)["runtime"]
+print(product, runtime["version"])
+PY
+)
+target=x86_64-unknown-linux-musl
+runtime_root="$work/astrid-$runtime_version-$target"
+mkdir -p "$runtime_root"
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  printf '#!/bin/sh\nexit 0\n' > "$runtime_root/$binary"
+  chmod 755 "$runtime_root/$binary"
+done
+COPYFILE_DISABLE=1 tar -czf "$work/runtime.tar.gz" -C "$work" "$(basename "$runtime_root")"
+cat > "$work/aos" <<EOF
+#!/bin/sh
+if [ "\${1:-}" = --version ]; then
+  echo "Unicity AOS $product_version"
+fi
+exit 0
+EOF
+chmod 755 "$work/aos"
+PYTHONPATH="$repo_root/scripts" python3 - "$capsules" <<'PY'
+import pathlib
+import sys
+
+from capsule_release import source_contract
+from test_capsule_release import write_fixture
+
+output = pathlib.Path(sys.argv[1])
+for spec in source_contract():
+    write_fixture(output / spec.asset, spec)
+PY
+runtime_musl="$work/runtime-musl.toml"
+cat > "$runtime_musl" <<EOF
+schema-version = 1
+
+[runtime]
+repository = "astrid-runtime/astrid"
+release-ready = true
+version = "$runtime_version"
+tag = "v$runtime_version"
+release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v$runtime_version"
+source-commit = "$(printf 'b%.0s' {1..40})"
+legacy-release-metadata-asset = "astrid-$runtime_version-release.toml"
+legacy-release-metadata-blake3 = "$(printf 'c%.0s' {1..64})"
+musl-release-metadata-asset = "astrid-$runtime_version-musl-release.toml"
+musl-release-metadata-blake3 = "$(printf 'd%.0s' {1..64})"
+EOF
+if bash "$repo_root/scripts/package-release.sh" \
+  "$target" \
+  "$work/aos" \
+  "$work/runtime.tar.gz" \
+  "$(printf '0%.0s' {1..64})" \
+  "$capsules" \
+  "$fixture" >/dev/null 2>&1; then
+  echo "musl release composer accepted the checked-in false readiness gate" >&2
+  exit 1
+fi
+malformed_runtime_musl="$work/runtime-musl-malformed.toml"
+sed \
+  's/musl-release-metadata-blake3 = "[0-9a-f]*"/musl-release-metadata-blake3 = "BAD"/' \
+  "$runtime_musl" > "$malformed_runtime_musl"
+malformed_output="$work/malformed-package"
+mkdir "$malformed_output"
+if bash "$repo_root/scripts/package-release.sh" \
+  "$target" \
+  "$work/aos" \
+  "$work/runtime.tar.gz" \
+  "$(printf '0%.0s' {1..64})" \
+  "$capsules" \
+  "$malformed_output" \
+  --musl-runtime-compatibility "$malformed_runtime_musl" \
+  >"$work/malformed-package.log" 2>&1; then
+  echo "musl release composer accepted a malformed ready compatibility pin" >&2
+  exit 1
+fi
+grep -F 'BLAKE3 is malformed' "$work/malformed-package.log" >/dev/null
+test -z "$(find "$malformed_output" -mindepth 1 -print -quit)"
+bash "$repo_root/scripts/package-release.sh" \
+  "$target" \
+  "$work/aos" \
+  "$work/runtime.tar.gz" \
+  "$(printf '0%.0s' {1..64})" \
+  "$capsules" \
+  "$fixture" \
+  --musl-runtime-compatibility "$runtime_musl" >/dev/null
+tar -xOf \
+  "$fixture/unicity-aos-$product_version-$target.tar.gz" \
+  "unicity-aos-$product_version-$target/runtime-musl-compatibility.toml" \
+  | grep -Fx 'release-ready = true' >/dev/null
+
+for metadata_target in \
+  aarch64-apple-darwin \
+  x86_64-apple-darwin \
+  aarch64-unknown-linux-gnu \
+  x86_64-unknown-linux-gnu \
+  aarch64-unknown-linux-musl; do
+  printf 'fixture:%s\n' "$metadata_target" \
+    > "$fixture/unicity-aos-$product_version-$metadata_target.tar.gz"
+done
+(
+  cd "$fixture"
+  b3sum -- ./*.tar.gz | sed 's#  \./#  #' > BLAKE3SUMS.txt
+  shasum -a 256 -- ./*.tar.gz | sed 's#  \./#  #' > SHA256SUMS.txt
+)
+legacy="$fixture/unicity-aos-$product_version-release.toml"
+python3 "$repo_root/scripts/release_metadata.py" render-release \
+  --version "$product_version" \
+  --tag "$product_version" \
+  --source-commit "$(printf 'a%.0s' {1..40})" \
+  --published-at 2026-07-16T10:00:00Z \
+  --artifacts "$fixture" \
+  --sha256 "$fixture/SHA256SUMS.txt" \
+  --blake3 "$fixture/BLAKE3SUMS.txt" \
+  --output "$legacy"
+
+extension="$fixture/unicity-aos-$product_version-musl-release.toml"
+python3 "$repo_root/scripts/musl_release_metadata.py" render \
+  --artifacts "$fixture" \
+  --legacy-release "$legacy" \
+  --runtime-compatibility "$runtime_musl" \
+  --output "$extension"
+
+python3 "$repo_root/scripts/release_metadata.py" render-channel \
+  --channel stable \
+  --generation 2 \
+  --published-at 2026-07-16T10:00:00Z \
+  --expires-at 2026-08-15T10:00:00Z \
+  --release-metadata "$legacy" \
+  --require-ready \
+  --output "$fixture/channel.toml"
+
+printf 'valid Sigstore fixture\n' > "$fixture/valid.sigstore.json"
+for signed in \
+  "$legacy" \
+  "$extension" \
+  "$fixture/channel.toml" \
+  "$fixture/unicity-aos-$product_version-$target.tar.gz"; do
+  cp "$fixture/valid.sigstore.json" "$signed.sigstore.json"
+done
+
+cat > "$fake_bin/uname" <<'EOF'
+#!/bin/sh
+case "${1:-}" in
+  -s) echo Linux ;;
+  -m) echo x86_64 ;;
+  *) exit 2 ;;
+esac
+EOF
+cat > "$fake_bin/getconf" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+cat > "$fake_bin/ldd" <<'EOF'
+#!/bin/sh
+printf '%s\n' 'musl libc (x86_64)' >&2
+exit 1
+EOF
+cat > "$fake_bin/date" <<'EOF'
+#!/bin/sh
+if [ "$#" -eq 2 ] && [ "$1" = -u ]; then
+  case "$2" in
+    +%Y-%m-%dT%H:%M:%SZ) printf '%s\n' '2026-07-16T10:00:00Z'; exit 0 ;;
+    +%s) printf '%s\n' '1784196000'; exit 0 ;;
+  esac
+fi
+exec /bin/date "$@"
+EOF
+cat > "$fake_bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+output=
+url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output=$2; shift ;;
+    http*) url=$1 ;;
+  esac
+  shift
+done
+cp "$AOS_TEST_FIXTURE/$(basename "$url")" "$output"
+EOF
+cat > "$fixture/cosign-linux-amd64" <<'EOF'
+#!/bin/sh
+set -eu
+[ "${1:-}" = verify-blob ]
+bundle=
+artifact=
+identity=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --bundle) bundle=$2; shift ;;
+    --certificate-identity) identity=$2; shift ;;
+    -*) ;;
+    *) artifact=$1 ;;
+  esac
+  shift
+done
+cmp "$AOS_TEST_FIXTURE/valid.sigstore.json" "$bundle"
+[ -f "$artifact" ]
+printf '%s|%s\n' "$(basename "$artifact")" "$identity" >> "$AOS_TEST_FIXTURE/cosign-trace"
+EOF
+cat > "$fake_bin/sha256sum" <<'EOF'
+#!/bin/sh
+set -eu
+case "$1" in
+  */cosign)
+    printf '%s  %s\n' ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc "$1"
+    ;;
+  *) exec /usr/bin/shasum -a 256 "$1" ;;
+esac
+EOF
+chmod 755 "$fake_bin"/* "$fixture/cosign-linux-amd64"
+
+run_installer() {
+  local home=$1
+  shift
+  PATH="$fake_bin:/usr/bin:/bin" \
+    HOME="$home" \
+    AOS_TEST_FIXTURE="$fixture" \
+    sh "$repo_root/install.sh" --yes --no-migrate-prompt "$@"
+}
+
+direct_home="$work/direct-home"
+run_installer "$direct_home" --version "$product_version" >/dev/null
+test -x "$direct_home/.aos/bin/aos"
+test -x "$direct_home/.aos/runtime/bin/astrid-daemon"
+direct_trace="$work/direct-trace"
+cp "$fixture/cosign-trace" "$direct_trace"
+test "$(sed -n '1s/|.*//p' "$direct_trace")" = "unicity-aos-$product_version-release.toml"
+test "$(sed -n '2s/|.*//p' "$direct_trace")" = "unicity-aos-$product_version-musl-release.toml"
+test "$(sed -n '3s/|.*//p' "$direct_trace")" = "unicity-aos-$product_version-$target.tar.gz"
+
+: > "$fixture/cosign-trace"
+channel_home="$work/channel-home"
+run_installer "$channel_home" >/dev/null
+test -x "$channel_home/.aos/bin/aos"
+test "$(sed -n '1s/|.*//p' "$fixture/cosign-trace")" = channel.toml
+test "$(sed -n '2s/|.*//p' "$fixture/cosign-trace")" = "unicity-aos-$product_version-release.toml"
+test "$(sed -n '3s/|.*//p' "$fixture/cosign-trace")" = "unicity-aos-$product_version-musl-release.toml"
+test "$(sed -n '4s/|.*//p' "$fixture/cosign-trace")" = "unicity-aos-$product_version-$target.tar.gz"
+test "$(cat "$channel_home/.aos/update/channels/stable/current")" = 2
+
+cp "$fixture/valid.sigstore.json" "$extension.sigstore.json"
+printf 'invalid Sigstore fixture\n' > "$extension.sigstore.json"
+if run_installer "$work/bad-signature-home" --version "$product_version" >/dev/null 2>&1; then
+  echo "musl installer accepted an invalid extension signature" >&2
+  exit 1
+fi
+test ! -e "$work/bad-signature-home/.aos/bin/aos"
+cp "$fixture/valid.sigstore.json" "$extension.sigstore.json"
+
+good_extension="$work/extension-good.toml"
+cp "$extension" "$good_extension"
+sed -i.bak 's/metadata-sha256 = "[0-9a-f]*"/metadata-sha256 = "0000000000000000000000000000000000000000000000000000000000000000"/' "$extension"
+rm "$extension.bak"
+if run_installer "$work/bad-link-home" --version "$product_version" >/dev/null 2>&1; then
+  echo "musl installer accepted an extension bound to different legacy bytes" >&2
+  exit 1
+fi
+test ! -e "$work/bad-link-home/.aos/bin/aos"
+cp "$good_extension" "$extension"
+
+sed -i.bak 's/tag = "v[0-9.]*"/tag = "v9.9.9"/' "$extension"
+rm "$extension.bak"
+if run_installer "$work/bad-runtime-home" --version "$product_version" >/dev/null 2>&1; then
+  echo "musl installer accepted a mismatched runtime identity" >&2
+  exit 1
+fi
+test ! -e "$work/bad-runtime-home/.aos/bin/aos"
+cp "$good_extension" "$extension"
+
+printf '\nsurprise = "value"\n' >> "$extension"
+if run_installer "$work/malformed-home" --version "$product_version" >/dev/null 2>&1; then
+  echo "musl installer accepted malformed extension metadata" >&2
+  exit 1
+fi
+test ! -e "$work/malformed-home/.aos/bin/aos"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -150,6 +150,11 @@ case "${1:-}" in
   *) exit 2 ;;
 esac
 EOF
+cat > "$fake_bin/getconf" <<'EOF'
+#!/bin/sh
+[ "${1:-}" = GNU_LIBC_VERSION ]
+printf '%s\n' 'glibc 2.34'
+EOF
 cat > "$fake_bin/date" <<'EOF'
 #!/bin/sh
 if [ "$#" -eq 2 ] && [ "$1" = -u ]; then
@@ -229,7 +234,7 @@ case "$1" in
   *) exec /usr/bin/shasum -a 256 "$1" ;;
 esac
 EOF
-chmod 755 "$fake_bin/uname" "$fake_bin/date" "$fake_bin/curl" "$fake_bin/cosign" \
+chmod 755 "$fake_bin/uname" "$fake_bin/getconf" "$fake_bin/date" "$fake_bin/curl" "$fake_bin/cosign" \
   "$fake_bin/sha256sum" "$fixture/cosign-linux-amd64"
 
 if PATH="$fake_bin:$PATH" HOME="$work/impossible-nightly-home" AOS_TEST_FIXTURE="$fixture" \

--- a/scripts/test-libc-detection.sh
+++ b/scripts/test-libc-detection.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+fake_bin="$work/bin"
+mkdir -p "$fake_bin"
+
+awk '
+  /^detect_linux_libc\(\) \{/ { copying = 1 }
+  copying { print }
+  copying && /^}$/ { exit }
+' "$repo_root/install.sh" > "$work/detect.sh"
+# shellcheck source=/dev/null
+source "$work/detect.sh"
+
+cat > "$fake_bin/getconf" <<'EOF'
+#!/bin/sh
+case "${AOS_TEST_GETCONF:-missing}" in
+  glibc) printf '%s\n' 'glibc 2.34' ;;
+  unknown) printf '%s\n' 'unsupported libc' ;;
+  missing) exit 127 ;;
+esac
+EOF
+cat > "$fake_bin/ldd" <<'EOF'
+#!/bin/sh
+case "${AOS_TEST_LDD:-missing}" in
+  glibc) printf '%s\n' 'ldd (GNU libc) 2.34' ;;
+  musl) printf '%s\n' 'musl libc (x86_64)' >&2 ;;
+  unknown) printf '%s\n' 'unknown dynamic loader' ;;
+  missing) exit 127 ;;
+esac
+EOF
+chmod 755 "$fake_bin/getconf" "$fake_bin/ldd"
+
+PATH="$fake_bin:/usr/bin:/bin" AOS_TEST_GETCONF=glibc AOS_TEST_LDD=musl \
+  test "$(PATH="$fake_bin:/usr/bin:/bin" AOS_TEST_GETCONF=glibc AOS_TEST_LDD=musl detect_linux_libc)" = gnu
+PATH="$fake_bin:/usr/bin:/bin" AOS_TEST_GETCONF=unknown AOS_TEST_LDD=glibc \
+  test "$(PATH="$fake_bin:/usr/bin:/bin" AOS_TEST_GETCONF=unknown AOS_TEST_LDD=glibc detect_linux_libc)" = gnu
+PATH="$fake_bin:/usr/bin:/bin" AOS_TEST_GETCONF=missing AOS_TEST_LDD=musl \
+  test "$(PATH="$fake_bin:/usr/bin:/bin" AOS_TEST_GETCONF=missing AOS_TEST_LDD=musl detect_linux_libc)" = musl
+
+loader_root="$work/root"
+mkdir -p "$loader_root/lib"
+touch "$loader_root/lib/ld-musl-x86_64.so.1"
+test "$(PATH="$fake_bin:/usr/bin:/bin" AOS_TEST_GETCONF=missing AOS_TEST_LDD=missing detect_linux_libc "$loader_root")" = musl
+
+if PATH="$fake_bin:/usr/bin:/bin" AOS_TEST_GETCONF=unknown AOS_TEST_LDD=unknown \
+  detect_linux_libc "$work/no-loader" >/dev/null; then
+  echo "libc detection guessed an unknown Linux libc" >&2
+  exit 1
+fi

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -104,6 +104,24 @@ assert len(manifest["capsules"]["assets"]) == 21
 assert len(set(manifest["capsules"]["assets"])) == 21
 PY
 
+darwin_target=aarch64-apple-darwin
+darwin_runtime_root="$work/astrid-$runtime_version-$darwin_target"
+mkdir -p "$darwin_runtime_root"
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  printf '#!/bin/sh\nexit 0\n' > "$darwin_runtime_root/$binary"
+  chmod 755 "$darwin_runtime_root/$binary"
+done
+COPYFILE_DISABLE=1 tar -czf "$work/runtime-darwin.tar.gz" \
+  -C "$work" "$(basename "$darwin_runtime_root")"
+bash "$repo_root/scripts/package-release.sh" \
+  "$darwin_target" \
+  "$work/aos" \
+  "$work/runtime-darwin.tar.gz" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$work/capsules" \
+  "$work/output" >/dev/null
+test -f "$work/output/unicity-aos-$product_version-$darwin_target.tar.gz"
+
 unsafe_root="$work/unsafe-runtime"
 mkdir -p "$unsafe_root/astrid-$runtime_version-$target"
 ln -s /tmp "$unsafe_root/astrid-$runtime_version-$target/astrid"

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -292,6 +292,11 @@ case "${1:-}" in
   *) exit 2 ;;
 esac
 EOF
+cat > "$fake_bin/getconf" <<'EOF'
+#!/bin/sh
+[ "${1:-}" = GNU_LIBC_VERSION ]
+printf '%s\n' 'glibc 2.34'
+EOF
 cat > "$fake_bin/curl" <<'EOF'
 #!/bin/sh
 set -eu
@@ -335,7 +340,7 @@ case "$1" in
   *) exec /usr/bin/shasum -a 256 "$1" ;;
 esac
 EOF
-chmod 755 "$fake_bin/uname" "$fake_bin/curl" "$fake_bin/sha256sum" \
+chmod 755 "$fake_bin/uname" "$fake_bin/getconf" "$fake_bin/curl" "$fake_bin/sha256sum" \
   "$fixture/cosign-linux-amd64"
 
 install_candidate() {

--- a/scripts/test_check_glibc.py
+++ b/scripts/test_check_glibc.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
+import pathlib
+import subprocess
+import tempfile
 import unittest
+from unittest import mock
 
 import check_glibc
 
@@ -26,6 +30,46 @@ class GlibcCompatibilityTests(unittest.TestCase):
         for value in ("2", "2.x", "v2.34"):
             with self.subTest(value=value), self.assertRaises(ValueError):
                 check_glibc.parse_version(value)
+
+    def test_check_binary_enforces_ceiling_and_reports_readelf_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            binary = pathlib.Path(directory) / "aos"
+            binary.write_bytes(b"ELF fixture")
+            with mock.patch.object(
+                check_glibc.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(
+                    args=[],
+                    returncode=0,
+                    stdout="Name: GLIBC_2.30",
+                    stderr="",
+                ),
+            ):
+                check_glibc.check_binary(binary, (2, 34))
+
+            with mock.patch.object(
+                check_glibc.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(
+                    args=[],
+                    returncode=0,
+                    stdout="Name: GLIBC_2.39",
+                    stderr="",
+                ),
+            ), self.assertRaisesRegex(ValueError, "newer than GLIBC_2.34"):
+                check_glibc.check_binary(binary, (2, 34))
+
+            failure = subprocess.CalledProcessError(
+                1,
+                ["readelf"],
+                stderr="invalid ELF",
+            )
+            with mock.patch.object(
+                check_glibc.subprocess,
+                "run",
+                side_effect=failure,
+            ), self.assertRaisesRegex(ValueError, "invalid ELF"):
+                check_glibc.check_binary(binary, (2, 34))
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_glibc.py
+++ b/scripts/test_check_glibc.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import check_glibc
+
+
+class GlibcCompatibilityTests(unittest.TestCase):
+    def test_extracts_unique_required_versions(self) -> None:
+        versions = check_glibc.required_versions(
+            """
+            0x0010: Name: GLIBC_2.17  Flags: none
+            0x0020: Name: GLIBC_2.34  Flags: none
+            0x0030: Name: GLIBC_2.17  Flags: none
+            """
+        )
+        self.assertEqual(versions, {(2, 17), (2, 34)})
+
+    def test_ignores_similar_non_glibc_symbols(self) -> None:
+        self.assertEqual(
+            check_glibc.required_versions("GLIBCXX_3.4 CXXABI_1.3"),
+            set(),
+        )
+
+    def test_rejects_malformed_ceiling(self) -> None:
+        for value in ("2", "2.x", "v2.34"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                check_glibc.parse_version(value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_musl_release_metadata.py
+++ b/scripts/test_musl_release_metadata.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Regression tests for the immutable AOS Linux musl metadata extension."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+import musl_release_metadata
+import release_metadata
+from test_release_metadata import release_fixture
+
+
+VERSION = "2026.1.3"
+
+
+def render_legacy(value: dict[str, object]) -> str:
+    lines = [
+        "schema-version = 1",
+        'kind = "aos-release"',
+        'product = "unicity-aos-ce"',
+        f'version = "{value["version"]}"',
+        f'tag = "{value["tag"]}"',
+        f'source-commit = "{value["source-commit"]}"',
+        f'published-at = "{value["published-at"]}"',
+        f'release-workflow-identity = "{value["release-workflow-identity"]}"',
+        "",
+        "[runtime]",
+    ]
+    for key in (
+        "repository",
+        "version",
+        "tag",
+        "release-workflow-identity",
+    ):
+        lines.append(f'{key} = "{value["runtime"][key]}"')
+    lines.extend(
+        [
+            f'release-metadata-available = {str(value["runtime"]["release-metadata-available"]).lower()}',
+            f'source-commit = "{value["runtime"]["source-commit"]}"',
+            f'release-metadata-asset = "{value["runtime"]["release-metadata-asset"]}"',
+            f'release-metadata-blake3 = "{value["runtime"]["release-metadata-blake3"]}"',
+            "",
+            "[contracts]",
+        ]
+    )
+    for key in ("repository", "commit", "sdk-rust-version", "sdk-rust-commit"):
+        lines.append(f'{key} = "{value["contracts"][key]}"')
+    lines.extend(
+        [
+            "",
+            "[gates]",
+            f'release-ready = {str(value["gates"]["release-ready"]).lower()}',
+            f'upgrade-self-heal-ready = {str(value["gates"]["upgrade-self-heal-ready"]).lower()}',
+        ]
+    )
+    release_metadata.write_target_tables(lines, value["targets"])
+    return "\n".join(lines) + "\n"
+
+
+class MuslReleaseMetadataTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.artifacts = self.root / "artifacts"
+        self.artifacts.mkdir()
+        self.legacy_path = self.artifacts / musl_release_metadata.legacy_metadata_name(VERSION)
+        self.legacy_path.write_text(render_legacy(release_fixture()), encoding="utf-8")
+        self.compatibility_path = self.root / "runtime-musl.toml"
+        self.compatibility_path.write_text(
+            "\n".join(
+                [
+                    "schema-version = 1",
+                    "",
+                    "[runtime]",
+                    'repository = "astrid-runtime/astrid"',
+                    "release-ready = true",
+                    'version = "0.11.0"',
+                    'tag = "v0.11.0"',
+                    'release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v0.11.0"',
+                    f'source-commit = "{"d" * 40}"',
+                    'legacy-release-metadata-asset = "astrid-0.11.0-release.toml"',
+                    f'legacy-release-metadata-blake3 = "{"e" * 64}"',
+                    'musl-release-metadata-asset = "astrid-0.11.0-musl-release.toml"',
+                    f'musl-release-metadata-blake3 = "{"f" * 64}"',
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        sha_lines = []
+        blake_lines = []
+        for target in (*release_metadata.TARGETS, *musl_release_metadata.MUSL_TARGETS):
+            name = f"unicity-aos-{VERSION}-{target}.tar.gz"
+            payload = f"archive:{target}".encode()
+            (self.artifacts / name).write_bytes(payload)
+            sha_lines.append(f"{hashlib.sha256(payload).hexdigest()}  {name}")
+            blake_lines.append(f"{hashlib.sha256(b'blake:' + payload).hexdigest()}  {name}")
+        (self.artifacts / "SHA256SUMS.txt").write_text(
+            "\n".join(sha_lines) + "\n", encoding="utf-8"
+        )
+        (self.artifacts / "BLAKE3SUMS.txt").write_text(
+            "\n".join(blake_lines) + "\n", encoding="utf-8"
+        )
+
+    def extension(self) -> dict[str, object]:
+        return musl_release_metadata.build_extension(
+            artifacts=self.artifacts,
+            legacy_path=self.legacy_path,
+            compatibility_path=self.compatibility_path,
+        )
+
+    def validate_bound(self, value: dict[str, object]) -> None:
+        musl_release_metadata.validate_extension(
+            value,
+            legacy=release_metadata.load(self.legacy_path),
+            legacy_bytes=self.legacy_path.read_bytes(),
+        )
+
+    def test_round_trip_binds_exact_two_targets_to_legacy_release(self) -> None:
+        value = self.extension()
+        rendered = musl_release_metadata.render_extension(value)
+        output = self.artifacts / musl_release_metadata.metadata_name(VERSION)
+        output.write_text(rendered, encoding="utf-8")
+        self.validate_bound(release_metadata.load(output))
+        self.assertEqual(
+            set(value["targets"]), set(musl_release_metadata.MUSL_TARGETS)
+        )
+        self.assertEqual(
+            value["legacy-release"]["metadata-sha256"],
+            hashlib.sha256(self.legacy_path.read_bytes()).hexdigest(),
+        )
+
+    def test_rejects_missing_duplicate_or_legacy_target(self) -> None:
+        missing = self.extension()
+        missing["targets"].pop("aarch64-unknown-linux-musl")
+        with self.assertRaisesRegex(ValueError, "missing keys"):
+            musl_release_metadata.validate_extension(missing)
+
+        legacy = self.extension()
+        legacy["targets"]["x86_64-unknown-linux-gnu"] = copy.deepcopy(
+            legacy["targets"]["x86_64-unknown-linux-musl"]
+        )
+        with self.assertRaisesRegex(ValueError, "unknown keys"):
+            musl_release_metadata.validate_extension(legacy)
+
+        duplicate = self.extension()
+        duplicate["targets"]["aarch64-unknown-linux-musl"] = copy.deepcopy(
+            duplicate["targets"]["x86_64-unknown-linux-musl"]
+        )
+        with self.assertRaisesRegex(ValueError, "asset must be"):
+            musl_release_metadata.validate_extension(duplicate)
+
+    def test_rejects_legacy_release_identity_or_digest_mismatch(self) -> None:
+        for key, value in (
+            ("version", "2026.1.4"),
+            ("tag", "2026.1.4"),
+            ("source-commit", "1" * 40),
+            (
+                "release-workflow-identity",
+                "https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/2026.1.4",
+            ),
+        ):
+            with self.subTest(key=key):
+                extension = self.extension()
+                extension[key] = value
+                with self.assertRaises(ValueError):
+                    self.validate_bound(extension)
+
+        extension = self.extension()
+        extension["legacy-release"]["metadata-sha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "bind"):
+            self.validate_bound(extension)
+
+    def test_rejects_runtime_pin_identity_mismatch_and_malformed_digest(self) -> None:
+        extension = self.extension()
+        extension["runtime-musl"]["tag"] = "v9.9.9"
+        with self.assertRaisesRegex(ValueError, "tag/version"):
+            musl_release_metadata.validate_extension(extension)
+
+        extension = self.extension()
+        extension["runtime-musl"]["musl-release-metadata-blake3"] = "BAD"
+        with self.assertRaisesRegex(ValueError, "BLAKE3"):
+            musl_release_metadata.validate_extension(extension)
+
+        extension = self.extension()
+        extension["runtime-musl"]["surprise"] = "value"
+        with self.assertRaisesRegex(ValueError, "unknown keys"):
+            musl_release_metadata.validate_extension(extension)
+
+    def test_render_refuses_unready_runtime_pin(self) -> None:
+        text = self.compatibility_path.read_text(encoding="utf-8")
+        self.compatibility_path.write_text(
+            text.replace("release-ready = true", "release-ready = false")
+            .replace(
+                'musl-release-metadata-asset = "astrid-0.11.0-musl-release.toml"',
+                'musl-release-metadata-asset = ""',
+            )
+            .replace(
+                f'musl-release-metadata-blake3 = "{"f" * 64}"',
+                'musl-release-metadata-blake3 = ""',
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "release-ready gate is false"):
+            self.extension()
+
+    def test_repository_pin_is_staged_and_fail_closed(self) -> None:
+        current = release_metadata.load(
+            Path(__file__).resolve().parent.parent
+            / "release/runtime-musl-compatibility.toml"
+        )
+        runtime = musl_release_metadata.validate_runtime_pin(
+            current, require_ready=False
+        )
+        self.assertFalse(runtime["release-ready"])
+        with self.assertRaisesRegex(ValueError, "release-ready gate is false"):
+            musl_release_metadata.validate_runtime_pin(current, require_ready=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -15,6 +15,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import capsule_release
+import musl_release_metadata
 import release_metadata
 import release_publication
 
@@ -33,7 +34,7 @@ def add_file(archive: tarfile.TarFile, name: str, value: bytes) -> None:
 
 
 class ReleasePublicationTests(unittest.TestCase):
-    def fixture(self, root: Path) -> tuple[Path, Path]:
+    def fixture(self, root: Path, *, musl: bool = False) -> tuple[Path, Path, Path]:
         artifacts = root / "artifacts"
         artifacts.mkdir()
         specs = capsule_release.source_contract()
@@ -43,7 +44,10 @@ class ReleasePublicationTests(unittest.TestCase):
                 for component in spec.components:
                     add_file(archive, component, b"\0asm")
 
-        for target in release_metadata.TARGETS:
+        release_targets = list(release_metadata.TARGETS)
+        if musl:
+            release_targets.extend(musl_release_metadata.MUSL_TARGETS)
+        for target in release_targets:
             (artifacts / f"unicity-aos-{VERSION}-{target}.tar.gz").write_bytes(
                 f"archive:{target}".encode()
             )
@@ -89,6 +93,50 @@ class ReleasePublicationTests(unittest.TestCase):
             .replace("upgrade-self-heal-ready = false", "upgrade-self-heal-ready = true")
         )
 
+        musl_compatibility = (
+            release_publication.ROOT
+            / "release"
+            / "runtime-musl-compatibility.toml"
+        )
+        if musl:
+            musl_compatibility = root / "runtime-musl-compatibility.toml"
+            musl_compatibility.write_text(
+                "\n".join(
+                    [
+                        "schema-version = 1",
+                        "",
+                        "[runtime]",
+                        'repository = "astrid-runtime/astrid"',
+                        "release-ready = true",
+                        'version = "0.11.0"',
+                        'tag = "v0.11.0"',
+                        'release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v0.11.0"',
+                        f'source-commit = "{"d" * 40}"',
+                        'legacy-release-metadata-asset = "astrid-0.11.0-release.toml"',
+                        f'legacy-release-metadata-blake3 = "{"e" * 64}"',
+                        'musl-release-metadata-asset = "astrid-0.11.0-musl-release.toml"',
+                        f'musl-release-metadata-blake3 = "{"f" * 64}"',
+                        "",
+                    ]
+                )
+            )
+            shutil.copyfile(
+                musl_compatibility,
+                artifacts / "runtime-musl-compatibility.toml",
+            )
+            extension = (
+                artifacts / musl_release_metadata.metadata_name(VERSION)
+            )
+            extension.write_text(
+                musl_release_metadata.render_extension(
+                    musl_release_metadata.build_extension(
+                        artifacts=artifacts,
+                        legacy_path=metadata,
+                        compatibility_path=musl_compatibility,
+                    )
+                )
+            )
+
         payloads = [
             *checksummed,
             "BLAKE3SUMS.txt",
@@ -96,63 +144,188 @@ class ReleasePublicationTests(unittest.TestCase):
             "runtime-compatibility.toml",
             metadata.name,
         ]
+        if musl:
+            payloads.extend(
+                [
+                    "runtime-musl-compatibility.toml",
+                    musl_release_metadata.metadata_name(VERSION),
+                ]
+            )
         for name in payloads:
             (artifacts / f"{name}.sigstore.json").write_text("{}\n")
-        return artifacts, compatibility
+        return artifacts, compatibility, musl_compatibility
 
-    def validate(self, artifacts: Path, compatibility: Path) -> list[str]:
+    def validate(
+        self,
+        artifacts: Path,
+        compatibility: Path,
+        musl_compatibility: Path | None = None,
+    ) -> list[str]:
         return release_publication.validate_release_assets(
             artifacts,
             version=VERSION,
             source_commit=SOURCE_COMMIT,
             compatibility_path=compatibility,
+            musl_compatibility_path=musl_compatibility,
         )
 
     def test_accepts_complete_authenticated_inventory(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            artifacts, compatibility = self.fixture(Path(temp))
-            payloads = self.validate(artifacts, compatibility)
+            artifacts, compatibility, musl_compatibility = self.fixture(Path(temp))
+            payloads = self.validate(artifacts, compatibility, musl_compatibility)
             self.assertIn(f"unicity-aos-{VERSION}-release.toml", payloads)
             self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 21)
 
     def test_rejects_missing_asset(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            artifacts, compatibility = self.fixture(Path(temp))
+            artifacts, compatibility, musl_compatibility = self.fixture(Path(temp))
             next(artifacts.glob("*.capsule.sigstore.json")).unlink()
             with self.assertRaisesRegex(ValueError, "asset set differs"):
-                self.validate(artifacts, compatibility)
+                self.validate(artifacts, compatibility, musl_compatibility)
 
     def test_rejects_unexpected_asset(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            artifacts, compatibility = self.fixture(Path(temp))
+            artifacts, compatibility, musl_compatibility = self.fixture(Path(temp))
             (artifacts / "unexpected").write_text("no")
             with self.assertRaisesRegex(ValueError, "asset set differs"):
-                self.validate(artifacts, compatibility)
+                self.validate(artifacts, compatibility, musl_compatibility)
+
+    def test_false_musl_gate_rejects_extension_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            artifacts, compatibility, musl_compatibility = self.fixture(Path(temp))
+            name = f"unicity-aos-{VERSION}-x86_64-unknown-linux-musl.tar.gz"
+            (artifacts / name).write_bytes(b"not enabled")
+            (artifacts / f"{name}.sigstore.json").write_text("{}\n")
+            with self.assertRaisesRegex(ValueError, "unexpected"):
+                self.validate(artifacts, compatibility, musl_compatibility)
 
     def test_rejects_changed_payload(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            artifacts, compatibility = self.fixture(Path(temp))
+            artifacts, compatibility, musl_compatibility = self.fixture(Path(temp))
             next(artifacts.glob("*.tar.gz")).write_bytes(b"changed")
             with self.assertRaisesRegex(ValueError, "SHA-256 mismatch"):
-                self.validate(artifacts, compatibility)
+                self.validate(artifacts, compatibility, musl_compatibility)
 
     def test_rejects_wrong_source_commit(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            artifacts, compatibility = self.fixture(Path(temp))
+            artifacts, compatibility, musl_compatibility = self.fixture(Path(temp))
             with self.assertRaisesRegex(ValueError, "source commit"):
                 release_publication.validate_release_assets(
                     artifacts,
                     version=VERSION,
                     source_commit="b" * 40,
                     compatibility_path=compatibility,
+                    musl_compatibility_path=musl_compatibility,
                 )
 
     def test_rejects_compatibility_drift(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            artifacts, compatibility = self.fixture(Path(temp))
+            artifacts, compatibility, musl_compatibility = self.fixture(Path(temp))
             compatibility.write_text(compatibility.read_text() + "\n# drift\n")
             with self.assertRaisesRegex(ValueError, "tagged source"):
-                self.validate(artifacts, compatibility)
+                self.validate(artifacts, compatibility, musl_compatibility)
+
+    def test_accepts_complete_authenticated_musl_union(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            artifacts, compatibility, musl_compatibility = self.fixture(
+                Path(temp), musl=True
+            )
+            payloads = self.validate(
+                artifacts, compatibility, musl_compatibility
+            )
+            self.assertIn(
+                musl_release_metadata.metadata_name(VERSION), payloads
+            )
+            self.assertEqual(
+                len(
+                    [
+                        name
+                        for name in payloads
+                        if name.endswith("-unknown-linux-musl.tar.gz")
+                    ]
+                ),
+                2,
+            )
+
+    def test_ready_musl_rejects_missing_or_partial_inventory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            artifacts, compatibility, musl_compatibility = self.fixture(
+                Path(temp), musl=True
+            )
+            (
+                artifacts
+                / f"{musl_release_metadata.metadata_name(VERSION)}.sigstore.json"
+            ).unlink()
+            with self.assertRaisesRegex(ValueError, "asset set differs"):
+                self.validate(artifacts, compatibility, musl_compatibility)
+
+        with tempfile.TemporaryDirectory() as temp:
+            artifacts, compatibility, musl_compatibility = self.fixture(
+                Path(temp), musl=True
+            )
+            target = f"unicity-aos-{VERSION}-aarch64-unknown-linux-musl.tar.gz"
+            (artifacts / target).unlink()
+            (artifacts / f"{target}.sigstore.json").unlink()
+            with self.assertRaisesRegex(ValueError, "asset set differs"):
+                self.validate(artifacts, compatibility, musl_compatibility)
+
+    def test_ready_musl_rejects_unexpected_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            artifacts, compatibility, musl_compatibility = self.fixture(
+                Path(temp), musl=True
+            )
+            name = f"unicity-aos-{VERSION}-riscv64-unknown-linux-musl.tar.gz"
+            (artifacts / name).write_bytes(b"unexpected")
+            (artifacts / f"{name}.sigstore.json").write_text("{}\n")
+            with self.assertRaisesRegex(ValueError, "unexpected"):
+                self.validate(artifacts, compatibility, musl_compatibility)
+
+    def test_ready_musl_rejects_partial_checksum_union(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            artifacts, compatibility, musl_compatibility = self.fixture(
+                Path(temp), musl=True
+            )
+            checksum = artifacts / "SHA256SUMS.txt"
+            lines = checksum.read_text().splitlines()
+            checksum.write_text(
+                "\n".join(
+                    line
+                    for line in lines
+                    if "aarch64-unknown-linux-musl" not in line
+                )
+                + "\n"
+            )
+            with self.assertRaisesRegex(ValueError, "exact payload set"):
+                self.validate(artifacts, compatibility, musl_compatibility)
+
+    def test_ready_musl_rejects_tampered_archive_or_extension_binding(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            artifacts, compatibility, musl_compatibility = self.fixture(
+                Path(temp), musl=True
+            )
+            (
+                artifacts
+                / f"unicity-aos-{VERSION}-x86_64-unknown-linux-musl.tar.gz"
+            ).write_bytes(b"tampered")
+            with self.assertRaisesRegex(ValueError, "SHA-256 mismatch"):
+                self.validate(artifacts, compatibility, musl_compatibility)
+
+        with tempfile.TemporaryDirectory() as temp:
+            artifacts, compatibility, musl_compatibility = self.fixture(
+                Path(temp), musl=True
+            )
+            extension = (
+                artifacts / musl_release_metadata.metadata_name(VERSION)
+            )
+            extension.write_text(
+                extension.read_text().replace(
+                    "metadata-sha256 = \"",
+                    f'metadata-sha256 = "{"0" * 64}" # ',
+                    1,
+                )
+            )
+            with self.assertRaisesRegex(ValueError, "bind"):
+                self.validate(artifacts, compatibility, musl_compatibility)
 
 
 if __name__ == "__main__":

--- a/scripts/validate-release-contract.py
+++ b/scripts/validate-release-contract.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import musl_release_metadata
+
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -142,6 +144,10 @@ def main(argv: list[str] | None = None) -> int:
     validate_release_readiness(
         readiness_metadata("release/runtime-compatibility.toml"),
         require_release_ready=args.require_release_ready,
+    )
+    musl_release_metadata.validate_runtime_pin(
+        readiness_metadata("release/runtime-musl-compatibility.toml"),
+        require_ready=False,
     )
 
     product_version = product[("package", "version")]


### PR DESCRIPTION
Closes #62

## Summary

Add a backward-compatible authenticated metadata and installer path for Linux
musl AOS releases. The existing exact-four channel and release documents remain
unchanged. Musl installs authenticate those legacy documents first, then an
exact-two, same-tag immutable extension bound to both the legacy AOS metadata
and the exact compatible Astrid legacy/musl metadata.

This PR is stacked on #59 so its diff contains only the musl metadata/installer
prerequisite. It must not merge before #59; after #59 lands, its base will be
retargeted to `main`.

## Changes

- add a strict exact-two musl release-extension schema without a second mutable
  channel pointer
- bind the extension to exact legacy AOS bytes and exact Astrid metadata names,
  digests, source commit, repository, and release-workflow identity
- detect Linux libc before persistent writes using `getconf`, optional `ldd`,
  and canonical musl loader paths; unknown libc fails closed
- authenticate channel/direct-version musl installs in legacy-then-extension
  order
- add a separate musl runtime compatibility pin with a default
  `release-ready=false` publication gate
- require the authoritative strict ready-pin validator before composing any
  musl archive
- validate and recover either the exact legacy inventory or the exact
  six-target signed inventory, rejecting partial, unexpected, or tampered
  releases
- preserve GNU, macOS, and legacy installer behavior

## Verification

- 6 musl metadata and 12 publication/recovery tests
- direct-version and channel musl installer tests
- libc detection tests including no-`ldd` loader fallback and unknown-libc
  rejection
- false/default, malformed-ready, and valid-ready composer tests
- real GNU and aarch64 Darwin composition regressions
- legacy installer, upgrade/self-heal, release contract, channel publication,
  transaction, nightly, and runtime archive suites
- product/capsule Rust tests, clippy with warnings denied, formatting
- shellcheck, Bash/dash syntax, Python compilation, workflow YAML parsing, and
  `git diff --check`
- three-pass independent cryptographic, backward-compatibility, and recovery
  review

## Release dependency

The checked-in musl pin intentionally cannot publish. A later release-only PR
must pin an Astrid patch release that actually contains the signed musl
extension and flip `release-ready=true`. No release or channel is promoted by
this change.
