### PR TITLE
feat(release): add native Linux musl targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,29 @@ env:
 jobs:
   linux-release-smoke:
     name: Linux release smoke (${{ matrix.target }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - aarch64-unknown-linux-gnu
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            libc: gnu
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            libc: gnu
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            libc: musl
+            architecture: x86_64
+            platform: linux/amd64
+            image: docker.io/library/rust@sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            libc: musl
+            architecture: aarch64
+            platform: linux/arm64
+            image: docker.io/library/rust@sha256:594694ee6b07747b63b5c265be2616b62e814180b66227e2c18c6ee85e4136be
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -36,6 +52,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Build against the Linux release baseline
+        if: matrix.libc == 'gnu'
         env:
           TARGET: ${{ matrix.target }}
           # Keep this digest synchronized with release.yml.
@@ -59,11 +76,62 @@ jobs:
               cargo build --locked --release --target "$TARGET" -p unicity-aos-bootstrap
             '
       - name: Enforce the Linux glibc compatibility ceiling
+        if: matrix.libc == 'gnu'
         env:
           TARGET: ${{ matrix.target }}
         run: |
           python3 scripts/check_glibc.py --max-version 2.34 \
             "target/glibc-2.31/${TARGET}/release/aos"
+      - name: Build in the native Linux musl environment
+        if: matrix.libc == 'musl'
+        env:
+          ARCHITECTURE: ${{ matrix.architecture }}
+          PLATFORM: ${{ matrix.platform }}
+          # Platform manifest from the official Rust 1.95.0 Alpine 3.23 image.
+          RUST_BUILD_IMAGE: ${{ matrix.image }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          SOURCE_SHA=$(git rev-parse --short=12 HEAD)
+          docker run --rm \
+            --platform "$PLATFORM" \
+            --env ARCHITECTURE \
+            --env CARGO_TERM_COLOR=always \
+            --env SOURCE_SHA="$SOURCE_SHA" \
+            --env TARGET \
+            --volume "$PWD:/workspace" \
+            --workdir /workspace \
+            "$RUST_BUILD_IMAGE" \
+            sh -ceu '
+              case "$ARCHITECTURE:$(uname -m)" in
+                x86_64:x86_64|aarch64:aarch64) ;;
+                *) echo "musl build is not running on the native architecture" >&2; exit 1 ;;
+              esac
+              apk add --no-cache binutils build-base git perl pkgconf python3
+              git config --global --add safe.directory /workspace
+              [ "$(git rev-parse --short=12 HEAD)" = "$SOURCE_SHA" ]
+              cargo build \
+                --locked \
+                --release \
+                --target "$TARGET" \
+                --target-dir target/musl \
+                -p unicity-aos-bootstrap
+              python3 scripts/check_static_elf.py --architecture "$ARCHITECTURE" \
+                "target/musl/$TARGET/release/aos"
+            '
+      - name: Exercise the AOS binary in fresh Alpine
+        if: matrix.libc == 'musl'
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          RUST_BUILD_IMAGE: ${{ matrix.image }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          docker run --rm \
+            --platform "$PLATFORM" \
+            --env TARGET \
+            --volume "$PWD:/workspace:ro" \
+            --workdir /workspace \
+            "$RUST_BUILD_IMAGE" \
+            sh -ceu '"target/musl/$TARGET/release/aos" --version'
 
   format:
     name: Format
@@ -90,8 +158,14 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo install b3sum --locked --version "$B3SUM_VERSION"
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v3.1.1'
       - run: sh -n install.sh
+      - run: bash -n scripts/test-clean-home-musl-install.sh
       - run: python3 scripts/test_check_glibc.py
+      - run: python3 scripts/test_check_static_elf.py
+      - run: python3 scripts/test_astrid_musl_release.py
+      - run: python3 scripts/test_musl_workflow_contract.py
       - run: python3 scripts/validate-release-contract.py
       - run: python3 scripts/test_validate_release_contract.py
       - run: python3 scripts/test_release_metadata.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,8 @@ jobs:
       - name: Install pinned BLAKE3 checksum tool
         run: cargo install b3sum --locked --version "$B3SUM_VERSION"
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v3.1.1'
       - name: Verify the pinned runtime command surface
         run: bash scripts/test-pinned-runtime-command-surface.sh
       - name: Refuse a nightly after its canonical base is tagged
@@ -138,7 +140,11 @@ jobs:
       - run: python3 scripts/test_validate_runtime_archive.py
       - run: bash scripts/test-extract-runtime-tool.sh
       - run: python3 scripts/test_check_glibc.py
+      - run: python3 scripts/test_check_static_elf.py
+      - run: python3 scripts/test_astrid_musl_release.py
+      - run: python3 scripts/test_musl_workflow_contract.py
       - run: sh -n install.sh
+      - run: bash -n scripts/test-clean-home-musl-install.sh
 
   build:
     name: Build (${{ matrix.target }})
@@ -150,12 +156,28 @@ jobs:
         include:
           - target: x86_64-apple-darwin
             os: macos-latest
+            libc: native
           - target: aarch64-apple-darwin
             os: macos-latest
+            libc: native
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            libc: gnu
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+            libc: gnu
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            libc: musl
+            architecture: x86_64
+            platform: linux/amd64
+            image: docker.io/library/rust@sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            libc: musl
+            architecture: aarch64
+            platform: linux/arm64
+            image: docker.io/library/rust@sha256:594694ee6b07747b63b5c265be2616b62e814180b66227e2c18c6ee85e4136be
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -172,29 +194,62 @@ jobs:
           toolchain: '1.95.0'
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: ${{ !endsWith(matrix.target, 'linux-gnu') }}
+        if: matrix.libc == 'native'
         with:
           key: aos-release-${{ matrix.target }}
       - name: Install pinned BLAKE3 checksum tool
         run: cargo install b3sum --locked --version "$B3SUM_VERSION"
       - name: Load runtime compatibility pins
+        env:
+          TARGET_LIBC: ${{ matrix.libc }}
         run: |
           python3 - <<'PY' >> "$GITHUB_ENV"
           import tomllib
-          with open("release/runtime-compatibility.toml", "rb") as file:
-              metadata = tomllib.load(file)["runtime"]
+          import os
+          from pathlib import Path
+          import sys
+
+          root = Path.cwd()
+          sys.path.insert(0, str(root / "scripts"))
+          if os.environ["TARGET_LIBC"] == "musl":
+              import musl_release_metadata
+              import release_metadata
+
+              path = root / "release/runtime-musl-compatibility.toml"
+              metadata = musl_release_metadata.validate_runtime_pin(
+                  release_metadata.load(path), require_ready=True
+              )
+              print(
+                  f"RUNTIME_LEGACY_METADATA="
+                  f"{metadata['legacy-release-metadata-asset']}"
+              )
+              print(
+                  f"RUNTIME_LEGACY_METADATA_BLAKE3="
+                  f"{metadata['legacy-release-metadata-blake3']}"
+              )
+              print(
+                  f"RUNTIME_MUSL_METADATA="
+                  f"{metadata['musl-release-metadata-asset']}"
+              )
+              print(
+                  f"RUNTIME_MUSL_METADATA_BLAKE3="
+                  f"{metadata['musl-release-metadata-blake3']}"
+              )
+          else:
+              with (root / "release/runtime-compatibility.toml").open("rb") as file:
+                  metadata = tomllib.load(file)["runtime"]
           print(f"RUNTIME_VERSION={metadata['version']}")
           print(f"RUNTIME_TAG={metadata['tag']}")
           print(f"RUNTIME_REPOSITORY={metadata['repository']}")
           print(f"RUNTIME_IDENTITY={metadata['release-workflow-identity']}")
           PY
       - name: Build product binary
-        if: ${{ !endsWith(matrix.target, 'linux-gnu') }}
+        if: matrix.libc == 'native'
         run: |
           cargo build --locked --release --target "${{ matrix.target }}" -p unicity-aos-bootstrap
           echo "AOS_BINARY=target/${{ matrix.target }}/release/aos" >> "$GITHUB_ENV"
       - name: Build Linux product binary against glibc 2.31
-        if: ${{ endsWith(matrix.target, 'linux-gnu') }}
+        if: matrix.libc == 'gnu'
         env:
           LINUX_BUILD_IMAGE: docker.io/library/rust:1.95.0-bullseye@sha256:646e8ceea789b00c5cfa339816a3ed44940dbf1651dc167b78f3c0aefcae0025
           TARGET: ${{ matrix.target }}
@@ -219,7 +274,45 @@ jobs:
           AOS_BINARY="target/glibc-2.31/${{ matrix.target }}/release/aos"
           python3 scripts/check_glibc.py --max-version 2.34 "$AOS_BINARY"
           echo "AOS_BINARY=$AOS_BINARY" >> "$GITHUB_ENV"
+      - name: Build product binary in the native Linux musl environment
+        if: matrix.libc == 'musl'
+        env:
+          ARCHITECTURE: ${{ matrix.architecture }}
+          PLATFORM: ${{ matrix.platform }}
+          # Platform manifest from the official Rust 1.95.0 Alpine 3.23 image.
+          RUST_BUILD_IMAGE: ${{ matrix.image }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          SOURCE_SHA=$(git rev-parse --short=12 HEAD)
+          docker run --rm \
+            --platform "$PLATFORM" \
+            --env ARCHITECTURE \
+            --env CARGO_TERM_COLOR=always \
+            --env SOURCE_SHA="$SOURCE_SHA" \
+            --env TARGET \
+            --volume "$PWD:/workspace" \
+            --workdir /workspace \
+            "$RUST_BUILD_IMAGE" \
+            sh -ceu '
+              case "$ARCHITECTURE:$(uname -m)" in
+                x86_64:x86_64|aarch64:aarch64) ;;
+                *) echo "musl build is not running on the native architecture" >&2; exit 1 ;;
+              esac
+              apk add --no-cache binutils build-base git perl pkgconf python3
+              git config --global --add safe.directory /workspace
+              [ "$(git rev-parse --short=12 HEAD)" = "$SOURCE_SHA" ]
+              cargo build \
+                --locked \
+                --release \
+                --target "$TARGET" \
+                --target-dir target/musl \
+                -p unicity-aos-bootstrap
+              python3 scripts/check_static_elf.py --architecture "$ARCHITECTURE" \
+                "target/musl/$TARGET/release/aos"
+            '
+          echo "AOS_BINARY=target/musl/${TARGET}/release/aos" >> "$GITHUB_ENV"
       - name: Download pinned runtime release
+        if: matrix.libc != 'musl'
         run: |
           ASSET="astrid-${RUNTIME_VERSION}-${{ matrix.target }}.tar.gz"
           BASE="https://github.com/${RUNTIME_REPOSITORY}/releases/download/${RUNTIME_TAG}"
@@ -232,15 +325,59 @@ jobs:
           echo "RUNTIME_ASSET=$ASSET" >> "$GITHUB_ENV"
           echo "RUNTIME_BLAKE3=$EXPECTED" >> "$GITHUB_ENV"
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v3.1.1'
       - name: Verify runtime release identity
+        if: matrix.libc != 'musl'
         run: |
           cosign verify-blob \
             --bundle "$RUNTIME_ASSET.sigstore.json" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             --certificate-identity "$RUNTIME_IDENTITY" \
             "$RUNTIME_ASSET"
+      - name: Authenticate the pinned Astrid musl release
+        if: matrix.libc == 'musl'
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          BASE="https://github.com/${RUNTIME_REPOSITORY}/releases/download/${RUNTIME_TAG}"
+          for metadata in "$RUNTIME_LEGACY_METADATA" "$RUNTIME_MUSL_METADATA"; do
+            curl --proto '=https' --tlsv1.2 -fsSLO "$BASE/$metadata"
+            curl --proto '=https' --tlsv1.2 -fsSLo "$metadata.sigstore.json" \
+              "$BASE/$metadata.sigstore.json"
+            cosign verify-blob \
+              --bundle "$metadata.sigstore.json" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              --certificate-identity "$RUNTIME_IDENTITY" \
+              --use-signed-timestamps \
+              "$metadata"
+          done
+          test "$(b3sum -- "$RUNTIME_LEGACY_METADATA" | awk '{print $1}')" \
+            = "$RUNTIME_LEGACY_METADATA_BLAKE3"
+          test "$(b3sum -- "$RUNTIME_MUSL_METADATA" | awk '{print $1}')" \
+            = "$RUNTIME_MUSL_METADATA_BLAKE3"
+
+          RUNTIME_ASSET="astrid-${RUNTIME_VERSION}-${TARGET}.tar.gz"
+          curl --proto '=https' --tlsv1.2 -fsSLO "$BASE/$RUNTIME_ASSET"
+          curl --proto '=https' --tlsv1.2 -fsSLo "$RUNTIME_ASSET.sigstore.json" \
+            "$BASE/$RUNTIME_ASSET.sigstore.json"
+          cosign verify-blob \
+            --bundle "$RUNTIME_ASSET.sigstore.json" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity "$RUNTIME_IDENTITY" \
+            --use-signed-timestamps \
+            "$RUNTIME_ASSET"
+          python3 scripts/astrid_musl_release.py \
+            --compatibility release/runtime-musl-compatibility.toml \
+            --legacy "$RUNTIME_LEGACY_METADATA" \
+            --extension "$RUNTIME_MUSL_METADATA" \
+            --target "$TARGET" \
+            --archive "$RUNTIME_ASSET"
+          echo "RUNTIME_ASSET=$RUNTIME_ASSET" >> "$GITHUB_ENV"
+          echo "RUNTIME_BLAKE3=$(b3sum -- "$RUNTIME_ASSET" | awk '{print $1}')" \
+            >> "$GITHUB_ENV"
       - name: Verify Linux runtime glibc compatibility
-        if: ${{ endsWith(matrix.target, 'linux-gnu') }}
+        if: matrix.libc == 'gnu'
         run: |
           RUNTIME_ROOT="astrid-${RUNTIME_VERSION}-${{ matrix.target }}"
           CHECK_ROOT="$RUNNER_TEMP/runtime-glibc-check"
@@ -255,20 +392,66 @@ jobs:
             "$CHECK_ROOT/$RUNTIME_ROOT/astrid-daemon" \
             "$CHECK_ROOT/$RUNTIME_ROOT/astrid-build" \
             "$CHECK_ROOT/$RUNTIME_ROOT/astrid-emit"
+      - name: Validate and exercise every Linux musl binary
+        if: matrix.libc == 'musl'
+        env:
+          ARCHITECTURE: ${{ matrix.architecture }}
+          PLATFORM: ${{ matrix.platform }}
+          RUST_BUILD_IMAGE: ${{ matrix.image }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          RUNTIME_ROOT="astrid-${RUNTIME_VERSION}-${TARGET}"
+          CHECK_ROOT="target/runtime-musl-${TARGET}"
+          python3 scripts/validate-runtime-archive.py \
+            "$RUNTIME_ASSET" \
+            "$RUNTIME_ROOT" \
+            astrid astrid-daemon astrid-build astrid-emit
+          mkdir -p "$CHECK_ROOT"
+          tar -xzf "$RUNTIME_ASSET" -C "$CHECK_ROOT"
+          python3 scripts/check_static_elf.py --architecture "$ARCHITECTURE" \
+            "$AOS_BINARY" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid-daemon" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid-build" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid-emit"
+          docker run --rm \
+            --platform "$PLATFORM" \
+            --env AOS_BINARY \
+            --env RUNTIME_ROOT \
+            --env TARGET \
+            --volume "$PWD:/workspace:ro" \
+            --workdir /workspace \
+            "$RUST_BUILD_IMAGE" \
+            sh -ceu '
+              "$AOS_BINARY" --version
+              for binary in astrid astrid-daemon astrid-build astrid-emit; do
+                "target/runtime-musl-$TARGET/$RUNTIME_ROOT/$binary" --version
+              done
+            '
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: capsule-artifacts
           name: aos-community-capsules
       - name: Compose product bundle
+        env:
+          TARGET_LIBC: ${{ matrix.libc }}
         run: |
           python3 scripts/capsule_release.py --artifacts capsule-artifacts
+          EXTRA=()
+          if [[ "$TARGET_LIBC" == musl ]]; then
+            EXTRA+=(
+              --musl-runtime-compatibility
+              release/runtime-musl-compatibility.toml
+            )
+          fi
           scripts/package-release.sh \
             "${{ matrix.target }}" \
             "$AOS_BINARY" \
             "$RUNTIME_ASSET" \
             "$RUNTIME_BLAKE3" \
             capsule-artifacts \
-            artifacts
+            artifacts \
+            "${EXTRA[@]}"
       - name: Test a clean Community Edition home
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: |
@@ -276,6 +459,28 @@ jobs:
           tar -xzf "artifacts/unicity-aos-${GITHUB_REF_NAME}-${{ matrix.target }}.tar.gz" \
             -C "$RUNNER_TEMP/clean-home-bundle" --strip-components=1
           scripts/test-clean-home-init.sh "$RUNNER_TEMP/clean-home-bundle"
+      - name: Test a clean Alpine Community Edition home
+        if: matrix.libc == 'musl'
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          RUST_BUILD_IMAGE: ${{ matrix.image }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          CLEAN_ROOT="target/clean-home-${TARGET}"
+          rm -rf "$CLEAN_ROOT"
+          mkdir -p "$CLEAN_ROOT"
+          tar -xzf "artifacts/unicity-aos-${GITHUB_REF_NAME}-${TARGET}.tar.gz" \
+            -C "$CLEAN_ROOT" --strip-components=1
+          docker run --rm \
+            --platform "$PLATFORM" \
+            --env CLEAN_ROOT \
+            --volume "$PWD:/workspace:ro" \
+            --workdir /workspace \
+            "$RUST_BUILD_IMAGE" \
+            sh -ceu '
+              apk add --no-cache bash bubblewrap python3 zsh
+              bash scripts/test-clean-home-init.sh "$CLEAN_ROOT"
+            '
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aos-${{ matrix.target }}
@@ -330,6 +535,8 @@ jobs:
           echo "RUNTIME_ASSET=$ASSET" >> "$GITHUB_ENV"
           echo "RUNTIME_TARGET=$TARGET" >> "$GITHUB_ENV"
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v3.1.1'
       - name: Verify runtime builder identity
         run: |
           cosign verify-blob \
@@ -410,6 +617,7 @@ jobs:
           b3sum -- ./*.tar.gz ./*.capsule | sed 's#  \./#  #' > BLAKE3SUMS.txt
           sha256sum -- ./*.tar.gz ./*.capsule | sed 's#  \./#  #' > SHA256SUMS.txt
           cp ../release/runtime-compatibility.toml .
+          cp ../release/runtime-musl-compatibility.toml .
       - name: Generate immutable release metadata
         env:
           SOURCE_COMMIT: ${{ needs.classify.outputs.source-commit }}
@@ -427,7 +635,17 @@ jobs:
             --output "$RELEASE_METADATA"
           python3 scripts/release_metadata.py validate-release \
             --require-ready "$RELEASE_METADATA"
+          MUSL_RELEASE_METADATA="artifacts/unicity-aos-${GITHUB_REF_NAME}-musl-release.toml"
+          python3 scripts/musl_release_metadata.py render \
+            --artifacts artifacts \
+            --legacy-release "$RELEASE_METADATA" \
+            --runtime-compatibility artifacts/runtime-musl-compatibility.toml \
+            --output "$MUSL_RELEASE_METADATA"
+          python3 scripts/musl_release_metadata.py validate \
+            "$MUSL_RELEASE_METADATA" \
+            --legacy-release "$RELEASE_METADATA"
           echo "RELEASE_METADATA=$RELEASE_METADATA" >> "$GITHUB_ENV"
+          echo "MUSL_RELEASE_METADATA=$MUSL_RELEASE_METADATA" >> "$GITHUB_ENV"
       - name: Authenticate the remote tag before candidate publication
         env:
           GH_TOKEN: ${{ github.token }}
@@ -477,6 +695,8 @@ jobs:
           }
           echo "EXISTING_RELEASE=1" >> "$GITHUB_ENV"
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v3.1.1'
       - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         if: env.EXISTING_RELEASE != '1'
         with:
@@ -486,6 +706,7 @@ jobs:
             artifacts/BLAKE3SUMS.txt
             artifacts/SHA256SUMS.txt
             artifacts/runtime-compatibility.toml
+            artifacts/runtime-musl-compatibility.toml
             artifacts/unicity-aos-*-release.toml
       - name: Sign release assets
         if: env.EXISTING_RELEASE != '1'
@@ -493,7 +714,7 @@ jobs:
           COSIGN_YES: 'true'
         run: |
           cd artifacts
-          for asset in ./*.tar.gz ./*.capsule BLAKE3SUMS.txt SHA256SUMS.txt runtime-compatibility.toml unicity-aos-*-release.toml; do
+          for asset in ./*.tar.gz ./*.capsule BLAKE3SUMS.txt SHA256SUMS.txt runtime-compatibility.toml runtime-musl-compatibility.toml unicity-aos-*-release.toml; do
             cosign sign-blob --yes --bundle "${asset}.sigstore.json" "$asset"
           done
       - name: Verify release signatures use the exact tag identity
@@ -501,7 +722,7 @@ jobs:
         run: |
           cd artifacts
           IDENTITY="https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/${GITHUB_REF_NAME}"
-          for asset in ./*.tar.gz ./*.capsule BLAKE3SUMS.txt SHA256SUMS.txt runtime-compatibility.toml unicity-aos-*-release.toml; do
+          for asset in ./*.tar.gz ./*.capsule BLAKE3SUMS.txt SHA256SUMS.txt runtime-compatibility.toml runtime-musl-compatibility.toml unicity-aos-*-release.toml; do
             cosign verify-blob \
               --bundle "${asset}.sigstore.json" \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
@@ -514,7 +735,7 @@ jobs:
           cat > release-notes.md <<EOF
           Unicity AOS Community Edition ${GITHUB_REF_NAME}.
 
-          This product release bundles Astrid Runtime ${RUNTIME_TAG}. The exact runtime release identity, WIT commit, and compatibility pins are published in \`runtime-compatibility.toml\` and in every archive's \`release-manifest.json\`.
+          This product release bundles Astrid Runtime ${RUNTIME_TAG}. The exact runtime release identity, WIT commit, and compatibility pins are published in \`runtime-compatibility.toml\`, \`runtime-musl-compatibility.toml\`, and every archive's \`release-manifest.json\`.
 
           The release also contains the 19 signed, installable capsule artifacts selected by Community Edition. Published \`astrid-capsule-*\` identities remain unchanged.
 
@@ -591,6 +812,8 @@ jobs:
             echo "RECOVER_DRAFT=1"
             echo "CANDIDATE=$EXISTING_ASSETS"
           } >> "$GITHUB_ENV"
+      - name: Test signed direct install in a clean Alpine home
+        run: bash scripts/test-clean-home-musl-install.sh "$CANDIDATE"
       - name: Create draft release with write-once assets
         if: env.RECOVER_DRAFT != '1'
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
@@ -606,6 +829,7 @@ jobs:
             artifacts/BLAKE3SUMS.txt
             artifacts/SHA256SUMS.txt
             artifacts/runtime-compatibility.toml
+            artifacts/runtime-musl-compatibility.toml
             artifacts/unicity-aos-*-release.toml
             artifacts/*.sigstore.json
           body_path: release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -558,13 +558,17 @@ jobs:
           name: aos-community-capsules
           path: artifacts/*.capsule
 
-  github-release:
-    name: Publish signed release
+  release-candidate:
+    name: Prepare signed release candidate
     needs: [classify, build, capsules]
     runs-on: ubuntu-latest
     environment: release
+    outputs:
+      artifact-name: ${{ steps.candidate.outputs.artifact-name }}
+      existing-release: ${{ steps.candidate.outputs.existing-release }}
+      release-id: ${{ steps.candidate.outputs.release-id }}
     permissions:
-      contents: write
+      contents: read
       id-token: write
       attestations: write
     steps:
@@ -590,14 +594,6 @@ jobs:
           toolchain: '1.95.0'
       - name: Install pinned BLAKE3 checksum tool
         run: cargo install b3sum --locked --version "$B3SUM_VERSION"
-      - name: Load runtime compatibility pins
-        run: |
-          python3 - <<'PY' >> "$GITHUB_ENV"
-          import tomllib
-          with open("release/runtime-compatibility.toml", "rb") as file:
-              metadata = tomllib.load(file)["runtime"]
-          print(f"RUNTIME_TAG={metadata['tag']}")
-          PY
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
@@ -730,23 +726,6 @@ jobs:
               --use-signed-timestamps \
               "$asset"
           done
-      - name: Write release notes
-        run: |
-          cat > release-notes.md <<EOF
-          Unicity AOS Community Edition ${GITHUB_REF_NAME}.
-
-          This product release bundles Astrid Runtime ${RUNTIME_TAG}. The exact runtime release identity, WIT commit, and compatibility pins are published in \`runtime-compatibility.toml\`, \`runtime-musl-compatibility.toml\`, and every archive's \`release-manifest.json\`.
-
-          The release also contains the 19 signed, installable capsule artifacts selected by Community Edition. Published \`astrid-capsule-*\` identities remain unchanged.
-
-          Install this exact release:
-
-          \`\`\`sh
-          curl --proto '=https' --tlsv1.2 -fsSL https://aos.unicity.ai/install.sh | sh -s -- --version ${GITHUB_REF_NAME}
-          \`\`\`
-
-          Moving channel installs change only after a separate protected promotion.
-          EOF
       - name: Refuse conflicting releases or authenticate a complete draft
         env:
           GH_TOKEN: ${{ github.token }}
@@ -812,8 +791,227 @@ jobs:
             echo "RECOVER_DRAFT=1"
             echo "CANDIDATE=$EXISTING_ASSETS"
           } >> "$GITHUB_ENV"
-      - name: Test signed direct install in a clean Alpine home
-        run: bash scripts/test-clean-home-musl-install.sh "$CANDIDATE"
+      - name: Revalidate the complete signed candidate
+        env:
+          EXPECTED_SOURCE: ${{ needs.classify.outputs.source-commit }}
+        run: |
+          PAYLOADS="$RUNNER_TEMP/candidate-payloads.txt"
+          python3 scripts/release_publication.py \
+            --artifacts "$CANDIDATE" \
+            --version "$GITHUB_REF_NAME" \
+            --source-commit "$EXPECTED_SOURCE" > "$PAYLOADS"
+          (
+            cd "$CANDIDATE"
+            b3sum --check BLAKE3SUMS.txt
+            sha256sum --check SHA256SUMS.txt
+          )
+          IDENTITY="https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/${GITHUB_REF_NAME}"
+          while IFS= read -r asset; do
+            cosign verify-blob \
+              --bundle "$CANDIDATE/${asset}.sigstore.json" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              --certificate-identity "$IDENTITY" \
+              --use-signed-timestamps \
+              "$CANDIDATE/$asset"
+          done < "$PAYLOADS"
+      - name: Export authenticated candidate state
+        id: candidate
+        run: |
+          ARTIFACT_NAME="signed-release-candidate-${GITHUB_RUN_ATTEMPT}"
+          mkdir signed-candidate
+          cp "$CANDIDATE"/* signed-candidate/
+          echo "artifact-name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          echo "existing-release=$RECOVER_DRAFT" >> "$GITHUB_OUTPUT"
+          if [[ "$RECOVER_DRAFT" == 1 ]]; then
+            [[ -n "$SELECTED_RELEASE_ID" ]]
+            echo "release-id=$SELECTED_RELEASE_ID" >> "$GITHUB_OUTPUT"
+          else
+            echo "release-id=" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload immutable signed candidate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.candidate.outputs.artifact-name }}
+          path: signed-candidate/*
+          if-no-files-found: error
+          compression-level: 0
+
+  signed-musl-install:
+    name: Signed musl install (${{ matrix.target }})
+    needs: [classify, release-candidate]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            platform: linux/amd64
+            expected_uname: x86_64
+            cosign_asset: cosign-linux-amd64
+            image: docker.io/library/rust@sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            platform: linux/arm64
+            expected_uname: aarch64
+            cosign_asset: cosign-linux-arm64
+            image: docker.io/library/rust@sha256:594694ee6b07747b63b5c265be2616b62e814180b66227e2c18c6ee85e4136be
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+      - name: Stage deterministic nightly version
+        if: needs.classify.outputs.nightly == 'true'
+        run: python3 scripts/nightly_version.py stage --version "$GITHUB_REF_NAME"
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: '1.95.0'
+      - name: Install pinned BLAKE3 checksum tool
+        run: cargo install b3sum --locked --version "$B3SUM_VERSION"
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v3.1.1'
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.release-candidate.outputs.artifact-name }}
+          path: candidate
+      - name: Authenticate the exact signed candidate
+        env:
+          EXPECTED_SOURCE: ${{ needs.classify.outputs.source-commit }}
+        run: |
+          PAYLOADS="$RUNNER_TEMP/candidate-payloads.txt"
+          python3 scripts/release_publication.py \
+            --artifacts candidate \
+            --version "$GITHUB_REF_NAME" \
+            --source-commit "$EXPECTED_SOURCE" > "$PAYLOADS"
+          (
+            cd candidate
+            b3sum --check BLAKE3SUMS.txt
+            sha256sum --check SHA256SUMS.txt
+          )
+          IDENTITY="https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/${GITHUB_REF_NAME}"
+          while IFS= read -r asset; do
+            cosign verify-blob \
+              --bundle "candidate/${asset}.sigstore.json" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              --certificate-identity "$IDENTITY" \
+              --use-signed-timestamps \
+              "candidate/$asset"
+          done < "$PAYLOADS"
+      - name: Exercise the signed installer on the native architecture
+        env:
+          COSIGN_ASSET: ${{ matrix.cosign_asset }}
+          EXPECTED_UNAME: ${{ matrix.expected_uname }}
+          IMAGE: ${{ matrix.image }}
+          PLATFORM: ${{ matrix.platform }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          bash scripts/test-clean-home-musl-install.sh \
+            candidate \
+            "$TARGET" \
+            "$PLATFORM" \
+            "$IMAGE" \
+            "$EXPECTED_UNAME" \
+            "$COSIGN_ASSET"
+
+  github-release:
+    name: Publish signed release
+    needs: [classify, release-candidate, signed-musl-install]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Require repository immutable releases
+        env:
+          GH_TOKEN: ${{ secrets.AOS_RELEASE_ADMIN_TOKEN }}
+        run: |
+          [[ -n "$GH_TOKEN" ]]
+          gh api "repos/$GITHUB_REPOSITORY/immutable-releases" \
+            --jq 'select(.enabled == true) | true' | grep -Fx true
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+      - name: Stage deterministic nightly version
+        if: needs.classify.outputs.nightly == 'true'
+        run: python3 scripts/nightly_version.py stage --version "$GITHUB_REF_NAME"
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: '1.95.0'
+      - name: Install pinned BLAKE3 checksum tool
+        run: cargo install b3sum --locked --version "$B3SUM_VERSION"
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v3.1.1'
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.release-candidate.outputs.artifact-name }}
+          path: candidate
+      - name: Load runtime compatibility pins
+        run: |
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import tomllib
+          with open("release/runtime-compatibility.toml", "rb") as file:
+              metadata = tomllib.load(file)["runtime"]
+          print(f"RUNTIME_TAG={metadata['tag']}")
+          PY
+      - name: Write release notes
+        run: |
+          cat > release-notes.md <<EOF
+          Unicity AOS Community Edition ${GITHUB_REF_NAME}.
+
+          This product release bundles Astrid Runtime ${RUNTIME_TAG}. The exact runtime release identity, WIT commit, and compatibility pins are published in \`runtime-compatibility.toml\`, \`runtime-musl-compatibility.toml\`, and every archive's \`release-manifest.json\`.
+
+          The release also contains the 19 signed, installable capsule artifacts selected by Community Edition. Published \`astrid-capsule-*\` identities remain unchanged.
+
+          Install this exact release:
+
+          \`\`\`sh
+          curl --proto '=https' --tlsv1.2 -fsSL https://aos.unicity.ai/install.sh | sh -s -- --version ${GITHUB_REF_NAME}
+          \`\`\`
+
+          Moving channel installs change only after a separate protected promotion.
+          EOF
+      - name: Refuse drift and select the publication draft
+        env:
+          EXPECTED_EXISTING: ${{ needs.release-candidate.outputs.existing-release }}
+          EXPECTED_PRERELEASE: ${{ needs.classify.outputs.nightly }}
+          EXPECTED_RELEASE_ID: ${{ needs.release-candidate.outputs.release-id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RELEASES="$RUNNER_TEMP/releases-before-create.json"
+          MATCHING_RELEASE="$RUNNER_TEMP/matching-release-before-create.json"
+          gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            --paginate --slurp > "$RELEASES"
+          jq --arg tag "$GITHUB_REF_NAME" \
+            '[.[][] | select(.tag_name == $tag)]' "$RELEASES" > "$MATCHING_RELEASE"
+          MATCH_COUNT=$(jq -er length "$MATCHING_RELEASE")
+          [[ "$MATCH_COUNT" -le 1 ]]
+          if [[ "$EXPECTED_EXISTING" == 1 ]]; then
+            jq -e --argjson prerelease "$EXPECTED_PRERELEASE" \
+              'length == 1 and .[0].draft == true and .[0].prerelease == $prerelease and .[0].published_at == null' \
+              "$MATCHING_RELEASE" >/dev/null
+            RELEASE_ID=$(jq -er '.[0].id' "$MATCHING_RELEASE")
+            [[ "$RELEASE_ID" == "$EXPECTED_RELEASE_ID" ]]
+            {
+              echo "RECOVER_DRAFT=1"
+              echo "SELECTED_RELEASE_ID=$RELEASE_ID"
+            } >> "$GITHUB_ENV"
+          else
+            [[ "$EXPECTED_EXISTING" == 0 ]]
+            [[ "$MATCH_COUNT" == 0 ]]
+            echo "RECOVER_DRAFT=0" >> "$GITHUB_ENV"
+          fi
       - name: Create draft release with write-once assets
         if: env.RECOVER_DRAFT != '1'
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
@@ -824,20 +1022,20 @@ jobs:
           overwrite_files: false
           fail_on_unmatched_files: true
           files: |
-            artifacts/*.tar.gz
-            artifacts/*.capsule
-            artifacts/BLAKE3SUMS.txt
-            artifacts/SHA256SUMS.txt
-            artifacts/runtime-compatibility.toml
-            artifacts/runtime-musl-compatibility.toml
-            artifacts/unicity-aos-*-release.toml
-            artifacts/*.sigstore.json
+            candidate/*.tar.gz
+            candidate/*.capsule
+            candidate/BLAKE3SUMS.txt
+            candidate/SHA256SUMS.txt
+            candidate/runtime-compatibility.toml
+            candidate/runtime-musl-compatibility.toml
+            candidate/unicity-aos-*-release.toml
+            candidate/*.sigstore.json
           body_path: release-notes.md
       - name: Bind newly created draft identity
         if: env.RECOVER_DRAFT != '1'
         env:
-          GH_TOKEN: ${{ github.token }}
           EXPECTED_PRERELEASE: ${{ needs.classify.outputs.nightly }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           RELEASES="$RUNNER_TEMP/releases-after-create.json"
           gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
@@ -848,9 +1046,9 @@ jobs:
           echo "SELECTED_RELEASE_ID=$RELEASE_ID" >> "$GITHUB_ENV"
       - name: Reauthenticate and publish the exact immutable release
         env:
-          GH_TOKEN: ${{ github.token }}
           EXPECTED_PRERELEASE: ${{ needs.classify.outputs.nightly }}
           EXPECTED_SOURCE: ${{ needs.classify.outputs.source-commit }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           EXPECTED_LATEST=true
           if [[ "$EXPECTED_PRERELEASE" == true ]]; then
@@ -912,8 +1110,8 @@ jobs:
           )
           IDENTITY="https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/${GITHUB_REF_NAME}"
           while IFS= read -r asset; do
-            cmp "$CANDIDATE/$asset" "$FINAL/$asset"
-            cmp "$CANDIDATE/${asset}.sigstore.json" "$FINAL/${asset}.sigstore.json"
+            cmp "candidate/$asset" "$FINAL/$asset"
+            cmp "candidate/${asset}.sigstore.json" "$FINAL/${asset}.sigstore.json"
             cosign verify-blob \
               --bundle "$FINAL/${asset}.sigstore.json" \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@
   authenticated legacy release, and pins the exact Astrid musl metadata.
   Installers detect libc without requiring `ldd` and fail closed when the Linux
   libc cannot be identified. Closes #62.
+- Native x86_64 and ARM64 Linux musl build and release lanes that verify the
+  AOS binary and all bundled Astrid binaries are static, architecture-correct,
+  free of interpreters, dynamic dependencies, and every `GLIBC_*` requirement,
+  then exercise the composed distro in clean Alpine. The checked false musl
+  compatibility pin continues to block publication until separate release
+  work names a published Astrid musl release. Closes #63.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ be true before a tag can publish. The latter is approved only after the exact
 candidate preserves a frozen standalone-home clone and boots with freshly
 generated runtime coordination state.
 
+Linux releases cover both GNU and fully static musl archives on native x86_64
+and ARM64 builders. Musl publication has its own exact Astrid compatibility
+pin, and remains fail-closed until that pin names authenticated legacy and musl
+runtime metadata from one immutable Astrid release.
+
 ## Command boundary
 
 AOS owns its product roots, including `init`, `status`, `migrate`, `update`,

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -61,6 +61,15 @@ digests. Its false gate on `main` is intentional until the corresponding Astrid
 release exists; changing the runtime pin and product version remains separate
 release work.
 
+Both musl targets build natively in the platform-specific official Rust
+1.95.0 Alpine 3.23 image: `ubuntu-latest` hosts x86_64 and
+`ubuntu-24.04-arm` hosts ARM64. The workflow does not install QEMU. It rejects
+the wrong ELF machine, an interpreter, a `NEEDED` entry, or any `GLIBC_*`
+symbol version (including `GLIBC_PRIVATE`) in the AOS binary or any of the four
+bundled Astrid binaries. All five binaries execute in a fresh Alpine container,
+and the composed archive initializes and stops an exact clean Community
+Edition home before publication can proceed.
+
 The channel pointer is a strict TOML document with a channel name, monotonically
 increasing generation, publication and expiry times, the immutable release
 metadata digest, and the same four target records. Its exact accepted identity

--- a/scripts/astrid_musl_release.py
+++ b/scripts/astrid_musl_release.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Validate a pinned Astrid musl release and its selected archive."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import musl_release_metadata
+import release_metadata
+
+
+PRODUCT = "astrid-runtime"
+REPOSITORY = "astrid-runtime/astrid"
+CONTRACTS_REPOSITORY = "astrid-runtime/wit"
+LEGACY_TARGETS = (
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+)
+TARGET_KEYS = {
+    "triple",
+    "asset",
+    "size",
+    "blake3",
+    "sha256",
+    "sigstore-bundle",
+}
+LEGACY_ROOT_KEYS = {
+    "schema-version",
+    "kind",
+    "product",
+    "repository",
+    "version",
+    "tag",
+    "source-commit",
+    "release-workflow-identity",
+    "contracts",
+    "targets",
+}
+MUSL_ROOT_KEYS = {
+    "schema-version",
+    "kind",
+    "product",
+    "repository",
+    "version",
+    "tag",
+    "source-commit",
+    "release-workflow-identity",
+    "legacy-release",
+    "targets",
+}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def exact_keys(value: Any, expected: set[str], context: str) -> dict[str, Any]:
+    require(isinstance(value, dict), f"{context} must be a TOML table")
+    actual = set(value)
+    require(
+        actual == expected,
+        f"{context} keys differ; missing={sorted(expected - actual)}, "
+        f"unknown={sorted(actual - expected)}",
+    )
+    return value
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as source:
+            value = tomllib.load(source)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ValueError(f"could not parse {path}: {error}") from error
+    require(isinstance(value, dict), f"{path} must contain a TOML table")
+    return value
+
+
+def blake3_file(path: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["b3sum", "--", str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise ValueError(f"could not compute BLAKE3 for {path}: {error}") from error
+    digest = result.stdout.split(maxsplit=1)[0] if result.stdout else ""
+    require(
+        release_metadata.HEX_64.fullmatch(digest) is not None,
+        f"b3sum returned a malformed digest for {path.name}",
+    )
+    return digest
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def validate_targets(
+    value: Any,
+    *,
+    version: str,
+    expected_targets: tuple[str, ...],
+    context: str,
+) -> dict[str, dict[str, Any]]:
+    require(isinstance(value, list), f"{context} must be an array of tables")
+    require(
+        len(value) == len(expected_targets),
+        f"{context} must contain exactly {len(expected_targets)} entries",
+    )
+    targets: dict[str, dict[str, Any]] = {}
+    for raw in value:
+        entry = exact_keys(raw, TARGET_KEYS, f"{context} entry")
+        triple = entry["triple"]
+        require(
+            isinstance(triple, str)
+            and triple in expected_targets
+            and triple not in targets,
+            f"{context} target set is invalid",
+        )
+        asset = f"astrid-{version}-{triple}.tar.gz"
+        require(entry["asset"] == asset, f"{context} asset is invalid for {triple}")
+        require(
+            entry["sigstore-bundle"] == f"{asset}.sigstore.json",
+            f"{context} Sigstore bundle is invalid for {triple}",
+        )
+        require(
+            type(entry["size"]) is int and entry["size"] > 0,
+            f"{context} size is invalid for {triple}",
+        )
+        for algorithm in ("sha256", "blake3"):
+            require(
+                isinstance(entry[algorithm], str)
+                and release_metadata.HEX_64.fullmatch(entry[algorithm]) is not None,
+                f"{context} {algorithm} is invalid for {triple}",
+            )
+        targets[triple] = entry
+    require(
+        set(targets) == set(expected_targets),
+        f"{context} target set is incomplete",
+    )
+    return targets
+
+
+def validate_identity(
+    value: dict[str, Any],
+    *,
+    version: str,
+    source_commit: str,
+    workflow_identity: str,
+    context: str,
+) -> None:
+    require(value["product"] == PRODUCT, f"{context} product is invalid")
+    require(value["repository"] == REPOSITORY, f"{context} repository is invalid")
+    require(value["version"] == version, f"{context} version differs from the pin")
+    require(value["tag"] == f"v{version}", f"{context} tag differs from the pin")
+    require(
+        value["source-commit"] == source_commit,
+        f"{context} source commit differs from the pin",
+    )
+    require(
+        value["release-workflow-identity"] == workflow_identity,
+        f"{context} workflow identity differs from the pin",
+    )
+
+
+def validate_release(
+    *,
+    compatibility_path: Path,
+    legacy_path: Path,
+    extension_path: Path,
+    target: str,
+    archive_path: Path,
+) -> dict[str, Any]:
+    pin = musl_release_metadata.validate_runtime_pin(
+        release_metadata.load(compatibility_path), require_ready=True
+    )
+    require(target in musl_release_metadata.MUSL_TARGETS, "unsupported Astrid musl target")
+    require(
+        legacy_path.name == pin["legacy-release-metadata-asset"],
+        "Astrid legacy metadata filename differs from the pin",
+    )
+    require(
+        extension_path.name == pin["musl-release-metadata-asset"],
+        "Astrid musl metadata filename differs from the pin",
+    )
+    require(
+        blake3_file(legacy_path) == pin["legacy-release-metadata-blake3"],
+        "Astrid legacy metadata BLAKE3 differs from the pin",
+    )
+    require(
+        blake3_file(extension_path) == pin["musl-release-metadata-blake3"],
+        "Astrid musl metadata BLAKE3 differs from the pin",
+    )
+
+    legacy = exact_keys(load(legacy_path), LEGACY_ROOT_KEYS, "Astrid legacy metadata")
+    require(
+        type(legacy["schema-version"]) is int and legacy["schema-version"] == 1,
+        "Astrid legacy metadata schema-version must be integer 1",
+    )
+    require(legacy["kind"] == "astrid-release", "Astrid legacy metadata kind is invalid")
+    validate_identity(
+        legacy,
+        version=pin["version"],
+        source_commit=pin["source-commit"],
+        workflow_identity=pin["release-workflow-identity"],
+        context="Astrid legacy metadata",
+    )
+    contracts = exact_keys(
+        legacy["contracts"], {"repository", "commit"}, "Astrid legacy metadata contracts"
+    )
+    require(
+        contracts["repository"] == CONTRACTS_REPOSITORY,
+        "Astrid legacy metadata contracts repository is invalid",
+    )
+    require(
+        isinstance(contracts["commit"], str)
+        and release_metadata.COMMIT.fullmatch(contracts["commit"]) is not None,
+        "Astrid legacy metadata contracts commit is invalid",
+    )
+    validate_targets(
+        legacy["targets"],
+        version=pin["version"],
+        expected_targets=LEGACY_TARGETS,
+        context="Astrid legacy metadata targets",
+    )
+
+    extension = exact_keys(
+        load(extension_path), MUSL_ROOT_KEYS, "Astrid musl metadata"
+    )
+    require(
+        type(extension["schema-version"]) is int
+        and extension["schema-version"] == 1,
+        "Astrid musl metadata schema-version must be integer 1",
+    )
+    require(
+        extension["kind"] == "astrid-release-musl-extension",
+        "Astrid musl metadata kind is invalid",
+    )
+    validate_identity(
+        extension,
+        version=pin["version"],
+        source_commit=pin["source-commit"],
+        workflow_identity=pin["release-workflow-identity"],
+        context="Astrid musl metadata",
+    )
+    for key in (
+        "product",
+        "repository",
+        "version",
+        "tag",
+        "source-commit",
+        "release-workflow-identity",
+    ):
+        require(
+            extension[key] == legacy[key],
+            f"Astrid musl metadata {key} differs from the legacy metadata",
+        )
+    legacy_link = exact_keys(
+        extension["legacy-release"],
+        {"metadata-asset", "metadata-blake3"},
+        "Astrid musl metadata legacy-release",
+    )
+    require(
+        legacy_link["metadata-asset"] == legacy_path.name,
+        "Astrid musl metadata names a different legacy metadata asset",
+    )
+    require(
+        legacy_link["metadata-blake3"] == pin["legacy-release-metadata-blake3"],
+        "Astrid musl metadata does not bind the pinned legacy metadata",
+    )
+    targets = validate_targets(
+        extension["targets"],
+        version=pin["version"],
+        expected_targets=musl_release_metadata.MUSL_TARGETS,
+        context="Astrid musl metadata targets",
+    )
+    selected = targets[target]
+    require(
+        archive_path.is_file()
+        and not archive_path.is_symlink()
+        and archive_path.name == selected["asset"],
+        "Astrid musl archive is missing or has a non-canonical name",
+    )
+    require(
+        archive_path.stat().st_size == selected["size"],
+        "Astrid musl archive size differs from authenticated metadata",
+    )
+    require(
+        sha256_file(archive_path) == selected["sha256"],
+        "Astrid musl archive SHA-256 differs from authenticated metadata",
+    )
+    require(
+        blake3_file(archive_path) == selected["blake3"],
+        "Astrid musl archive BLAKE3 differs from authenticated metadata",
+    )
+    return selected
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    root.add_argument("--compatibility", type=Path, required=True)
+    root.add_argument("--legacy", type=Path, required=True)
+    root.add_argument("--extension", type=Path, required=True)
+    root.add_argument("--target", required=True)
+    root.add_argument("--archive", type=Path, required=True)
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    validate_release(
+        compatibility_path=args.compatibility,
+        legacy_path=args.legacy,
+        extension_path=args.extension,
+        target=args.target,
+        archive_path=args.archive,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (KeyError, OSError, ValueError) as error:
+        print(f"Astrid musl release: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/check_static_elf.py
+++ b/scripts/check_static_elf.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Validate statically linked ELF release binaries for the expected machine."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+
+
+MACHINES = {
+    "x86_64": "Advanced Micro Devices X86-64",
+    "aarch64": "AArch64",
+}
+GLIBC_SYMBOL_VERSION = re.compile(r"\bGLIBC_[A-Za-z0-9_.]+")
+
+
+def validate_readelf(
+    architecture: str,
+    file_header: str,
+    program_headers: str,
+    dynamic_section: str,
+    version_info: str,
+) -> None:
+    expected = MACHINES.get(architecture)
+    if expected is None:
+        raise ValueError(f"unsupported ELF architecture {architecture!r}")
+    machine = next(
+        (
+            line.split(":", 1)[1].strip()
+            for line in file_header.splitlines()
+            if line.lstrip().startswith("Machine:")
+        ),
+        None,
+    )
+    if machine != expected:
+        raise ValueError(
+            f"ELF machine is {machine or 'missing'}, expected {expected}"
+        )
+    if any(line.split()[:1] == ["INTERP"] for line in program_headers.splitlines()):
+        raise ValueError("ELF has a program interpreter and is not static")
+    if "(NEEDED)" in dynamic_section:
+        raise ValueError("ELF has dynamic shared-library dependencies")
+    if GLIBC_SYMBOL_VERSION.search(version_info):
+        raise ValueError("ELF contains a glibc symbol-version requirement")
+
+
+def readelf(path: pathlib.Path, *arguments: str) -> str:
+    try:
+        result = subprocess.run(
+            ["readelf", *arguments, "--wide", "--", str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise ValueError("readelf is required to validate static ELF binaries") from error
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() if error.stderr else "unknown readelf error"
+        raise ValueError(f"could not inspect {path}: {stderr}") from error
+    return result.stdout
+
+
+def check_binary(path: pathlib.Path, architecture: str) -> None:
+    if not path.is_file() or path.is_symlink():
+        raise ValueError(f"binary is missing or not a regular file: {path}")
+    validate_readelf(
+        architecture,
+        readelf(path, "--file-header"),
+        readelf(path, "--program-headers"),
+        readelf(path, "--dynamic"),
+        readelf(path, "--version-info"),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--architecture", choices=sorted(MACHINES), required=True)
+    parser.add_argument("binary", nargs="+", type=pathlib.Path)
+    args = parser.parse_args()
+
+    try:
+        for binary in args.binary:
+            check_binary(binary, args.architecture)
+    except ValueError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-clean-home-musl-install.sh
+++ b/scripts/test-clean-home-musl-install.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <signed-release-artifacts>" >&2
+  exit 2
+fi
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+artifacts=$(cd "$1" && pwd -P)
+version=$(python3 - "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" <<'PY'
+import pathlib
+import sys
+import tomllib
+
+with pathlib.Path(sys.argv[1]).open("rb") as source:
+    print(tomllib.load(source)["package"]["version"])
+PY
+)
+target=x86_64-unknown-linux-musl
+legacy="unicity-aos-${version}-release.toml"
+extension="unicity-aos-${version}-musl-release.toml"
+archive="unicity-aos-${version}-${target}.tar.gz"
+cosign=$(command -v cosign)
+expected_cosign_sha256=ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc
+actual_cosign_sha256=$(sha256sum -- "$cosign" | awk '{print $1}')
+[[ "$actual_cosign_sha256" == "$expected_cosign_sha256" ]] || {
+  echo "release smoke requires the installer's pinned cosign v3.1.1 binary" >&2
+  exit 1
+}
+
+PYTHONPATH="$repo_root/scripts" python3 - "$repo_root" <<'PY'
+import pathlib
+import sys
+
+import musl_release_metadata
+import release_metadata
+
+root = pathlib.Path(sys.argv[1])
+musl_release_metadata.validate_runtime_pin(
+    release_metadata.load(root / "release/runtime-musl-compatibility.toml"),
+    require_ready=True,
+)
+PY
+
+for required in \
+  "$legacy" \
+  "$legacy.sigstore.json" \
+  "$extension" \
+  "$extension.sigstore.json" \
+  "$archive" \
+  "$archive.sigstore.json"; do
+  [[ -f "$artifacts/$required" && ! -L "$artifacts/$required" ]] || {
+    echo "signed musl installer smoke is missing $required" >&2
+    exit 1
+  }
+done
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+mkdir -p \
+  "$work/good" \
+  "$work/bad-legacy" \
+  "$work/bad-extension" \
+  "$work/fake-bin"
+for fixture in good bad-legacy bad-extension; do
+  cp \
+    "$artifacts/$legacy" \
+    "$artifacts/$legacy.sigstore.json" \
+    "$artifacts/$extension" \
+    "$artifacts/$extension.sigstore.json" \
+    "$artifacts/$archive" \
+    "$artifacts/$archive.sigstore.json" \
+    "$work/$fixture/"
+  cp "$cosign" "$work/$fixture/cosign-linux-amd64"
+done
+printf '\n# signature-invalidating tamper\n' >> "$work/bad-legacy/$legacy"
+printf '\n# signature-invalidating tamper\n' >> "$work/bad-extension/$extension"
+
+cat > "$work/fake-bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+output=
+url=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output=$2; shift ;;
+    http*) url=$1 ;;
+  esac
+  shift
+done
+[ -n "$output" ] && [ -n "$url" ]
+asset=${url##*/}
+printf '%s\n' "$asset" >> "$AOS_INSTALL_TRACE"
+[ -f "$AOS_INSTALL_FIXTURE/$asset" ]
+cp "$AOS_INSTALL_FIXTURE/$asset" "$output"
+EOF
+chmod 755 "$work/fake-bin/curl"
+
+image=docker.io/library/rust@sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15
+docker run --rm \
+  --platform linux/amd64 \
+  --env AOS_HOME=/work/good-home/.aos \
+  --env AOS_INSTALL_FIXTURE=/work/good \
+  --env AOS_INSTALL_TRACE=/work/good-trace \
+  --env HOME=/work/good-home \
+  --env PATH=/work/fake-bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  --volume "$repo_root:/workspace:ro" \
+  --volume "$work:/work" \
+  --workdir /workspace \
+  "$image" \
+  sh -ceu '
+    test "$(uname -m)" = x86_64
+    apk add --no-cache bash bubblewrap python3 zsh
+    sh install.sh --yes --no-migrate-prompt --version "'"$version"'"
+    bash scripts/test-clean-home-init.sh \
+      "/work/good-home/.aos/releases/'"$version"'"
+  '
+
+cat > "$work/expected-good-trace" <<EOF
+cosign-linux-amd64
+$legacy
+$legacy.sigstore.json
+$extension
+$extension.sigstore.json
+$archive
+$archive.sigstore.json
+EOF
+cmp "$work/expected-good-trace" "$work/good-trace"
+
+run_negative_install() {
+  local fixture=$1
+  if docker run --rm \
+    --platform linux/amd64 \
+    --env "AOS_HOME=/work/${fixture}-home/.aos" \
+    --env "AOS_INSTALL_FIXTURE=/work/$fixture" \
+    --env "AOS_INSTALL_TRACE=/work/${fixture}-trace" \
+    --env "HOME=/work/${fixture}-home" \
+    --env PATH=/work/fake-bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    --volume "$repo_root:/workspace:ro" \
+    --volume "$work:/work" \
+    --workdir /workspace \
+    "$image" \
+    sh -ceu '
+      test "$(uname -m)" = x86_64
+      sh install.sh --yes --no-migrate-prompt --version "'"$version"'"
+    ' >"$work/${fixture}-install.log" 2>&1; then
+    echo "clean Alpine installer accepted tampered $fixture metadata" >&2
+    return 1
+  fi
+  [[ ! -x "$work/${fixture}-home/.aos/bin/aos" ]]
+}
+
+run_negative_install bad-legacy
+cat > "$work/expected-bad-legacy-trace" <<EOF
+cosign-linux-amd64
+$legacy
+$legacy.sigstore.json
+EOF
+cmp "$work/expected-bad-legacy-trace" "$work/bad-legacy-trace"
+
+run_negative_install bad-extension
+cat > "$work/expected-bad-extension-trace" <<EOF
+cosign-linux-amd64
+$legacy
+$legacy.sigstore.json
+$extension
+$extension.sigstore.json
+EOF
+cmp "$work/expected-bad-extension-trace" "$work/bad-extension-trace"
+
+if grep -Fx "$archive" "$work/bad-extension-trace" >/dev/null; then
+  echo "installer downloaded the archive before authenticating musl metadata" >&2
+  exit 1
+fi
+
+echo "signed musl installer authenticated metadata in order and initialized a clean Alpine home"

--- a/scripts/test-clean-home-musl-install.sh
+++ b/scripts/test-clean-home-musl-install.sh
@@ -1,13 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-  echo "usage: $0 <signed-release-artifacts>" >&2
+if [[ $# -ne 6 ]]; then
+  echo "usage: $0 <signed-release-artifacts> <target> <platform> <image> <expected-uname> <cosign-asset>" >&2
   exit 2
 fi
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 artifacts=$(cd "$1" && pwd -P)
+target=$2
+platform=$3
+image=$4
+expected_uname=$5
+cosign_asset=$6
+case "$target:$platform:$expected_uname:$cosign_asset:$image" in
+  "x86_64-unknown-linux-musl:linux/amd64:x86_64:cosign-linux-amd64:docker.io/library/rust@sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15")
+    expected_cosign_sha256=ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc
+    ;;
+  "aarch64-unknown-linux-musl:linux/arm64:aarch64:cosign-linux-arm64:docker.io/library/rust@sha256:594694ee6b07747b63b5c265be2616b62e814180b66227e2c18c6ee85e4136be")
+    expected_cosign_sha256=2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11
+    ;;
+  *)
+    echo "unsupported or internally inconsistent native musl smoke configuration" >&2
+    exit 2
+    ;;
+esac
+[[ "$(uname -m)" == "$expected_uname" ]] || {
+  echo "musl smoke runner is not native $expected_uname" >&2
+  exit 1
+}
 version=$(python3 - "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" <<'PY'
 import pathlib
 import sys
@@ -17,12 +38,10 @@ with pathlib.Path(sys.argv[1]).open("rb") as source:
     print(tomllib.load(source)["package"]["version"])
 PY
 )
-target=x86_64-unknown-linux-musl
 legacy="unicity-aos-${version}-release.toml"
 extension="unicity-aos-${version}-musl-release.toml"
 archive="unicity-aos-${version}-${target}.tar.gz"
 cosign=$(command -v cosign)
-expected_cosign_sha256=ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc
 actual_cosign_sha256=$(sha256sum -- "$cosign" | awk '{print $1}')
 [[ "$actual_cosign_sha256" == "$expected_cosign_sha256" ]] || {
   echo "release smoke requires the installer's pinned cosign v3.1.1 binary" >&2
@@ -72,7 +91,7 @@ for fixture in good bad-legacy bad-extension; do
     "$artifacts/$archive" \
     "$artifacts/$archive.sigstore.json" \
     "$work/$fixture/"
-  cp "$cosign" "$work/$fixture/cosign-linux-amd64"
+  cp "$cosign" "$work/$fixture/$cosign_asset"
 done
 printf '\n# signature-invalidating tamper\n' >> "$work/bad-legacy/$legacy"
 printf '\n# signature-invalidating tamper\n' >> "$work/bad-extension/$extension"
@@ -97,20 +116,20 @@ cp "$AOS_INSTALL_FIXTURE/$asset" "$output"
 EOF
 chmod 755 "$work/fake-bin/curl"
 
-image=docker.io/library/rust@sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15
 docker run --rm \
-  --platform linux/amd64 \
+  --platform "$platform" \
   --env AOS_HOME=/work/good-home/.aos \
   --env AOS_INSTALL_FIXTURE=/work/good \
   --env AOS_INSTALL_TRACE=/work/good-trace \
   --env HOME=/work/good-home \
+  --env "EXPECTED_UNAME=$expected_uname" \
   --env PATH=/work/fake-bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
   --volume "$repo_root:/workspace:ro" \
   --volume "$work:/work" \
   --workdir /workspace \
   "$image" \
   sh -ceu '
-    test "$(uname -m)" = x86_64
+    test "$(uname -m)" = "$EXPECTED_UNAME"
     apk add --no-cache bash bubblewrap python3 zsh
     sh install.sh --yes --no-migrate-prompt --version "'"$version"'"
     bash scripts/test-clean-home-init.sh \
@@ -118,7 +137,7 @@ docker run --rm \
   '
 
 cat > "$work/expected-good-trace" <<EOF
-cosign-linux-amd64
+$cosign_asset
 $legacy
 $legacy.sigstore.json
 $extension
@@ -131,18 +150,19 @@ cmp "$work/expected-good-trace" "$work/good-trace"
 run_negative_install() {
   local fixture=$1
   if docker run --rm \
-    --platform linux/amd64 \
+    --platform "$platform" \
     --env "AOS_HOME=/work/${fixture}-home/.aos" \
     --env "AOS_INSTALL_FIXTURE=/work/$fixture" \
     --env "AOS_INSTALL_TRACE=/work/${fixture}-trace" \
     --env "HOME=/work/${fixture}-home" \
+    --env "EXPECTED_UNAME=$expected_uname" \
     --env PATH=/work/fake-bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     --volume "$repo_root:/workspace:ro" \
     --volume "$work:/work" \
     --workdir /workspace \
     "$image" \
     sh -ceu '
-      test "$(uname -m)" = x86_64
+      test "$(uname -m)" = "$EXPECTED_UNAME"
       sh install.sh --yes --no-migrate-prompt --version "'"$version"'"
     ' >"$work/${fixture}-install.log" 2>&1; then
     echo "clean Alpine installer accepted tampered $fixture metadata" >&2
@@ -153,7 +173,7 @@ run_negative_install() {
 
 run_negative_install bad-legacy
 cat > "$work/expected-bad-legacy-trace" <<EOF
-cosign-linux-amd64
+$cosign_asset
 $legacy
 $legacy.sigstore.json
 EOF
@@ -161,7 +181,7 @@ cmp "$work/expected-bad-legacy-trace" "$work/bad-legacy-trace"
 
 run_negative_install bad-extension
 cat > "$work/expected-bad-extension-trace" <<EOF
-cosign-linux-amd64
+$cosign_asset
 $legacy
 $legacy.sigstore.json
 $extension

--- a/scripts/test_astrid_musl_release.py
+++ b/scripts/test_astrid_musl_release.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import astrid_musl_release
+
+
+VERSION = "0.11.0"
+SOURCE = "a" * 40
+CONTRACTS = "b" * 40
+IDENTITY = (
+    "https://github.com/astrid-runtime/astrid/.github/workflows/"
+    f"release.yml@refs/tags/v{VERSION}"
+)
+
+
+def fake_blake3(path: Path) -> str:
+    return hashlib.sha256(b"blake3:" + path.read_bytes()).hexdigest()
+
+
+def target_entry(target: str, payload: bytes) -> dict[str, object]:
+    asset = f"astrid-{VERSION}-{target}.tar.gz"
+    return {
+        "triple": target,
+        "asset": asset,
+        "size": len(payload),
+        "blake3": hashlib.sha256(b"blake3:" + payload).hexdigest(),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "sigstore-bundle": f"{asset}.sigstore.json",
+    }
+
+
+def render(value: dict[str, object]) -> str:
+    def quote(item: object) -> str:
+        return f'"{item}"'
+
+    lines = [
+        f"schema-version = {value['schema-version']}",
+        f"kind = {quote(value['kind'])}",
+        f"product = {quote(value['product'])}",
+        f"repository = {quote(value['repository'])}",
+        f"version = {quote(value['version'])}",
+        f"tag = {quote(value['tag'])}",
+        f"source-commit = {quote(value['source-commit'])}",
+        f"release-workflow-identity = {quote(value['release-workflow-identity'])}",
+    ]
+    if "surprise" in value:
+        lines.append(f"surprise = {quote(value['surprise'])}")
+    if "contracts" in value:
+        lines.extend(
+            [
+                "",
+                "[contracts]",
+                f"repository = {quote(value['contracts']['repository'])}",
+                f"commit = {quote(value['contracts']['commit'])}",
+            ]
+        )
+    if "legacy-release" in value:
+        lines.extend(
+            [
+                "",
+                "[legacy-release]",
+                f"metadata-asset = {quote(value['legacy-release']['metadata-asset'])}",
+                f"metadata-blake3 = {quote(value['legacy-release']['metadata-blake3'])}",
+            ]
+        )
+    for entry in value["targets"]:
+        lines.extend(
+            [
+                "",
+                "[[targets]]",
+                f"triple = {quote(entry['triple'])}",
+                f"asset = {quote(entry['asset'])}",
+                f"size = {entry['size']}",
+                f"blake3 = {quote(entry['blake3'])}",
+                f"sha256 = {quote(entry['sha256'])}",
+                f"sigstore-bundle = {quote(entry['sigstore-bundle'])}",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+class AstridMuslReleaseTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.target = "x86_64-unknown-linux-musl"
+        self.archive = self.root / f"astrid-{VERSION}-{self.target}.tar.gz"
+        self.archive.write_bytes(b"static archive")
+        payloads = {
+            target: (
+                self.archive.read_bytes()
+                if target == self.target
+                else f"archive:{target}".encode()
+            )
+            for target in (
+                *astrid_musl_release.LEGACY_TARGETS,
+                "aarch64-unknown-linux-musl",
+                self.target,
+            )
+        }
+        base = {
+            "schema-version": 1,
+            "product": "astrid-runtime",
+            "repository": "astrid-runtime/astrid",
+            "version": VERSION,
+            "tag": f"v{VERSION}",
+            "source-commit": SOURCE,
+            "release-workflow-identity": IDENTITY,
+        }
+        self.legacy = {
+            **base,
+            "kind": "astrid-release",
+            "contracts": {
+                "repository": "astrid-runtime/wit",
+                "commit": CONTRACTS,
+            },
+            "targets": [
+                target_entry(target, payloads[target])
+                for target in astrid_musl_release.LEGACY_TARGETS
+            ],
+        }
+        self.legacy_path = self.root / f"astrid-{VERSION}-release.toml"
+        self.legacy_path.write_text(render(self.legacy), encoding="utf-8")
+        self.extension = {
+            **base,
+            "kind": "astrid-release-musl-extension",
+            "legacy-release": {
+                "metadata-asset": self.legacy_path.name,
+                "metadata-blake3": fake_blake3(self.legacy_path),
+            },
+            "targets": [
+                target_entry(target, payloads[target])
+                for target in (
+                    "aarch64-unknown-linux-musl",
+                    "x86_64-unknown-linux-musl",
+                )
+            ],
+        }
+        self.extension_path = self.root / f"astrid-{VERSION}-musl-release.toml"
+        self.extension_path.write_text(render(self.extension), encoding="utf-8")
+        self.compatibility_path = self.root / "runtime-musl.toml"
+        self.write_compatibility()
+
+    def write_compatibility(self, *, ready: bool = True) -> None:
+        self.compatibility_path.write_text(
+            "\n".join(
+                [
+                    "schema-version = 1",
+                    "",
+                    "[runtime]",
+                    'repository = "astrid-runtime/astrid"',
+                    f"release-ready = {str(ready).lower()}",
+                    f'version = "{VERSION}"',
+                    f'tag = "v{VERSION}"',
+                    f'release-workflow-identity = "{IDENTITY}"',
+                    f'source-commit = "{SOURCE}"',
+                    f'legacy-release-metadata-asset = "{self.legacy_path.name}"',
+                    f'legacy-release-metadata-blake3 = "{fake_blake3(self.legacy_path)}"',
+                    (
+                        f'musl-release-metadata-asset = "{self.extension_path.name}"'
+                        if ready
+                        else 'musl-release-metadata-asset = ""'
+                    ),
+                    (
+                        f'musl-release-metadata-blake3 = "{fake_blake3(self.extension_path)}"'
+                        if ready
+                        else 'musl-release-metadata-blake3 = ""'
+                    ),
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+    def validate(self) -> dict[str, object]:
+        with mock.patch.object(
+            astrid_musl_release, "blake3_file", side_effect=fake_blake3
+        ):
+            return astrid_musl_release.validate_release(
+                compatibility_path=self.compatibility_path,
+                legacy_path=self.legacy_path,
+                extension_path=self.extension_path,
+                target=self.target,
+                archive_path=self.archive,
+            )
+
+    def rewrite_extension(self, value: dict[str, object]) -> None:
+        self.extension_path.write_text(render(value), encoding="utf-8")
+        self.write_compatibility()
+
+    def test_accepts_the_exact_pinned_release_and_archive(self) -> None:
+        selected = self.validate()
+        self.assertEqual(selected["triple"], self.target)
+
+    def test_false_release_gate_blocks_the_release_path(self) -> None:
+        self.write_compatibility(ready=False)
+        with self.assertRaisesRegex(ValueError, "gate is false"):
+            self.validate()
+
+    def test_rejects_extension_not_bound_to_legacy_bytes(self) -> None:
+        changed = copy.deepcopy(self.extension)
+        changed["legacy-release"]["metadata-blake3"] = "f" * 64
+        self.rewrite_extension(changed)
+        with self.assertRaisesRegex(ValueError, "bind"):
+            self.validate()
+
+    def test_rejects_identity_and_target_set_changes(self) -> None:
+        changed = copy.deepcopy(self.extension)
+        changed["source-commit"] = "c" * 40
+        self.rewrite_extension(changed)
+        with self.assertRaisesRegex(ValueError, "source commit"):
+            self.validate()
+
+        changed = copy.deepcopy(self.extension)
+        changed["targets"][0] = copy.deepcopy(changed["targets"][1])
+        self.rewrite_extension(changed)
+        with self.assertRaisesRegex(ValueError, "target set"):
+            self.validate()
+
+    def test_rejects_archive_size_and_digest_changes(self) -> None:
+        self.archive.write_bytes(b"tampered")
+        with self.assertRaisesRegex(ValueError, "size|SHA-256|BLAKE3"):
+            self.validate()
+
+    def test_rejects_unknown_schema_fields(self) -> None:
+        changed = copy.deepcopy(self.extension)
+        changed["surprise"] = "value"
+        self.rewrite_extension(changed)
+        with self.assertRaisesRegex(ValueError, "unknown"):
+            self.validate()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_static_elf.py
+++ b/scripts/test_check_static_elf.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import unittest
+
+import check_static_elf
+
+
+class StaticElfTests(unittest.TestCase):
+    def validate(
+        self,
+        *,
+        architecture: str = "x86_64",
+        machine: str = "Advanced Micro Devices X86-64",
+        programs: str = "LOAD 0x000000",
+        dynamic: str = "There is no dynamic section in this file.",
+        versions: str = "No version information found in this file.",
+    ) -> None:
+        check_static_elf.validate_readelf(
+            architecture,
+            f"ELF Header:\n  Machine: {machine}\n",
+            programs,
+            dynamic,
+            versions,
+        )
+
+    def test_accepts_static_x86_64_and_aarch64(self) -> None:
+        self.validate()
+        self.validate(architecture="aarch64", machine="AArch64")
+
+    def test_rejects_wrong_machine(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ELF machine"):
+            self.validate(machine="AArch64")
+
+    def test_rejects_program_interpreter(self) -> None:
+        with self.assertRaisesRegex(ValueError, "program interpreter"):
+            self.validate(programs=" INTERP 0x000000\n LOAD 0x001000")
+
+    def test_rejects_dynamic_dependency(self) -> None:
+        with self.assertRaisesRegex(ValueError, "shared-library"):
+            self.validate(dynamic="0x0000000000000001 (NEEDED) Shared library: [libc.so]")
+
+    def test_rejects_every_glibc_symbol_version(self) -> None:
+        with self.assertRaisesRegex(ValueError, "glibc"):
+            self.validate(versions="Name: GLIBC_2.34")
+        with self.assertRaisesRegex(ValueError, "glibc"):
+            self.validate(versions="Name: GLIBC_PRIVATE")
+
+    def test_rejects_unknown_architecture(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported ELF architecture"):
+            self.validate(architecture="riscv64")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_musl_workflow_contract.py
+++ b/scripts/test_musl_workflow_contract.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Regression checks for the native Linux musl workflow boundary."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+AMD64_IMAGE = (
+    "docker.io/library/rust@"
+    "sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15"
+)
+ARM64_IMAGE = (
+    "docker.io/library/rust@"
+    "sha256:594694ee6b07747b63b5c265be2616b62e814180b66227e2c18c6ee85e4136be"
+)
+
+
+class MuslWorkflowContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        self.release = (ROOT / ".github/workflows/release.yml").read_text(
+            encoding="utf-8"
+        )
+
+    def test_both_native_targets_use_exact_platform_images(self) -> None:
+        for workflow in (self.ci, self.release):
+            self.assertIn("target: x86_64-unknown-linux-musl", workflow)
+            self.assertIn("os: ubuntu-latest", workflow)
+            self.assertIn("platform: linux/amd64", workflow)
+            self.assertIn(AMD64_IMAGE, workflow)
+            self.assertIn("target: aarch64-unknown-linux-musl", workflow)
+            self.assertIn("os: ubuntu-24.04-arm", workflow)
+            self.assertIn("platform: linux/arm64", workflow)
+            self.assertIn(ARM64_IMAGE, workflow)
+            self.assertNotIn("setup-qemu", workflow.lower())
+
+    def test_release_authenticates_runtime_metadata_before_packaging(self) -> None:
+        legacy = self.release.index('for metadata in "$RUNTIME_LEGACY_METADATA"')
+        validator = self.release.index("scripts/astrid_musl_release.py")
+        package = self.release.index("scripts/package-release.sh", validator)
+        self.assertLess(legacy, validator)
+        self.assertLess(validator, package)
+        self.assertIn("--use-signed-timestamps", self.release[legacy:validator])
+
+    def test_release_gate_and_signed_install_smoke_are_mandatory(self) -> None:
+        self.assertIn(
+            "validate-release-contract.py --require-release-ready", self.release
+        )
+        self.assertIn(
+            'test-clean-home-musl-install.sh "$CANDIDATE"', self.release
+        )
+        self.assertIn("runtime-musl-compatibility.toml", self.release)
+        self.assertIn("unicity-aos-*-release.toml", self.release)
+
+    def test_static_validation_covers_aos_and_all_runtime_binaries(self) -> None:
+        validation = self.release[
+            self.release.index("Validate and exercise every Linux musl binary") :
+        ]
+        for binary in ("$AOS_BINARY", "astrid", "astrid-daemon", "astrid-build", "astrid-emit"):
+            self.assertIn(binary, validation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_musl_workflow_contract.py
+++ b/scripts/test_musl_workflow_contract.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import unittest
 from pathlib import Path
 
@@ -18,12 +19,38 @@ ARM64_IMAGE = (
 )
 
 
+def job_block(workflow: str, name: str) -> str:
+    lines = workflow.splitlines()
+    header = f"  {name}:"
+    try:
+        start = lines.index(header)
+    except ValueError as error:
+        raise AssertionError(f"workflow job {name!r} is missing") from error
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if re.fullmatch(r"  [A-Za-z0-9_-]+:", lines[index]):
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+def job_needs(workflow: str, name: str) -> set[str]:
+    block = job_block(workflow, name)
+    match = re.search(r"^    needs: \[([^]]*)\]$", block, re.MULTILINE)
+    if match is None:
+        raise AssertionError(f"workflow job {name!r} has no inline needs list")
+    return {dependency.strip() for dependency in match.group(1).split(",")}
+
+
 class MuslWorkflowContractTests(unittest.TestCase):
     def setUp(self) -> None:
         self.ci = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
         self.release = (ROOT / ".github/workflows/release.yml").read_text(
             encoding="utf-8"
         )
+        self.installer_smoke = (
+            ROOT / "scripts/test-clean-home-musl-install.sh"
+        ).read_text(encoding="utf-8")
 
     def test_both_native_targets_use_exact_platform_images(self) -> None:
         for workflow in (self.ci, self.release):
@@ -49,11 +76,72 @@ class MuslWorkflowContractTests(unittest.TestCase):
         self.assertIn(
             "validate-release-contract.py --require-release-ready", self.release
         )
-        self.assertIn(
-            'test-clean-home-musl-install.sh "$CANDIDATE"', self.release
-        )
+        self.assertIn("test-clean-home-musl-install.sh", self.release)
+        for value in (
+            '"$TARGET"',
+            '"$PLATFORM"',
+            '"$IMAGE"',
+            '"$EXPECTED_UNAME"',
+            '"$COSIGN_ASSET"',
+        ):
+            self.assertIn(value, self.release)
         self.assertIn("runtime-musl-compatibility.toml", self.release)
         self.assertIn("unicity-aos-*-release.toml", self.release)
+
+    def test_signed_candidate_is_smoked_before_any_new_draft_or_publication(self) -> None:
+        candidate_job = job_block(self.release, "release-candidate")
+        smoke_job = job_block(self.release, "signed-musl-install")
+        publish_job = job_block(self.release, "github-release")
+        self.assertEqual(
+            job_needs(self.release, "signed-musl-install"),
+            {"classify", "release-candidate"},
+        )
+        self.assertEqual(
+            job_needs(self.release, "github-release"),
+            {"classify", "release-candidate", "signed-musl-install"},
+        )
+        self.assertIn('ARTIFACT_NAME="signed-release-candidate-', candidate_job)
+        self.assertNotIn("Create draft release", candidate_job)
+        self.assertNotIn("draft=false", candidate_job)
+        self.assertIn("Create draft release with write-once assets", publish_job)
+        self.assertIn("draft=false", publish_job)
+        self.assertNotIn("id-token: write", smoke_job)
+        self.assertNotIn("id-token: write", publish_job)
+        self.assertIn("id-token: write", candidate_job)
+        self.assertIn("permissions:\n      contents: read", candidate_job)
+        self.assertIn("permissions:\n      contents: read", smoke_job)
+        self.assertIn("permissions:\n      contents: write", publish_job)
+        self.assertNotIn("attestations: write", smoke_job)
+        self.assertNotIn("attestations: write", publish_job)
+
+    def test_signed_smoke_matrix_is_native_and_target_complete(self) -> None:
+        smoke = job_block(self.release, "signed-musl-install")
+        for value in (
+            "os: ubuntu-latest",
+            "platform: linux/amd64",
+            "expected_uname: x86_64",
+            "cosign_asset: cosign-linux-amd64",
+            "os: ubuntu-24.04-arm",
+            "platform: linux/arm64",
+            "expected_uname: aarch64",
+            "cosign_asset: cosign-linux-arm64",
+            AMD64_IMAGE,
+            ARM64_IMAGE,
+        ):
+            self.assertIn(value, smoke)
+        self.assertNotIn("setup-qemu", smoke.lower())
+
+    def test_installer_smoke_rejects_cross_architecture_configuration(self) -> None:
+        for value in (
+            "x86_64-unknown-linux-musl:linux/amd64:x86_64:cosign-linux-amd64:"
+            + AMD64_IMAGE,
+            "aarch64-unknown-linux-musl:linux/arm64:aarch64:cosign-linux-arm64:"
+            + ARM64_IMAGE,
+            '[[ "$(uname -m)" == "$expected_uname" ]]',
+            '--platform "$platform"',
+            '--env "EXPECTED_UNAME=$expected_uname"',
+        ):
+            self.assertIn(value, self.installer_smoke)
 
     def test_static_validation_covers_aos_and_all_runtime_binaries(self) -> None:
         validation = self.release[

--- a/scripts/test_validate_release_contract.py
+++ b/scripts/test_validate_release_contract.py
@@ -144,10 +144,19 @@ class ReleaseReadinessTests(unittest.TestCase):
         runtime = VALIDATOR.readiness_metadata(
             ROOT / "release/runtime-compatibility.toml"
         )["runtime"]
-        if runtime["release-ready"] and runtime["upgrade-self-heal-ready"]:
+        musl_runtime = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-musl-compatibility.toml"
+        )["runtime"]
+        if (
+            runtime["release-ready"]
+            and runtime["upgrade-self-heal-ready"]
+            and musl_runtime["release-ready"]
+        ):
             self.assertEqual(VALIDATOR.main(["--require-release-ready"]), 0)
         else:
-            with self.assertRaisesRegex(ValueError, "refusing to publish"):
+            with self.assertRaisesRegex(
+                ValueError, "refusing to publish|release-ready gate is false"
+            ):
                 VALIDATOR.main(["--require-release-ready"])
 
     def test_cli_matches_the_current_publication_gate(self) -> None:
@@ -163,6 +172,9 @@ class ReleaseReadinessTests(unittest.TestCase):
         runtime = VALIDATOR.readiness_metadata(
             ROOT / "release/runtime-compatibility.toml"
         )["runtime"]
+        musl_runtime = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-musl-compatibility.toml"
+        )["runtime"]
         strict = subprocess.run(
             [sys.executable, str(SCRIPT), "--require-release-ready"],
             cwd=ROOT,
@@ -170,11 +182,17 @@ class ReleaseReadinessTests(unittest.TestCase):
             capture_output=True,
             check=False,
         )
-        if runtime["release-ready"] and runtime["upgrade-self-heal-ready"]:
+        if (
+            runtime["release-ready"]
+            and runtime["upgrade-self-heal-ready"]
+            and musl_runtime["release-ready"]
+        ):
             self.assertEqual(strict.returncode, 0, strict.stderr)
         else:
             self.assertEqual(strict.returncode, 1)
-            self.assertIn("refusing to publish", strict.stderr)
+            self.assertRegex(
+                strict.stderr, "refusing to publish|release-ready gate is false"
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/validate-release-contract.py
+++ b/scripts/validate-release-contract.py
@@ -147,7 +147,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     musl_release_metadata.validate_runtime_pin(
         readiness_metadata("release/runtime-musl-compatibility.toml"),
-        require_ready=False,
+        require_ready=args.require_release_ready,
     )
 
     product_version = product[("package", "version")]


### PR DESCRIPTION
Closes #63

## Summary

Add native x86_64 and ARM64 Linux musl build, validation, packaging, and signed installer-smoke lanes for AOS CE. Each target uses its exact official Rust Alpine platform manifest on a native GitHub runner with no QEMU setup.

This PR is stacked on #68 so its diff contains only the native target work. It must not merge before #68; after the prerequisites land, its base will be retargeted to `main`.

## Changes

- add explicit native x86_64 and ARM64 musl CI/release matrices
- assert runner, Docker platform, image architecture, target architecture, `uname`, and Cosign asset agree before building or testing
- statically validate AOS and all four Astrid binaries for the expected machine, no interpreter, no dynamic dependency, and no `GLIBC_*` requirement
- execute all five binaries in fresh Alpine environments
- authenticate Astrid legacy metadata, its bound exact-two musl extension, and both runtime archives before AOS packaging
- generate/sign the exact-two AOS musl extension while preserving exact-four legacy documents
- extend exact-six publication and interrupted-draft recovery validation
- prepare a complete immutable signed candidate before testing either architecture
- run the signed clean-home installer smoke on native amd64 and native arm64, with legacy-first and extension-before-archive tamper cases
- prevent release-draft creation and publication until both native smoke jobs pass through exact workflow dependencies
- keep the checked false runtime pin as a complete release-DAG blocker
- preserve existing GNU and macOS paths

## Verification

- native ARM64 pinned-image build, static validation, and fresh Alpine execution
- x86_64 native build/execution assigned to the `ubuntu-latest` CI lane
- 146 Python contract and release tests after rebasing onto the refreshed #68/#59 stack
- exact workflow dependency assertions for candidate → native smoke → publication
- 54 library, 32 binary, and 25 CLI-boundary Rust tests
- clippy with warnings denied and Rust formatting
- release metadata, installer, publication/recovery, package, channel, legacy GNU/macOS, and workflow contract suites
- ShellCheck, actionlint, shell syntax, workflow YAML parsing, Ruff formatting, and `git diff --check`
- independent architecture, cryptographic-ordering, native-release-gate, and dependency-graph review
- both Copilot review threads addressed and resolved

## Release dependency

The current musl compatibility pin intentionally blocks the entire release DAG. A later release-only PR must pin a published Astrid release containing the signed musl extension and flip the gate. No version, release, or channel is changed here.
