### PR TITLE
Add capsule-trace: durable trace/evaluation archive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aos-trace"
+version = "0.1.0"
+dependencies = [
+ "astrid-sdk",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "aos-users"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "capsules/capsule-shell",
     "capsules/capsule-skills",
     "capsules/capsule-system",
+    "capsules/capsule-trace",
     "capsules/capsule-users",
 ]
 resolver = "3"

--- a/capsules/capsule-trace/.cargo/config.toml
+++ b/capsules/capsule-trace/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "wasm32-unknown-unknown"
+
+[target.wasm32-unknown-unknown]
+# Activates astrid-sys's custom getrandom backend that routes to
+# `astrid:sys.random-bytes`. Without this, uuid v4 / HashMap RNG seed
+# init fail to link on `wasm32-unknown-unknown`.
+rustflags = ["--cfg=getrandom_backend=\"custom\""]

--- a/capsules/capsule-trace/.gitattributes
+++ b/capsules/capsule-trace/.gitattributes
@@ -1,0 +1,1 @@
+crates/astrid-openclaw/kernel/engine.wasm binary

--- a/capsules/capsule-trace/.github/workflows/ci.yml
+++ b/capsules/capsule-trace/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: Check & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --locked --target wasm32-unknown-unknown -- -D warnings
+
+      - name: Build WASM
+        run: cargo build --locked --release --target wasm32-unknown-unknown
+
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: capsule-wasm
+          path: target/wasm32-unknown-unknown/release/*.wasm
+          if-no-files-found: error

--- a/capsules/capsule-trace/.github/workflows/release.yml
+++ b/capsules/capsule-trace/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Fetch astrid-build from the astrid release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download --repo astrid-runtime/astrid \
+            --pattern 'astrid-*-x86_64-unknown-linux-gnu.tar.gz' --dir /tmp/astrid-cli
+          tar xzf /tmp/astrid-cli/*.tar.gz -C /tmp/astrid-cli
+          echo "$(dirname "$(find /tmp/astrid-cli -name astrid-build -type f | head -1)")" >> "$GITHUB_PATH"
+
+      - name: Build .capsule (componentized, install-ready)
+        run: astrid-build . --output dist
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.capsule
+          generate_release_notes: true

--- a/capsules/capsule-trace/.gitignore
+++ b/capsules/capsule-trace/.gitignore
@@ -1,0 +1,2 @@
+/target
+.DS_Store

--- a/capsules/capsule-trace/Capsule.toml
+++ b/capsules/capsule-trace/Capsule.toml
@@ -1,0 +1,29 @@
+[package]
+name = "aos-trace"
+version = "0.1.0"
+description = "Durable trace and evaluation archive for Unicity AOS agents"
+authors = ["Marek Sepp <marek.sepp@gmail.com>", "Unicity Labs <info@unicity-labs.com>"]
+astrid-version = ">=0.7.0"
+
+[[component]]
+id = "trace-tools"
+file = "aos_trace.wasm"
+type = "executable"
+capabilities = { fs_read = ["cwd://"], fs_write = ["cwd://"] }
+
+[publish]
+"tool.v1.execute.*.result" = { wit = "@unicity-astrid/wit/types/tool-call-result" }
+"tool.v1.response.describe.*" = { wit = "@unicity-astrid/wit/tool/describe-response" }
+
+[subscribe]
+"tool.v1.execute.record_trace" = { wit = "@unicity-astrid/wit/types/tool-call", handler = "tool_execute_record_trace" }
+"tool.v1.execute.list_traces" = { wit = "@unicity-astrid/wit/types/tool-call", handler = "tool_execute_list_traces" }
+"tool.v1.execute.get_trace" = { wit = "@unicity-astrid/wit/types/tool-call", handler = "tool_execute_get_trace" }
+"tool.v1.request.describe" = { wit = "@unicity-astrid/wit/tool/describe-request", handler = "tool_describe" }
+
+[env]
+# Name of the project folder the archive is written under (set by the
+# distro). Override to rebrand without forking: set cwd_dir = ".myagent"
+# in your Distro.toml. Shares the convention used by aos-memory so both
+# capsules land in the same project-local directory.
+cwd_dir = { type = "string", request = "Project folder name", default = ".astrid" }

--- a/capsules/capsule-trace/Cargo.toml
+++ b/capsules/capsule-trace/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "aos-trace"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Durable trace and evaluation archive capsule for Unicity AOS"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+astrid-sdk = { workspace = true }
+uuid = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/capsules/capsule-trace/LICENSE-APACHE
+++ b/capsules/capsule-trace/LICENSE-APACHE
@@ -1,0 +1,200 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an
+      individually identifiable public domain dedication and license
+      statement from each contributor.
+
+   Copyright 2026 Marek Sepp and Unicity Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/capsules/capsule-trace/LICENSE-MIT
+++ b/capsules/capsule-trace/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Marek Sepp and Unicity Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/capsules/capsule-trace/README.md
+++ b/capsules/capsule-trace/README.md
@@ -1,0 +1,41 @@
+# aos-trace
+
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
+
+**Durable trace and evaluation archive for [Unicity AOS](https://github.com/unicity-aos/aos-ce) agents.**
+
+In the OS model, this capsule is the black-box recorder: a typed capability for turning a session's work into inspectable experience instead of losing it when the session ends. It fills a gap named directly in [`docs/meta-harness.md`](../../docs/meta-harness.md): a meta-harness proposer needs "a unified inventory of harness artifacts, durable trace/evaluation archives" to compare candidates on more than a compressed score.
+
+## Tools
+
+- **`record_trace`** - Append a `trace` or `evaluation` record: summary, outcome, score, cost, tags, candidate id, source ref, and an optional structured `metadata` payload (capped at 8 KB - point large payloads at a file via `source_ref` instead). Returns the assigned `id` and `ts`.
+- **`list_traces`** - Filtered, summarized listing (by `kind`, `candidate_id`, `tag`, `since`), newest first, capped at 100 records. Summaries omit `metadata` so a listing call can't flood the context window.
+- **`get_trace`** - Fetch one full record, including `metadata`, by `id`.
+
+## Storage
+
+Records are appended as newline-delimited JSON to `cwd://{cwd_dir}/trace.jsonl`, sharing the `cwd_dir` project-folder convention `aos-memory` uses (default `.astrid`). The archive is append-only by design - there is no edit or delete tool. Archived experience is retained evidence for later search and evaluation, not scratch state; an operator who needs to prune the file can do so directly with `aos-fs`.
+
+## Design notes
+
+- **No prompt injection.** Unlike `aos-memory`, this capsule never writes into the system prompt. An agent (or a Forge-built proposer) calls it deliberately when recording or inspecting experience.
+- **Bounded reads.** `list_traces` defaults to 20 records and hard-caps at 100, matching the "raw, selectively inspectable experience" principle from the meta-harness research: the proposer decides what to inspect next rather than being handed the whole archive at once.
+- **Reject, don't mangle, oversized metadata.** `record_trace` errors if `metadata` exceeds 8 KB serialized rather than silently truncating structured JSON into something invalid.
+
+## Capabilities
+
+`fs_read = ["cwd://"]`, `fs_write = ["cwd://"]` - project-scoped only, no `home://` or `net` access.
+
+## Development
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+cargo test
+```
+
+## License
+
+Dual-licensed under [MIT](LICENSE-MIT) and [Apache 2.0](LICENSE-APACHE).
+
+Copyright (c) 2026 Marek Sepp and Unicity Labs.

--- a/capsules/capsule-trace/rust-toolchain.toml
+++ b/capsules/capsule-trace/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.94.0"
+targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]

--- a/capsules/capsule-trace/src/lib.rs
+++ b/capsules/capsule-trace/src/lib.rs
@@ -130,7 +130,7 @@ struct TraceSummary<'a> {
     outcome: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     score: Option<f64>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "<[String]>::is_empty")]
     tags: &'a [String],
 }
 

--- a/capsules/capsule-trace/src/lib.rs
+++ b/capsules/capsule-trace/src/lib.rs
@@ -1,0 +1,440 @@
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+#![deny(unreachable_pub)]
+#![allow(missing_docs)]
+
+//! Durable trace and evaluation archive capsule for Unicity AOS.
+//!
+//! Gives agents a typed capability to record inspectable experience —
+//! harness candidates, task outcomes, scores, and cost — instead of losing
+//! it at the end of a session. This is the gap named directly in
+//! `docs/meta-harness.md`: "a unified inventory of harness artifacts,
+//! durable trace/evaluation archives" is called out as the next thing a
+//! meta-harness needs to make world changes genuinely evaluable rather than
+//! guessed at.
+//!
+//! Records are appended as newline-delimited JSON to a single project-local
+//! file (`cwd://{cwd_dir}/trace.jsonl`, sharing the `cwd_dir` convention
+//! `aos-memory` uses). Each record captures one unit of experience: a
+//! harness candidate's source/reasoning, a task outcome, a score or
+//! qualitative note, and cost — the fields `docs/meta-harness.md` asks
+//! evaluation to retain.
+//!
+//! Three tools:
+//! - `record_trace` — append a trace or evaluation record, returns its id.
+//! - `list_traces` — filtered, summarized listing (bounded, newest first).
+//! - `get_trace` — fetch one full record by id.
+//!
+//! # Design notes
+//!
+//! **Append, don't rewrite the world.** The archive is meant to accumulate
+//! across sessions and candidates. There is no `delete`/`update` tool by
+//! design — trace data is retained evidence, not scratch state. An operator
+//! who needs to prune the file can do so with `aos-fs` directly.
+//!
+//! **Bounded reads.** `list_traces` never returns full records (metadata is
+//! omitted) and is capped at [`MAX_LIST_LIMIT`] to avoid a single call
+//! flooding the agent's context window as the archive grows across a long
+//! meta-harness search run.
+//!
+//! **No prompt injection.** Unlike `aos-memory`, this capsule never writes
+//! into the system prompt. It is a plain callable capability — an agent (or
+//! a Forge-built proposer) reaches for it deliberately when recording or
+//! inspecting experience, matching the "raw, selectively inspectable
+//! experience" principle from the meta-harness research.
+
+mod time;
+
+use astrid_sdk::prelude::*;
+use astrid_sdk::schemars;
+use serde::{Deserialize, Serialize};
+
+/// Path (relative to the VFS root) the archive is stored under.
+const ARCHIVE_FILE: &str = "trace.jsonl";
+
+/// Last-resort project folder name if the distro did not set `cwd_dir`.
+const DEFAULT_CWD_DIR: &str = ".astrid";
+
+/// Hard cap on serialized `metadata` size per record (8 KB). Rejected rather
+/// than silently truncated — truncating structured JSON can produce invalid
+/// data, and the caller is better positioned to decide what to drop.
+const MAX_METADATA_BYTES: usize = 8 * 1024;
+
+/// Hard cap on `summary` length (4 KB). Truncated (not rejected) since it is
+/// free text and a shortened summary is still useful.
+const MAX_SUMMARY_BYTES: usize = 4 * 1024;
+
+/// Default number of records `list_traces` returns when `limit` is omitted.
+const DEFAULT_LIST_LIMIT: usize = 20;
+
+/// Maximum number of records `list_traces` will return in one call,
+/// regardless of the requested `limit`.
+const MAX_LIST_LIMIT: usize = 100;
+
+/// The kinds of experience this capsule archives.
+const VALID_KINDS: [&str; 2] = ["trace", "evaluation"];
+
+/// Trace/evaluation archive capsule.
+#[derive(Default)]
+pub struct TraceArchive;
+
+/// One archived unit of experience.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TraceRecord {
+    /// Unique id assigned at record time (UUID v4).
+    id: String,
+    /// RFC 3339 timestamp assigned at record time.
+    ts: String,
+    /// `"trace"` (a candidate's raw execution trace) or `"evaluation"` (a
+    /// scored/qualitative judgment of a candidate or task outcome).
+    kind: String,
+    /// Identifier for the harness/agent candidate this record belongs to,
+    /// if any. Lets a proposer group prior experience by candidate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    candidate_id: Option<String>,
+    /// Pointer to the source this record is about (a file path, commit,
+    /// capsule name, or other caller-defined reference).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_ref: Option<String>,
+    /// Free-text summary of what happened. Always present.
+    summary: String,
+    /// Free-text task outcome (e.g. "passed", "regressed p50 latency 12%").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    outcome: Option<String>,
+    /// Numeric score, if the evaluation produced one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    score: Option<f64>,
+    /// Cost of producing this record (tokens, dollars, seconds — caller's
+    /// unit of choice; not interpreted by this capsule).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cost: Option<f64>,
+    /// Free-form tags for filtering (e.g. `["retrieval", "regression"]`).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    tags: Vec<String>,
+    /// Arbitrary structured payload (raw trace data, diffs, evidence).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<serde_json::Value>,
+}
+
+/// Summary view of a [`TraceRecord`] returned by `list_traces`. Omits
+/// `metadata` so a listing call cannot blow the context window.
+#[derive(Serialize)]
+struct TraceSummary<'a> {
+    id: &'a str,
+    ts: &'a str,
+    kind: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    candidate_id: Option<&'a str>,
+    summary: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    outcome: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    score: Option<f64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tags: &'a [String],
+}
+
+impl<'a> From<&'a TraceRecord> for TraceSummary<'a> {
+    fn from(r: &'a TraceRecord) -> Self {
+        Self {
+            id: &r.id,
+            ts: &r.ts,
+            kind: &r.kind,
+            candidate_id: r.candidate_id.as_deref(),
+            summary: &r.summary,
+            outcome: r.outcome.as_deref(),
+            score: r.score,
+            tags: &r.tags,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
+pub struct RecordTraceArgs {
+    /// `"trace"` or `"evaluation"`. Defaults to `"trace"`.
+    pub kind: Option<String>,
+    /// Candidate id this record belongs to, if part of a harness search.
+    pub candidate_id: Option<String>,
+    /// Pointer to the source this record is about.
+    pub source_ref: Option<String>,
+    /// What happened, in plain language. Required.
+    pub summary: String,
+    /// Task outcome, in plain language.
+    pub outcome: Option<String>,
+    /// Numeric score, if any.
+    pub score: Option<f64>,
+    /// Cost of producing this record, in the caller's unit of choice.
+    pub cost: Option<f64>,
+    /// Tags for later filtering.
+    pub tags: Option<Vec<String>>,
+    /// Arbitrary structured payload (max 8 KB serialized).
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
+pub struct ListTracesArgs {
+    /// Filter to `"trace"` or `"evaluation"` records only.
+    pub kind: Option<String>,
+    /// Filter to records with this exact `candidate_id`.
+    pub candidate_id: Option<String>,
+    /// Filter to records that carry this tag.
+    pub tag: Option<String>,
+    /// Only return records with `ts >= since` (RFC 3339, lexicographic
+    /// comparison is safe since timestamps are zero-padded).
+    pub since: Option<String>,
+    /// Max records to return (default 20, hard cap 100). Newest first.
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
+pub struct GetTraceArgs {
+    /// The record id returned by `record_trace`.
+    pub id: String,
+}
+
+/// Directory the archive file lives in, `cwd://{cwd_dir}`.
+fn archive_dir() -> String {
+    let dir = env::var("cwd_dir");
+    format!("cwd://{}", dir.as_deref().unwrap_or(DEFAULT_CWD_DIR))
+}
+
+/// Full path to the archive file.
+fn archive_path() -> String {
+    format!("{}/{ARCHIVE_FILE}", archive_dir())
+}
+
+/// Truncate `s` to `max_bytes` on a UTF-8 char boundary, appending a marker
+/// if truncation occurred.
+fn truncate(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let end = s.floor_char_boundary(max_bytes);
+    format!("{}... [truncated, {} bytes total]", &s[..end], s.len())
+}
+
+/// Read every well-formed record currently in the archive.
+///
+/// Malformed lines (should not occur outside manual file tampering) are
+/// skipped rather than failing the whole read, so one bad line cannot brick
+/// the archive.
+fn read_all() -> Result<Vec<TraceRecord>, SysError> {
+    let path = archive_path();
+    if !fs::exists(&path)? {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(&path)?;
+    Ok(content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<TraceRecord>(l).ok())
+        .collect())
+}
+
+/// Append `record` to the archive, creating the project directory and file
+/// if this is the first write.
+fn append(record: &TraceRecord) -> Result<(), SysError> {
+    let dir = archive_dir();
+    if !fs::exists(&dir)? {
+        fs::create_dir(&dir)?;
+    }
+
+    let path = archive_path();
+    let mut content = if fs::exists(&path)? {
+        fs::read_to_string(&path)?
+    } else {
+        String::new()
+    };
+    if !content.is_empty() && !content.ends_with('\n') {
+        content.push('\n');
+    }
+    content.push_str(&serde_json::to_string(record).map_err(|e| SysError::ApiError(e.to_string()))?);
+    content.push('\n');
+
+    fs::write(&path, content.as_bytes())?;
+    Ok(())
+}
+
+/// Trace/evaluation archive tools: record, list, and fetch inspectable
+/// experience for meta-harness style search and ordinary agent work.
+#[capsule]
+impl TraceArchive {
+    /// Record a trace or evaluation entry in the durable archive. Returns
+    /// the assigned `id` and `ts` as a JSON object. Use `kind: "trace"` for
+    /// a raw execution record and `kind: "evaluation"` for a scored or
+    /// qualitative judgment. Records are append-only — there is no
+    /// edit/delete tool, since archived experience is meant to stay intact.
+    #[astrid::tool("record_trace", mutable)]
+    pub fn record_trace(&self, args: RecordTraceArgs) -> Result<String, SysError> {
+        let kind = args.kind.unwrap_or_else(|| "trace".to_string());
+        if !VALID_KINDS.contains(&kind.as_str()) {
+            return Err(SysError::ApiError(format!(
+                "invalid kind '{kind}': expected one of {VALID_KINDS:?}"
+            )));
+        }
+
+        let summary = args.summary.trim();
+        if summary.is_empty() {
+            return Err(SysError::ApiError("summary must not be empty".into()));
+        }
+        let summary = truncate(summary, MAX_SUMMARY_BYTES);
+
+        let metadata = match &args.metadata {
+            Some(v) => {
+                let encoded =
+                    serde_json::to_string(v).map_err(|e| SysError::ApiError(e.to_string()))?;
+                if encoded.len() > MAX_METADATA_BYTES {
+                    return Err(SysError::ApiError(format!(
+                        "metadata is {} bytes, limit is {MAX_METADATA_BYTES} bytes; shrink it or store the large payload via aos-fs and pass a source_ref instead",
+                        encoded.len()
+                    )));
+                }
+                Some(v.clone())
+            }
+            None => None,
+        };
+
+        let record = TraceRecord {
+            id: uuid::Uuid::new_v4().to_string(),
+            ts: time::now_rfc3339(),
+            kind,
+            candidate_id: args.candidate_id,
+            source_ref: args.source_ref,
+            summary,
+            outcome: args.outcome,
+            score: args.score,
+            cost: args.cost,
+            tags: args.tags.unwrap_or_default(),
+            metadata,
+        };
+
+        append(&record)?;
+
+        serde_json::to_string(&serde_json::json!({ "id": record.id, "ts": record.ts }))
+            .map_err(|e| SysError::ApiError(e.to_string()))
+    }
+
+    /// List archived records, newest first, filtered by `kind`,
+    /// `candidate_id`, `tag`, and/or `since`. Returns summaries (no
+    /// `metadata`) capped at `limit` (default 20, max 100) to keep results
+    /// bounded as the archive grows.
+    #[astrid::tool("list_traces")]
+    pub fn list_traces(&self, args: ListTracesArgs) -> Result<String, SysError> {
+        let limit = args.limit.unwrap_or(DEFAULT_LIST_LIMIT).min(MAX_LIST_LIMIT);
+
+        let mut records = read_all()?;
+        records.sort_by(|a, b| b.ts.cmp(&a.ts));
+
+        let filtered: Vec<TraceSummary<'_>> = records
+            .iter()
+            .filter(|r| args.kind.as_deref().is_none_or(|k| r.kind == k))
+            .filter(|r| {
+                args.candidate_id
+                    .as_deref()
+                    .is_none_or(|c| r.candidate_id.as_deref() == Some(c))
+            })
+            .filter(|r| {
+                args.tag
+                    .as_deref()
+                    .is_none_or(|t| r.tags.iter().any(|tag| tag == t))
+            })
+            .filter(|r| args.since.as_deref().is_none_or(|s| r.ts.as_str() >= s))
+            .take(limit)
+            .map(TraceSummary::from)
+            .collect();
+
+        serde_json::to_string(&filtered).map_err(|e| SysError::ApiError(e.to_string()))
+    }
+
+    /// Fetch one full record (including `metadata`) by `id`.
+    #[astrid::tool("get_trace")]
+    pub fn get_trace(&self, args: GetTraceArgs) -> Result<String, SysError> {
+        let records = read_all()?;
+        let record = records
+            .into_iter()
+            .find(|r| r.id == args.id)
+            .ok_or_else(|| SysError::ApiError(format!("no trace record with id '{}'", args.id)))?;
+
+        serde_json::to_string(&record).map_err(|e| SysError::ApiError(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_short_unchanged() {
+        assert_eq!(truncate("hello", 100), "hello");
+    }
+
+    #[test]
+    fn truncate_long_adds_marker() {
+        let input = "a".repeat(50);
+        let out = truncate(&input, 10);
+        assert!(out.starts_with(&"a".repeat(10)));
+        assert!(out.contains("[truncated, 50 bytes total]"));
+    }
+
+    #[test]
+    fn truncate_at_char_boundary() {
+        let input = "\u{1F600}".repeat(20); // 4 bytes each = 80 bytes
+        let out = truncate(&input, 10);
+        // floor_char_boundary(10) for 4-byte chars = 8
+        assert!(out.starts_with(&"\u{1F600}".repeat(2)));
+    }
+
+    #[test]
+    fn valid_kinds_contains_trace_and_evaluation() {
+        assert!(VALID_KINDS.contains(&"trace"));
+        assert!(VALID_KINDS.contains(&"evaluation"));
+        assert!(!VALID_KINDS.contains(&"bogus"));
+    }
+
+    #[test]
+    fn trace_summary_from_record_omits_metadata() {
+        let record = TraceRecord {
+            id: "abc".into(),
+            ts: "2026-01-01T00:00:00.000Z".into(),
+            kind: "trace".into(),
+            candidate_id: Some("c1".into()),
+            source_ref: None,
+            summary: "did a thing".into(),
+            outcome: Some("passed".into()),
+            score: Some(0.9),
+            cost: None,
+            tags: vec!["retrieval".into()],
+            metadata: Some(serde_json::json!({"big": "payload"})),
+        };
+        let summary = TraceSummary::from(&record);
+        let json = serde_json::to_string(&summary).unwrap();
+        assert!(!json.contains("payload"));
+        assert!(json.contains("did a thing"));
+    }
+
+    #[test]
+    fn record_serializes_without_optional_fields() {
+        let record = TraceRecord {
+            id: "abc".into(),
+            ts: "2026-01-01T00:00:00.000Z".into(),
+            kind: "trace".into(),
+            candidate_id: None,
+            source_ref: None,
+            summary: "minimal".into(),
+            outcome: None,
+            score: None,
+            cost: None,
+            tags: Vec::new(),
+            metadata: None,
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        assert!(!json.contains("candidate_id"));
+        assert!(!json.contains("tags"));
+        assert!(!json.contains("metadata"));
+
+        // Round-trips through the archive's line-based reader.
+        let parsed: TraceRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, "abc");
+        assert!(parsed.tags.is_empty());
+    }
+}

--- a/capsules/capsule-trace/src/lib.rs
+++ b/capsules/capsule-trace/src/lib.rs
@@ -248,7 +248,8 @@ fn append(record: &TraceRecord) -> Result<(), SysError> {
     if !content.is_empty() && !content.ends_with('\n') {
         content.push('\n');
     }
-    content.push_str(&serde_json::to_string(record).map_err(|e| SysError::ApiError(e.to_string()))?);
+    content
+        .push_str(&serde_json::to_string(record).map_err(|e| SysError::ApiError(e.to_string()))?);
     content.push('\n');
 
     fs::write(&path, content.as_bytes())?;

--- a/capsules/capsule-trace/src/time.rs
+++ b/capsules/capsule-trace/src/time.rs
@@ -1,0 +1,97 @@
+//! RFC 3339 timestamp formatting without pulling in `chrono`.
+//!
+//! Chrono is small but not free in a `opt-level = "z"` WASM build, and this
+//! capsule only ever needs one strftime-shaped operation. The
+//! civil-from-days conversion below is Howard Hinnant's branchless
+//! POSIX-day-to-Gregorian-date algorithm, the canonical reference
+//! implementation (same technique `aos-users` uses for its own timestamps).
+
+/// Render an RFC 3339 timestamp for the current host wallclock.
+///
+/// On wasm32 this calls the SDK `time::now()` host fn; on every other
+/// target (host-target unit tests) it reads `std::time::SystemTime`
+/// directly. Either source's failure mode falls back to the Unix epoch —
+/// records stay structurally valid with an obviously-fake timestamp the
+/// operator can grep for.
+#[must_use]
+pub(crate) fn now_rfc3339() -> String {
+    let millis = current_unix_millis();
+    let secs = (millis / 1000) as i64;
+    let sub_ms = (millis % 1000) as u32;
+    format_rfc3339(secs, sub_ms)
+}
+
+#[cfg(target_family = "wasm")]
+fn current_unix_millis() -> u128 {
+    match astrid_sdk::prelude::time::now() {
+        Ok(t) => t
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_millis()),
+        Err(_) => 0,
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn current_unix_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_millis())
+}
+
+/// Format a POSIX timestamp as RFC 3339 (`YYYY-MM-DDTHH:MM:SS.mmmZ`).
+/// Standalone so tests can drive it deterministically.
+#[must_use]
+pub(crate) fn format_rfc3339(unix_secs: i64, sub_ms: u32) -> String {
+    let total_days = unix_secs.div_euclid(86_400);
+    let rem_secs = unix_secs.rem_euclid(86_400) as u32;
+    let hour = rem_secs / 3_600;
+    let minute = (rem_secs % 3_600) / 60;
+    let second = rem_secs % 60;
+    let (year, month, day) = days_to_ymd(total_days);
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{sub_ms:03}Z")
+}
+
+/// Convert a day index relative to 1970-01-01 into `(year, month, day)`.
+fn days_to_ymd(days: i64) -> (i32, u32, u32) {
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year_adj = if m <= 2 { y + 1 } else { y };
+    (year_adj as i32, m as u32, d as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc3339_epoch() {
+        assert_eq!(format_rfc3339(0, 0), "1970-01-01T00:00:00.000Z");
+    }
+
+    #[test]
+    fn rfc3339_known_date() {
+        assert_eq!(
+            format_rfc3339(1_768_480_496, 789),
+            "2026-01-15T12:34:56.789Z"
+        );
+    }
+
+    #[test]
+    fn rfc3339_y2038_safe() {
+        assert_eq!(format_rfc3339(2_147_483_647, 0), "2038-01-19T03:14:07.000Z");
+    }
+
+    #[test]
+    fn rfc3339_lexicographic_order_matches_time_order() {
+        let earlier = format_rfc3339(1_768_480_000, 0);
+        let later = format_rfc3339(1_768_480_496, 789);
+        assert!(earlier < later, "string comparison must match time order");
+    }
+}


### PR DESCRIPTION
## What

New first-party capsule: `capsule-trace` (`aos-trace`), a durable trace/evaluation archive for agents.

This directly fills a gap named in `docs/meta-harness.md`, which lists as a next step: "a unified inventory of harness artifacts, durable trace/evaluation archives." Today nothing in the capsule set gives an agent or Forge-built proposer a typed way to persist a candidate's source/reasoning, task outcome, score, and cost as inspectable experience across sessions — this capsule is that surface.

## Tools

- `record_trace` — append a `trace` or `evaluation` record (summary, outcome, score, cost, tags, candidate id, source ref, optional 8KB-capped `metadata`). Returns the assigned `id`/`ts`.
- `list_traces` — filtered (`kind`, `candidate_id`, `tag`, `since`), summarized, newest-first listing capped at 100 records — bounded so it can't flood the agent's context window as the archive grows.
- `get_trace` — fetch one full record by `id`.

## Design

- **Storage**: append-only JSONL at `cwd://{cwd_dir}/trace.jsonl`, reusing the `cwd_dir` env convention `aos-memory` already uses.
- **Capabilities**: `fs_read = ["cwd://"]`, `fs_write = ["cwd://"]` only — no `net`, no `home://`, no prompt injection. Least-privilege, matching the `capsule-fs`/`capsule-http` pattern.
- **No edit/delete tool** — archived experience is retained evidence, not scratch state, by design.
- Modeled directly on `capsule-http` and `capsule-memory` (manifest shape, `#[capsule]`/`#[astrid::tool]` usage, RFC 3339 timestamp helper ported from `capsule-users/src/time.rs` to avoid a `chrono` dependency in the WASM build).

## Testing

Unit tests included for truncation, kind validation, summary serialization (metadata omission), and RFC 3339 formatting/ordering. Not yet built/run against the real `wasm32-unknown-unknown` toolchain or `astrid capsule build` in this environment — CI (`ci.yml`, mirrored from `capsule-http`) will do that on push.

## Not done yet

- No `.capsule` release workflow validation (release.yml mirrored from capsule-http, untested).
- No manual `capsule_doctor`/`validate_manifest` run against Forge — recommend running that before merge.

Opened as a draft-style PR against `main`, not pushed directly — please review the manifest capability grant and tool surface before merging.