### PR TITLE
Add Novita AI as a provider option

### DIFF
--- a/capsules/capsule-openai-compat/README.md
+++ b/capsules/capsule-openai-compat/README.md
@@ -19,6 +19,7 @@ Configure `base_url` to point at any compatible provider:
 | Mistral | `https://api.mistral.ai` | |
 | DeepSeek | `https://api.deepseek.com` | |
 | Fireworks | `https://api.fireworks.ai/inference` | |
+| Novita | `https://api.novita.ai/openai` | |
 | LM Studio | `http://localhost:1234` | Requires operator local-egress exemption -- see below |
 | vLLM | `http://localhost:8000` | Requires operator local-egress exemption -- see below |
 | llama.cpp | `http://localhost:8080` | Requires operator local-egress exemption -- see below |

--- a/capsules/capsule-openai-compat/src/lib.rs
+++ b/capsules/capsule-openai-compat/src/lib.rs
@@ -17,6 +17,7 @@
 //! - Mistral: `https://api.mistral.ai`
 //! - DeepSeek: `https://api.deepseek.com`
 //! - Fireworks: `https://api.fireworks.ai/inference`
+//! - Novita: `https://api.novita.ai/openai`
 
 mod schemas;
 


### PR DESCRIPTION
## Summary

- Adds Novita AI as a provider option.

## Validation

Compared against the baseline on `913764d53345`: unverified_locally. Pre-existing failures are left as-is.

## Reviewer Notes

- This is a documentation-only change: two lines added to the existing OpenAI-compatible provider table (README.md) and the matching doc comment in src/lib.rs. No Rust logic, tests, or Capsule.toml/Distro.toml files were touched.
- I was not able to run `cargo build` / `cargo test` in my environment for this change (unrelated local resource constraint) and have not verified compilation. Given the change is limited to two doc-comment/table lines, the risk of a build regression is low but unverified.
- I have not made a live authenticated request to Novita's chat/completions endpoint; I only confirmed via unauthenticated requests that `https://api.novita.ai/openai/v1/models` returns 200 and `https://api.novita.ai/openai/v1/chat/completions` returns 403 (auth required) rather than 404, which indicates the path is correct for this capsule's `{base_url}/v1/chat/completions` and `{base_url}/v1/models` convention.
- I did not implement Novita as a first-class capsule (separate crate, `astrid:llm` export, `Distro.toml` entry) — only the documentation listing. A maintainer may prefer that larger scope, or may prefer to reject a docs-only entry as too small to be worth reviewing.
- This repository requires a signed CLA (per CONTRIBUTING.md); the CLA bot will prompt automatically on PR open, so no separate action was taken before this branch was prepared.
