### PR TITLE
feat(hooks): split frontend protocol adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aos-hook-adapter-oracle"
+version = "0.1.0"
+dependencies = [
+ "astrid-sdk",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "aos-hook-bridge"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "capsules/capsule-forge",
     "capsules/capsule-fs",
     "capsules/capsule-hook-bridge",
+    "capsules/capsule-hook-adapter-oracle",
     "capsules/capsule-meta-harness",
     "capsules/capsule-http",
     "capsules/capsule-identity",

--- a/capsules/capsule-hook-adapter-oracle/.cargo/config.toml
+++ b/capsules/capsule-hook-adapter-oracle/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "wasm32-unknown-unknown"
+
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg=getrandom_backend=\"custom\""]

--- a/capsules/capsule-hook-adapter-oracle/Capsule.toml
+++ b/capsules/capsule-hook-adapter-oracle/Capsule.toml
@@ -1,0 +1,25 @@
+[package]
+name = "aos-hook-adapter-oracle"
+version = "0.1.0"
+description = "Authenticated Codex, Claude, and Grok hook adapter for the canonical AOS hook bus"
+authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
+astrid-version = ">=0.10.1"
+
+[[component]]
+id = "hook-adapter-oracle"
+file = "aos_hook_adapter_oracle.wasm"
+type = "executable"
+
+[publish]
+"hook.v1.event.*" = { wit = "@unicity-astrid/wit/hook/hook-event-request" }
+"oracle.v1.hook.response.*" = { wit = "opaque" }
+
+[subscribe]
+# Exactly one adapter owns each authenticated frontend topic. No priority is
+# set: these are protocol ingress points, not a middleware chain.
+"oracle.v1.hook.validated.codex" = { wit = "opaque", handler = "on_codex_hook" }
+"oracle.v1.hook.validated.claude" = { wit = "opaque", handler = "on_claude_hook" }
+"oracle.v1.hook.validated.grok" = { wit = "opaque", handler = "on_grok_hook" }
+
+# Dynamic, correlation-scoped response collection for prompt-context hooks.
+"hook.v1.response.message_received.*" = { wit = "opaque" }

--- a/capsules/capsule-hook-adapter-oracle/Cargo.toml
+++ b/capsules/capsule-hook-adapter-oracle/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "aos-hook-adapter-oracle"
+version = "0.1.0"
+edition = "2024"
+description = "Authenticated Oracle frontend hooks to canonical AOS hook events"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+astrid-sdk = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/capsules/capsule-hook-adapter-oracle/README.md
+++ b/capsules/capsule-hook-adapter-oracle/README.md
@@ -1,0 +1,15 @@
+# aos-hook-adapter-oracle
+
+Translates authenticated Codex, Claude, and Grok frontend hook envelopes into
+the canonical AOS `hook.v1.event.*` protocol.
+
+The adapter owns protocol translation only. It does not own downstream hook
+policy and it does not turn observation events into authorization decisions.
+`user_prompt_submit` collects bounded `additional_context` replies for the exact
+host turn. `pre_tool_use` and `permission_request` are observation-only on this
+relay; binding native-tool denial remains on the `astrid-gate`/broker decision
+path, whose response schema can express deny.
+
+Canonical hook subscribers should normally omit `priority`, preserving
+independent fan-out. See [`docs/hooks.md`](../../docs/hooks.md) for the complete
+composition and priority contract.

--- a/capsules/capsule-hook-adapter-oracle/rust-toolchain.toml
+++ b/capsules/capsule-hook-adapter-oracle/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.94.0"
+targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]

--- a/capsules/capsule-hook-adapter-oracle/src/lib.rs
+++ b/capsules/capsule-hook-adapter-oracle/src/lib.rs
@@ -1,0 +1,499 @@
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+#![deny(unreachable_pub)]
+#![warn(missing_docs)]
+
+//! Authenticated Oracle frontend hooks to canonical AOS hook events.
+//!
+//! `capsule-mcp` authenticates the host route and strips its bearer token.
+//! This capsule then binds each exact validated topic to its expected frontend,
+//! verifies the kernel-stamped principal, translates the frontend event, and
+//! returns only the response shape that frontend transport supports.
+
+use astrid_sdk::contracts::hook::HookEventRequest;
+use astrid_sdk::prelude::*;
+use serde::{Deserialize, Serialize};
+
+const HOST_HOOK_COLLECT_DEADLINE_MS: u64 = 1_000;
+const HOOK_QUIESCENCE_MS: u64 = 25;
+const MAX_HOST_PAYLOAD_BYTES: usize = 1024 * 1024;
+const MAX_CANONICAL_EVENT_BYTES: usize = 1024 * 1024;
+const MAX_HOST_CONTEXT_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Frontend {
+    Codex,
+    Claude,
+    Grok,
+}
+
+impl Frontend {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Codex => "codex",
+            Self::Claude => "claude",
+            Self::Grok => "grok",
+        }
+    }
+
+    fn mapping(self, event: &str) -> Option<HookMapping> {
+        // Separate tables are deliberate. The upstream plugins normalize onto
+        // common names today, but each frontend may evolve independently
+        // without weakening another adapter's accepted surface.
+        match self {
+            Self::Codex => codex_mapping(event),
+            Self::Claude => claude_mapping(event),
+            Self::Grok => grok_mapping(event),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResponseMode {
+    /// Publish the canonical event but do not solicit a reply.
+    Observe,
+    /// Collect bounded `additional_context` for the exact host turn.
+    AdditionalContext,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HookMapping {
+    hook: &'static str,
+    response: ResponseMode,
+}
+
+const fn observe(hook: &'static str) -> HookMapping {
+    HookMapping {
+        hook,
+        response: ResponseMode::Observe,
+    }
+}
+
+const fn context(hook: &'static str) -> HookMapping {
+    HookMapping {
+        hook,
+        response: ResponseMode::AdditionalContext,
+    }
+}
+
+fn common_mapping(event: &str) -> Option<HookMapping> {
+    match event {
+        "session_start" => Some(observe("session_start")),
+        "user_prompt_submit" => Some(context("message_received")),
+        // This relay's outer response schema carries context only. These are
+        // observations here; binding native-tool decisions use astrid-gate.
+        "pre_tool_use" | "permission_request" => Some(observe("before_tool_call")),
+        "post_tool_use" => Some(observe("after_tool_call")),
+        "pre_compact" => Some(observe("on_compaction_started")),
+        "post_compact" => Some(observe("on_compaction_completed")),
+        "subagent_start" => Some(observe("subagent_start")),
+        "subagent_stop" => Some(observe("subagent_stop")),
+        "stop" | "session_end" => Some(observe("session_end")),
+        _ => None,
+    }
+}
+
+fn codex_mapping(event: &str) -> Option<HookMapping> {
+    common_mapping(event)
+}
+
+fn claude_mapping(event: &str) -> Option<HookMapping> {
+    common_mapping(event)
+}
+
+fn grok_mapping(event: &str) -> Option<HookMapping> {
+    common_mapping(event)
+}
+
+#[derive(Debug, Deserialize)]
+struct OracleHookEvent {
+    schema_version: u8,
+    principal_id: String,
+    host: String,
+    session_id: String,
+    event: String,
+    correlation_id: String,
+    route_id: String,
+    delivery_id: String,
+    #[serde(default)]
+    turn_id: Option<String>,
+    #[serde(default)]
+    workspace_id: Option<String>,
+    payload: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+struct OracleHookResponse<'a> {
+    schema_version: u8,
+    principal_id: &'a str,
+    host: &'a str,
+    session_id: &'a str,
+    event: &'a str,
+    correlation_id: &'a str,
+    route_id: &'a str,
+    delivery_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CanonicalOraclePayload<'a> {
+    principal_id: &'a str,
+    host: &'a str,
+    session_id: &'a str,
+    source_event: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    turn_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_id: Option<&'a str>,
+    payload: &'a serde_json::Value,
+}
+
+fn is_clean_segment(value: &str, max: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+fn is_lower_hex(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn validate_oracle_hook(
+    expected: Frontend,
+    event: &OracleHookEvent,
+) -> Result<HookMapping, &'static str> {
+    if event.schema_version != 1 {
+        return Err("unsupported schema version");
+    }
+    // Bind the payload host to the exact topic handler. A valid `claude`
+    // envelope delivered on the Codex topic is still invalid.
+    if event.host != expected.name() {
+        return Err("host does not match validated topic");
+    }
+    let Some(mapping) = expected.mapping(&event.event) else {
+        return Err("unsupported host event");
+    };
+    if !is_clean_segment(&event.session_id, 128)
+        || !is_clean_segment(&event.event, 128)
+        || !is_clean_segment(&event.delivery_id, 128)
+    {
+        return Err("invalid routed segment");
+    }
+    if !is_lower_hex(&event.route_id, 64) || !is_lower_hex(&event.correlation_id, 32) {
+        return Err("invalid route identifier");
+    }
+    if event.delivery_id != format!("{}-{}", event.route_id, event.correlation_id) {
+        return Err("delivery identifier does not bind route and correlation");
+    }
+    if event
+        .turn_id
+        .as_deref()
+        .is_some_and(|value| value.is_empty() || value.len() > 256)
+        || event
+            .workspace_id
+            .as_deref()
+            .is_some_and(|value| !is_clean_segment(value, 128))
+    {
+        return Err("invalid optional routing metadata");
+    }
+    if serde_json::to_vec(&event.payload)
+        .map_or(true, |payload| payload.len() > MAX_HOST_PAYLOAD_BYTES)
+    {
+        return Err("host payload exceeds limit");
+    }
+    Ok(mapping)
+}
+
+fn push_context(contexts: &mut Vec<String>, total: &mut usize, context: &str) -> bool {
+    let separator = usize::from(!contexts.is_empty()) * 2;
+    let Some(next_total) = total
+        .checked_add(separator)
+        .and_then(|value| value.checked_add(context.len()))
+    else {
+        return false;
+    };
+    if next_total > MAX_HOST_CONTEXT_BYTES {
+        return false;
+    }
+    contexts.push(context.to_owned());
+    *total = next_total;
+    true
+}
+
+fn collect_additional_context(
+    subscription: &ipc::Subscription,
+    reply_topic: &str,
+    principal: &str,
+) -> Result<Option<String>, SysError> {
+    let mut contexts = Vec::new();
+    let mut context_bytes = 0;
+    let start = time::monotonic();
+    loop {
+        let elapsed_ms = u64::try_from((time::monotonic().saturating_sub(start)).as_millis())
+            .unwrap_or(HOST_HOOK_COLLECT_DEADLINE_MS);
+        if elapsed_ms >= HOST_HOOK_COLLECT_DEADLINE_MS {
+            break;
+        }
+        let remaining = if contexts.is_empty() {
+            HOST_HOOK_COLLECT_DEADLINE_MS - elapsed_ms
+        } else {
+            HOOK_QUIESCENCE_MS.min(HOST_HOOK_COLLECT_DEADLINE_MS - elapsed_ms)
+        };
+        match subscription.recv(remaining) {
+            Ok(poll) if poll.messages.is_empty() => break,
+            Ok(poll) => {
+                if poll.dropped != 0 || poll.lagged != 0 {
+                    log::warn(format!(
+                        "hook-adapter-oracle: incomplete context fan-out on {reply_topic}; dropping all partial context"
+                    ));
+                    return Ok(None);
+                }
+                for message in poll.messages {
+                    if message.topic != reply_topic
+                        || message.principal.verified() != Some(principal)
+                    {
+                        log::warn(format!(
+                            "hook-adapter-oracle: dropping mismatched context reply on {reply_topic}"
+                        ));
+                        continue;
+                    }
+                    match serde_json::from_str::<serde_json::Value>(&message.payload) {
+                        Ok(value) => {
+                            if let Some(context) = value
+                                .get("additional_context")
+                                .and_then(serde_json::Value::as_str)
+                                .filter(|context| !context.trim().is_empty())
+                                && !push_context(&mut contexts, &mut context_bytes, context)
+                            {
+                                log::warn(format!(
+                                    "hook-adapter-oracle: dropping context beyond {MAX_HOST_CONTEXT_BYTES} bytes"
+                                ));
+                            }
+                        }
+                        Err(error) => log::warn(format!(
+                            "hook-adapter-oracle: dropping malformed reply on {reply_topic}: {error}"
+                        )),
+                    }
+                }
+            }
+            Err(SysError::HostError(message)) if message.contains("Timeout") => break,
+            Err(error) => return Err(error),
+        }
+    }
+    if contexts.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(contexts.join("\n\n")))
+    }
+}
+
+fn canonical_request(
+    event: &OracleHookEvent,
+    mapping: HookMapping,
+) -> Result<HookEventRequest, SysError> {
+    let payload = CanonicalOraclePayload {
+        principal_id: &event.principal_id,
+        host: &event.host,
+        session_id: &event.session_id,
+        source_event: &event.event,
+        turn_id: event.turn_id.as_deref(),
+        workspace_id: event.workspace_id.as_deref(),
+        payload: &event.payload,
+    };
+    let request = HookEventRequest {
+        hook: mapping.hook.to_owned(),
+        payload: serde_json::to_string(&payload)?,
+        correlation_id: matches!(mapping.response, ResponseMode::AdditionalContext)
+            .then(|| event.correlation_id.clone()),
+    };
+    if serde_json::to_vec(&request)?.len() > MAX_CANONICAL_EVENT_BYTES {
+        return Err(SysError::HostError(
+            "canonical hook event exceeds IPC payload limit".to_owned(),
+        ));
+    }
+    Ok(request)
+}
+
+fn dispatch_oracle_hook(
+    event: &OracleHookEvent,
+    mapping: HookMapping,
+) -> Result<Option<String>, SysError> {
+    let event_topic = format!("hook.v1.event.{}", mapping.hook);
+    let request = canonical_request(event, mapping)?;
+    if matches!(mapping.response, ResponseMode::Observe) {
+        ipc::publish_json(&event_topic, &request)?;
+        return Ok(None);
+    }
+
+    let reply_topic = format!("hook.v1.response.{}.{}", mapping.hook, event.correlation_id);
+    let subscription = ipc::subscribe(&reply_topic)?;
+    ipc::publish_json(&event_topic, &request)?;
+    collect_additional_context(&subscription, &reply_topic, &event.principal_id)
+}
+
+fn handle_oracle_hook(expected: Frontend, payload: serde_json::Value) -> Result<(), SysError> {
+    let event: OracleHookEvent = match serde_json::from_value(payload) {
+        Ok(event) => event,
+        Err(error) => {
+            log::warn(format!(
+                "hook-adapter-oracle: dropping malformed {} hook: {error}",
+                expected.name()
+            ));
+            return Ok(());
+        }
+    };
+    let mapping = match validate_oracle_hook(expected, &event) {
+        Ok(mapping) => mapping,
+        Err(reason) => {
+            log::warn(format!(
+                "hook-adapter-oracle: dropping invalid {} hook '{}': {reason}",
+                expected.name(),
+                event.event
+            ));
+            return Ok(());
+        }
+    };
+    let caller = runtime::caller()?;
+    if caller.principal.as_deref() != Some(event.principal_id.as_str()) {
+        log::warn(format!(
+            "hook-adapter-oracle: dropping principal mismatch for {}",
+            expected.name()
+        ));
+        return Ok(());
+    }
+
+    let context = dispatch_oracle_hook(&event, mapping)?;
+    ipc::publish_json(
+        &format!("oracle.v1.hook.response.{}", event.delivery_id),
+        &OracleHookResponse {
+            schema_version: 1,
+            principal_id: &event.principal_id,
+            host: &event.host,
+            session_id: &event.session_id,
+            event: &event.event,
+            correlation_id: &event.correlation_id,
+            route_id: &event.route_id,
+            delivery_id: &event.delivery_id,
+            context,
+        },
+    )
+}
+
+/// Oracle hook protocol adapter.
+#[derive(Default)]
+pub struct OracleHookAdapter;
+
+#[capsule]
+impl OracleHookAdapter {
+    /// Translate a token-validated Codex hook.
+    #[astrid::interceptor("on_codex_hook")]
+    pub fn on_codex_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        handle_oracle_hook(Frontend::Codex, payload)
+    }
+
+    /// Translate a token-validated Claude hook.
+    #[astrid::interceptor("on_claude_hook")]
+    pub fn on_claude_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        handle_oracle_hook(Frontend::Claude, payload)
+    }
+
+    /// Translate a token-validated Grok hook.
+    #[astrid::interceptor("on_grok_hook")]
+    pub fn on_grok_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        handle_oracle_hook(Frontend::Grok, payload)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host_event(host: &str) -> OracleHookEvent {
+        let route_id = "a".repeat(64);
+        let correlation_id = "b".repeat(32);
+        OracleHookEvent {
+            schema_version: 1,
+            principal_id: "codex-code".to_owned(),
+            host: host.to_owned(),
+            session_id: "codex-session".to_owned(),
+            event: "user_prompt_submit".to_owned(),
+            delivery_id: format!("{route_id}-{correlation_id}"),
+            correlation_id,
+            route_id,
+            turn_id: Some("turn-one".to_owned()),
+            workspace_id: Some("workspace-one".to_owned()),
+            payload: serde_json::json!({"prompt": "hello"}),
+        }
+    }
+
+    #[test]
+    fn each_validated_topic_binds_its_exact_host() {
+        assert!(validate_oracle_hook(Frontend::Codex, &host_event("codex")).is_ok());
+        assert_eq!(
+            validate_oracle_hook(Frontend::Codex, &host_event("claude")),
+            Err("host does not match validated topic")
+        );
+    }
+
+    #[test]
+    fn prompt_is_context_bearing_but_pretool_is_observation_only() {
+        assert_eq!(
+            Frontend::Claude.mapping("user_prompt_submit"),
+            Some(context("message_received"))
+        );
+        assert_eq!(
+            Frontend::Claude.mapping("pre_tool_use"),
+            Some(observe("before_tool_call"))
+        );
+    }
+
+    #[test]
+    fn delivery_binds_route_and_correlation() {
+        let mut event = host_event("grok");
+        assert!(validate_oracle_hook(Frontend::Grok, &event).is_ok());
+        event.delivery_id = format!("{}-{}", "c".repeat(64), event.correlation_id);
+        assert_eq!(
+            validate_oracle_hook(Frontend::Grok, &event),
+            Err("delivery identifier does not bind route and correlation")
+        );
+    }
+
+    #[test]
+    fn event_and_session_cannot_add_topic_segments() {
+        let mut event = host_event("codex");
+        event.session_id = "codex.other".to_owned();
+        assert_eq!(
+            validate_oracle_hook(Frontend::Codex, &event),
+            Err("invalid routed segment")
+        );
+    }
+
+    #[test]
+    fn combined_context_stays_inside_relay_limit() {
+        let mut contexts = Vec::new();
+        let mut total = 0;
+        assert!(push_context(
+            &mut contexts,
+            &mut total,
+            &"a".repeat(MAX_HOST_CONTEXT_BYTES - 3)
+        ));
+        assert!(push_context(&mut contexts, &mut total, "b"));
+        assert_eq!(contexts.join("\n\n").len(), MAX_HOST_CONTEXT_BYTES);
+        assert!(!push_context(&mut contexts, &mut total, "c"));
+    }
+
+    #[test]
+    fn canonical_request_keeps_observation_uncorrelated() {
+        let event = host_event("codex");
+        let request = canonical_request(&event, observe("before_tool_call")).unwrap();
+        assert!(request.correlation_id.is_none());
+        let request = canonical_request(&event, context("message_received")).unwrap();
+        assert_eq!(request.correlation_id, Some(event.correlation_id));
+    }
+}

--- a/capsules/capsule-hook-bridge/Capsule.toml
+++ b/capsules/capsule-hook-bridge/Capsule.toml
@@ -15,13 +15,16 @@ type = "executable"
 
 [publish]
 "hook.v1.event.*" = { wit = "@unicity-astrid/wit/hook/hook-event-request" }
-"oracle.v1.hook.response.*" = { wit = "opaque" }
 
 [subscribe]
-"oracle.v1.hook.validated.codex" = { wit = "opaque", handler = "on_codex_hook" }
-"oracle.v1.hook.validated.claude" = { wit = "opaque", handler = "on_claude_hook" }
-"oracle.v1.hook.validated.grok" = { wit = "opaque", handler = "on_grok_hook" }
-"hook.v1.response.message_received.*" = { wit = "opaque" }
+# Correlation-scoped replies collected inline by the four binding lifecycle
+# mappings below. Keep these arity-fixed instead of granting the entire hook
+# response namespace.
+"hook.v1.response.before_tool_call.*" = { wit = "opaque" }
+"hook.v1.response.after_tool_call.*" = { wit = "opaque" }
+"hook.v1.response.tool_result_persist.*" = { wit = "opaque" }
+"hook.v1.response.message_sending.*" = { wit = "opaque" }
+
 "astrid.v1.lifecycle.session_created" = { wit = "@unicity-astrid/wit/hook/lifecycle-event", handler = "on_session_created" }
 "astrid.v1.lifecycle.session_ended" = { wit = "@unicity-astrid/wit/hook/lifecycle-event", handler = "on_session_ended" }
 "astrid.v1.lifecycle.tool_call_started" = { wit = "@unicity-astrid/wit/hook/lifecycle-event", handler = "on_tool_call_started" }

--- a/capsules/capsule-hook-bridge/README.md
+++ b/capsules/capsule-hook-bridge/README.md
@@ -3,66 +3,19 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**The lifecycle-to-hook mapper for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
+The canonical Astrid lifecycle-to-hook router for Unicity AOS.
 
-In the OS model, this capsule is the interrupt dispatcher. The kernel emits raw lifecycle events. This capsule translates each one to a named semantic hook, fans out to subscriber capsules via `hooks::trigger`, and applies a merge strategy to the collected responses.
+Frontend protocols are translated by adapter capsules such as
+`aos-hook-adapter-oracle`. This capsule maps only kernel lifecycle events onto
+`hook.v1.event.*`, collects correlation-scoped responses for binding lifecycle
+hooks, and applies their merge semantics.
 
-This is a **policy** capsule. It owns the event-to-hook mapping table and the merge rules. The fan-out mechanism lives in the kernel's `astrid_trigger_hook` host function.
+Observation hooks are priority-free fan-out. Binding lifecycle hooks use an
+explicit request/response protocol: `before_tool_call` is deny-wins and
+last-transform-wins; result/content transformations use last-non-null.
 
-## Event mappings
-
-### Session
-
-| Lifecycle Event | Hook Name | Merge |
-|---|---|---|
-| `session_created` | `session_start` | None |
-| `session_ended` | `session_end` | None |
-
-### Tool
-
-| Lifecycle Event | Hook Name | Merge |
-|---|---|---|
-| `tool_call_started` | `before_tool_call` | ToolCallBefore |
-| `tool_call_completed` | `after_tool_call` | LastNonNull(`modified_result`) |
-| `tool_result_persisting` | `tool_result_persist` | LastNonNull(`transformed_result`) |
-
-### Message
-
-| Lifecycle Event | Hook Name | Merge |
-|---|---|---|
-| `message_received` | `message_received` | None |
-| `message_sending` | `message_sending` | LastNonNull(`modified_content`) |
-| `message_sent` | `message_sent` | None |
-
-### Sub-agent
-
-| Lifecycle Event | Hook Name | Merge |
-|---|---|---|
-| `sub_agent_spawned` | `subagent_start` | None |
-| `sub_agent_completed/failed/cancelled` | `subagent_stop` | None |
-
-### Context and kernel
-
-| Lifecycle Event | Hook Name | Merge |
-|---|---|---|
-| `context_compaction_started` | `on_compaction_started` | None |
-| `context_compaction_completed` | `on_compaction_completed` | None |
-| `kernel_started` | `kernel_start` | None |
-| `kernel_shutdown` | `kernel_stop` | None |
-
-## Merge strategies
-
-**None** - Fire-and-forget. Subscriber responses are discarded. Used for observation-only hooks.
-
-**ToolCallBefore** - Any `skip: true` wins. Last non-null `modified_params` wins. Lets any subscriber block a tool call, and lets the last subscriber to touch the params have final say.
-
-**LastNonNull** - Last non-null value for a named field wins. Used for `after_tool_call`, `tool_result_persist`, and `message_sending`.
-
-## Development
-
-```bash
-cargo build --target wasm32-unknown-unknown --release
-```
+See [`docs/hooks.md`](../../docs/hooks.md) for the architecture, response
+semantics, extension model, and priority rules.
 
 ## License
 

--- a/capsules/capsule-hook-bridge/src/lib.rs
+++ b/capsules/capsule-hook-bridge/src/lib.rs
@@ -3,158 +3,39 @@
 #![deny(unreachable_pub)]
 #![warn(missing_docs)]
 
-//! Hook Bridge capsule — maps lifecycle events to semantic hooks.
+//! Canonical Astrid lifecycle-to-hook router.
 //!
-//! The kernel dispatches lifecycle events (e.g. `tool_call_started`,
-//! `session_created`) to this capsule via interceptors. The Hook Bridge
-//! maps each event to a semantic hook name, fans out to subscriber
-//! capsules over IPC, and applies merge strategies to the collected
-//! responses.
-//!
-//! # Architecture (post per-domain WIT split)
-//!
-//! ```text
-//! Kernel EventBus → EventDispatcher → Hook Bridge (this capsule)
-//!                                        ↓ ipc::publish("hook.v1.event.<hook>", req)
-//!                                     Subscriber capsules A, B, C...
-//!                                        ↓ publish "hook.v1.response.<hook>.<corr_id>"
-//!                                     Hook Bridge collects responses, applies merge
-//!                                        ↓ returns merged result via interceptor reply
-//! ```
-//!
-//! Before the per-domain WIT split, fan-out was driven by the
-//! `sys::trigger-hook` host fn (removed in `sdk-rust` 0.7). The kernel
-//! iterated `CapsuleRegistry` itself and returned a concatenated list
-//! of responses. Post-split, fan-out is a capsule-to-capsule IPC
-//! convention: the Hook Bridge publishes a request, listens on a
-//! correlation-keyed reply topic, and applies the merge.
-//!
-//! This is a **policy** capsule: it defines which lifecycle events map
-//! to which hook names and how responses are merged.
+//! Frontend-specific protocols are translated by adapter capsules before they
+//! reach the canonical `hook.v1.*` bus. This capsule owns only Astrid lifecycle
+//! mapping and canonical response merge policy.
 
-use astrid_sdk::contracts::hook::HookEventRequest;
+use astrid_sdk::contracts::hook::{HookEventRequest, HookResult};
 use astrid_sdk::prelude::*;
-use serde::{Deserialize, Serialize};
 
-/// Hard deadline for collecting hook responses, per dispatch.
-///
-/// The bus capped `request_response` at 60 s; we use a much shorter
-/// window because interceptors block the lifecycle event chain and any
-/// hook handler that takes >1 s is misbehaving. If no responses arrive
-/// in this window, we return the merge of whatever did arrive (which
-/// may be the `MergeSemantics::None` result).
 const HOOK_COLLECT_DEADLINE_MS: u64 = 5_000;
-
-/// Once one responder has answered, allow a short window for peers in the
-/// same fan-out before returning. This avoids paying the full deadline after
-/// the common single-responder case.
 const HOOK_QUIESCENCE_MS: u64 = 25;
+const MAX_HOOK_RESPONSE_BYTES: usize = 1024 * 1024;
 
-/// Host prompt hooks are latency-sensitive and all expected responders are
-/// already-loaded local capsules.
-const HOST_HOOK_COLLECT_DEADLINE_MS: u64 = 1_000;
-
-const MAX_HOST_PAYLOAD_BYTES: usize = 1024 * 1024;
-const MAX_HOST_CONTEXT_BYTES: usize = 64 * 1024;
-
-/// Merged result from hook fan-out.
-///
-/// Uses `serde_json::Value` for `data` (not `String`) to preserve the
-/// wire format: consumers expect `data` as a nested JSON object, not a
-/// JSON-encoded string. The WIT contract describes this as
-/// `option<string>` for schema purposes, but the Rust type must match
-/// what goes on the wire.
-#[derive(Serialize)]
-pub struct HookResult {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    skip: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    data: Option<serde_json::Value>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OracleHookEvent {
-    schema_version: u8,
-    principal_id: String,
-    host: String,
-    session_id: String,
-    event: String,
-    correlation_id: String,
-    route_id: String,
-    delivery_id: String,
-    #[serde(default)]
-    turn_id: Option<String>,
-    #[serde(default)]
-    workspace_id: Option<String>,
-    payload: serde_json::Value,
-}
-
-#[derive(Debug, Serialize)]
-struct OracleHookResponse<'a> {
-    schema_version: u8,
-    principal_id: &'a str,
-    host: &'a str,
-    session_id: &'a str,
-    event: &'a str,
-    correlation_id: &'a str,
-    route_id: &'a str,
-    delivery_id: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    context: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct CanonicalOraclePayload<'a> {
-    principal_id: &'a str,
-    host: &'a str,
-    session_id: &'a str,
-    source_event: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    turn_id: Option<&'a str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    workspace_id: Option<&'a str>,
-    payload: &'a serde_json::Value,
-}
-
-// ── Merge Semantics ────────────────────────────────────────────────────────────────
-
-/// How interceptor responses are merged for a hook.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum MergeSemantics {
-    /// Fire-and-forget: responses are discarded.
     None,
-    /// `before_tool_call` specific: any `skip: true` → skip,
-    /// last non-null `modified_params` wins.
     ToolCallBefore,
-    /// Last non-null value for the named field wins.
     LastNonNull { field: &'static str },
 }
 
-/// A mapping from a lifecycle event to a hook name and merge strategy.
 struct HookMapping {
     hook_name: &'static str,
     merge: MergeSemantics,
 }
 
-// ── Hook Trigger Protocol ──────────────────────────────────────────────────────────
+#[derive(Default)]
+struct ResponseBatch {
+    values: Vec<serde_json::Value>,
+    complete: bool,
+}
 
-// The event published on `hook.v1.event.<hook_name>` is the canonical
-// `astrid:hook/hook-event-request` shape — `astrid_sdk::contracts::hook::HookEventRequest`,
-// shared with sage (the other producer) and the SDK consumer side. Per the
-// WIT, `payload` is the lifecycle event serialized as a JSON STRING (not an
-// inline value), so a subscriber using the canonical type / the SDK's
-// `HookEvent::payload::<T>()` can deserialize it. Subscribers reply on
-// `hook.v1.response.<hook_name>.<correlation_id>` when a correlation id is
-// present; absent => fire-and-forget.
-
-// ── Event-to-Hook Mapping Table ────────────────────────────────────────────────────
-
-/// Resolve the hook mapping for a given event type string.
-///
-/// Returns `None` for events that have no corresponding hook.
 fn mapping_for_event(event_type: &str) -> Option<HookMapping> {
     match event_type {
-        // Session lifecycle
         "astrid.v1.lifecycle.session_created" => Some(HookMapping {
             hook_name: "session_start",
             merge: MergeSemantics::None,
@@ -163,8 +44,6 @@ fn mapping_for_event(event_type: &str) -> Option<HookMapping> {
             hook_name: "session_end",
             merge: MergeSemantics::None,
         }),
-
-        // Tool hooks
         "astrid.v1.lifecycle.tool_call_started" => Some(HookMapping {
             hook_name: "before_tool_call",
             merge: MergeSemantics::ToolCallBefore,
@@ -181,8 +60,6 @@ fn mapping_for_event(event_type: &str) -> Option<HookMapping> {
                 field: "transformed_result",
             },
         }),
-
-        // Message hooks
         "astrid.v1.lifecycle.message_received" => Some(HookMapping {
             hook_name: "message_received",
             merge: MergeSemantics::None,
@@ -197,8 +74,6 @@ fn mapping_for_event(event_type: &str) -> Option<HookMapping> {
             hook_name: "message_sent",
             merge: MergeSemantics::None,
         }),
-
-        // Sub-agent hooks
         "astrid.v1.lifecycle.sub_agent_spawned" => Some(HookMapping {
             hook_name: "subagent_start",
             merge: MergeSemantics::None,
@@ -209,8 +84,6 @@ fn mapping_for_event(event_type: &str) -> Option<HookMapping> {
             hook_name: "subagent_stop",
             merge: MergeSemantics::None,
         }),
-
-        // Context compaction (broadcast-only observation hooks)
         "astrid.v1.lifecycle.context_compaction_started" => Some(HookMapping {
             hook_name: "on_compaction_started",
             merge: MergeSemantics::None,
@@ -219,8 +92,6 @@ fn mapping_for_event(event_type: &str) -> Option<HookMapping> {
             hook_name: "on_compaction_completed",
             merge: MergeSemantics::None,
         }),
-
-        // Kernel lifecycle
         "astrid.v1.lifecycle.kernel_started" => Some(HookMapping {
             hook_name: "kernel_start",
             merge: MergeSemantics::None,
@@ -229,132 +100,84 @@ fn mapping_for_event(event_type: &str) -> Option<HookMapping> {
             hook_name: "kernel_stop",
             merge: MergeSemantics::None,
         }),
-
-        _ => Option::None,
+        _ => None,
     }
 }
 
-// ── Merge Logic ────────────────────────────────────────────────────────────────────
-
-/// Apply merge semantics to a list of subscriber responses.
 fn apply_merge(merge: &MergeSemantics, responses: &[serde_json::Value]) -> HookResult {
     match merge {
         MergeSemantics::None => HookResult {
-            skip: Option::None,
-            data: Option::None,
+            skip: None,
+            data: None,
         },
-
         MergeSemantics::ToolCallBefore => {
             let mut skip = false;
-            let mut last_params: Option<serde_json::Value> = Option::None;
-
-            for resp in responses {
-                // Any response with skip: true wins
-                if resp.get("skip").and_then(|v| v.as_bool()).unwrap_or(false) {
-                    skip = true;
-                }
-                // Last non-null modified_params wins
-                if let Some(params) = resp.get("modified_params")
+            let mut last_params = None;
+            for response in responses {
+                skip |= response
+                    .get("skip")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
+                if let Some(params) = response.get("modified_params")
                     && !params.is_null()
                 {
                     last_params = Some(params.clone());
                 }
             }
-
             HookResult {
-                skip: if skip { Some(true) } else { Option::None },
-                data: last_params,
+                skip: skip.then_some(true),
+                data: last_params.map(|value| value.to_string()),
             }
         }
-
-        MergeSemantics::LastNonNull { field } => {
-            let mut last_value: Option<serde_json::Value> = Option::None;
-
-            for resp in responses {
-                if let Some(val) = resp.get(*field)
-                    && !val.is_null()
-                {
-                    last_value = Some(val.clone());
-                }
-            }
-
-            HookResult {
-                skip: Option::None,
-                data: last_value,
-            }
-        }
+        MergeSemantics::LastNonNull { field } => HookResult {
+            skip: None,
+            data: responses
+                .iter()
+                .filter_map(|response| response.get(*field))
+                .rfind(|value| !value.is_null())
+                .map(serde_json::Value::to_string),
+        },
     }
 }
 
-// ── Correlation IDs ────────────────────────────────────────────────────────────────
+fn merge_batch(merge: &MergeSemantics, batch: ResponseBatch) -> HookResult {
+    if batch.complete {
+        return apply_merge(merge, &batch.values);
+    }
 
-/// Generate a 16-byte hex correlation id from the host CSPRNG.
-///
-/// We can't depend on `uuid` directly (not re-exported from
-/// `astrid-sdk`), and using a monotonic timestamp would collide if two
-/// dispatches landed in the same nanosecond. `runtime::random_bytes` is
-/// the documented CSPRNG path.
+    // Never apply a partial transform. For the security-sensitive pre-tool
+    // hook, a transport integrity failure is a binding denial.
+    match merge {
+        MergeSemantics::ToolCallBefore => HookResult {
+            skip: Some(true),
+            data: None,
+        },
+        MergeSemantics::None | MergeSemantics::LastNonNull { .. } => HookResult {
+            skip: None,
+            data: None,
+        },
+    }
+}
+
 fn correlation_id() -> Result<String, SysError> {
     let bytes = runtime::random_bytes(16)?;
-    let mut s = String::with_capacity(32);
-    for b in bytes {
-        s.push(char::from_digit(u32::from(b >> 4), 16).unwrap_or('0'));
-        s.push(char::from_digit(u32::from(b & 0x0F), 16).unwrap_or('0'));
+    let mut output = String::with_capacity(32);
+    for byte in bytes {
+        output.push(char::from_digit(u32::from(byte >> 4), 16).unwrap_or('0'));
+        output.push(char::from_digit(u32::from(byte & 0x0f), 16).unwrap_or('0'));
     }
-    Ok(s)
+    Ok(output)
 }
 
-// ── Core Dispatch ──────────────────────────────────────────────────────────────────
-
-/// Dispatch a lifecycle event through the hook system.
-///
-/// 1. Look up the event-to-hook mapping.
-/// 2. For `MergeSemantics::None`: publish on
-///    `hook.v1.event.<hook_name>` fire-and-forget.
-/// 3. For merge cases: subscribe to a correlation-keyed reply topic,
-///    publish the event with the correlation id, collect responses
-///    until quiescence or deadline, apply the merge.
-fn dispatch_hook(
-    event_type: &str,
-    payload: &serde_json::Value,
-) -> Result<Option<HookResult>, SysError> {
-    let Some(mapping) = mapping_for_event(event_type) else {
-        // No hook mapping for this event — nothing to do.
-        return Ok(Option::None);
+fn collect_responses(
+    subscription: &ipc::Subscription,
+    reply_topic: &str,
+    principal: Option<&str>,
+) -> Result<ResponseBatch, SysError> {
+    let mut batch = ResponseBatch {
+        complete: true,
+        ..ResponseBatch::default()
     };
-
-    let event_topic = format!("hook.v1.event.{}", mapping.hook_name);
-
-    // Fire-and-forget for None-merge events. No responder is expected,
-    // so we don't allocate a subscription handle.
-    if matches!(mapping.merge, MergeSemantics::None) {
-        let request = HookEventRequest {
-            hook: mapping.hook_name.to_string(),
-            payload: serde_json::to_string(payload)?,
-            correlation_id: Option::None,
-        };
-        ipc::publish_json(&event_topic, &request)?;
-        return Ok(Option::None);
-    }
-
-    // Fan-out + collect. Subscribe BEFORE publishing so a fast responder
-    // can't beat us to the reply topic.
-    let corr_id = correlation_id()?;
-    let reply_topic = format!("hook.v1.response.{}.{corr_id}", mapping.hook_name);
-
-    let sub = ipc::subscribe(&reply_topic)?;
-
-    let request = HookEventRequest {
-        hook: mapping.hook_name.to_string(),
-        payload: serde_json::to_string(payload)?,
-        correlation_id: Some(corr_id),
-    };
-    ipc::publish_json(&event_topic, &request)?;
-
-    // Drain replies until the collection window closes, or `recv`
-    // returns an empty batch (quiescence). The Drop on `sub` releases
-    // the kernel-side subscription on every return path.
-    let mut responses: Vec<serde_json::Value> = Vec::new();
     let start = time::monotonic();
     loop {
         let elapsed_ms = u64::try_from((time::monotonic().saturating_sub(start)).as_millis())
@@ -362,150 +185,43 @@ fn dispatch_hook(
         if elapsed_ms >= HOOK_COLLECT_DEADLINE_MS {
             break;
         }
-        let remaining = if responses.is_empty() {
+        let remaining = if batch.values.is_empty() {
             HOOK_COLLECT_DEADLINE_MS - elapsed_ms
         } else {
             HOOK_QUIESCENCE_MS.min(HOOK_COLLECT_DEADLINE_MS - elapsed_ms)
         };
-
-        match sub.recv(remaining) {
-            Ok(poll) => {
-                if poll.messages.is_empty() {
-                    // Either the host returned early-empty or we hit the
-                    // deadline without new messages. Either way, stop.
-                    break;
-                }
-                for msg in poll.messages {
-                    match serde_json::from_str::<serde_json::Value>(&msg.payload) {
-                        Ok(v) => responses.push(v),
-                        Err(e) => {
-                            log::warn(format!(
-                                "hook-bridge: dropping malformed reply on {reply_topic}: {e}"
-                            ));
-                        }
-                    }
-                }
-            }
-            Err(SysError::HostError(msg)) if msg.contains("Timeout") => {
-                // No more replies inside the window. Done.
-                break;
-            }
-            Err(e) => return Err(e),
-        }
-    }
-
-    Ok(Some(apply_merge(&mapping.merge, &responses)))
-}
-
-fn canonical_hook_for_host_event(event: &str) -> Option<(&'static str, bool)> {
-    match event {
-        "session_start" => Some(("session_start", false)),
-        "user_prompt_submit" => Some(("message_received", true)),
-        "pre_tool_use" | "permission_request" => Some(("before_tool_call", false)),
-        "post_tool_use" => Some(("after_tool_call", false)),
-        "pre_compact" => Some(("on_compaction_started", false)),
-        "post_compact" => Some(("on_compaction_completed", false)),
-        "subagent_start" => Some(("subagent_start", false)),
-        "subagent_stop" => Some(("subagent_stop", false)),
-        "stop" | "session_end" => Some(("session_end", false)),
-        _ => None,
-    }
-}
-
-fn is_clean_segment(value: &str, max: usize) -> bool {
-    !value.is_empty()
-        && value.len() <= max
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
-}
-
-fn is_lower_hex(value: &str, expected_len: usize) -> bool {
-    value.len() == expected_len
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-}
-
-fn validate_oracle_hook(event: &OracleHookEvent) -> Result<(), &'static str> {
-    if event.schema_version != 1 {
-        return Err("unsupported schema version");
-    }
-    if !matches!(event.host.as_str(), "codex" | "claude" | "grok") {
-        return Err("unsupported host");
-    }
-    if canonical_hook_for_host_event(&event.event).is_none() {
-        return Err("unsupported host event");
-    }
-    if !is_clean_segment(&event.session_id, 128)
-        || !is_clean_segment(&event.event, 128)
-        || !is_clean_segment(&event.delivery_id, 128)
-    {
-        return Err("invalid routed segment");
-    }
-    if !is_lower_hex(&event.route_id, 64) || !is_lower_hex(&event.correlation_id, 32) {
-        return Err("invalid route identifier");
-    }
-    if event.delivery_id != format!("{}-{}", event.route_id, event.correlation_id) {
-        return Err("delivery identifier does not bind route and correlation");
-    }
-    if event
-        .turn_id
-        .as_deref()
-        .is_some_and(|value| value.is_empty() || value.len() > 256)
-        || event
-            .workspace_id
-            .as_deref()
-            .is_some_and(|value| !is_clean_segment(value, 128))
-    {
-        return Err("invalid optional routing metadata");
-    }
-    if serde_json::to_vec(&event.payload)
-        .map_or(true, |payload| payload.len() > MAX_HOST_PAYLOAD_BYTES)
-    {
-        return Err("host payload exceeds limit");
-    }
-    Ok(())
-}
-
-fn collect_additional_context(
-    subscription: &ipc::Subscription,
-    reply_topic: &str,
-) -> Result<Option<String>, SysError> {
-    let mut contexts = Vec::new();
-    let mut context_bytes = 0;
-    let start = time::monotonic();
-    loop {
-        let elapsed_ms = u64::try_from((time::monotonic().saturating_sub(start)).as_millis())
-            .unwrap_or(HOST_HOOK_COLLECT_DEADLINE_MS);
-        if elapsed_ms >= HOST_HOOK_COLLECT_DEADLINE_MS {
-            break;
-        }
-        let remaining = if contexts.is_empty() {
-            HOST_HOOK_COLLECT_DEADLINE_MS - elapsed_ms
-        } else {
-            HOOK_QUIESCENCE_MS.min(HOST_HOOK_COLLECT_DEADLINE_MS - elapsed_ms)
-        };
         match subscription.recv(remaining) {
             Ok(poll) if poll.messages.is_empty() => break,
             Ok(poll) => {
+                if poll.dropped != 0 || poll.lagged != 0 {
+                    batch.complete = false;
+                    log::warn(format!(
+                        "hook-bridge: response fan-out on {reply_topic} lost messages"
+                    ));
+                }
                 for message in poll.messages {
-                    match serde_json::from_str::<serde_json::Value>(&message.payload) {
-                        Ok(value) => {
-                            if let Some(context) = value
-                                .get("additional_context")
-                                .and_then(serde_json::Value::as_str)
-                                .filter(|context| !context.trim().is_empty())
-                                && !push_context(&mut contexts, &mut context_bytes, context)
-                            {
-                                log::warn(format!(
-                                    "hook-bridge: dropping host-hook context that exceeds the {MAX_HOST_CONTEXT_BYTES}-byte response limit"
-                                ));
-                            }
+                    if message.topic != reply_topic || message.principal.verified() != principal {
+                        batch.complete = false;
+                        log::warn(format!(
+                            "hook-bridge: dropping response with mismatched route or principal on {reply_topic}"
+                        ));
+                        continue;
+                    }
+                    if message.payload.len() > MAX_HOOK_RESPONSE_BYTES {
+                        batch.complete = false;
+                        log::warn(format!(
+                            "hook-bridge: dropping oversized reply on {reply_topic}"
+                        ));
+                        continue;
+                    }
+                    match serde_json::from_str(&message.payload) {
+                        Ok(value) => batch.values.push(value),
+                        Err(error) => {
+                            batch.complete = false;
+                            log::warn(format!(
+                                "hook-bridge: dropping malformed reply on {reply_topic}: {error}"
+                            ));
                         }
-                        Err(error) => log::warn(format!(
-                            "hook-bridge: dropping malformed host-hook reply on {reply_topic}: {error}"
-                        )),
                     }
                 }
             }
@@ -513,118 +229,51 @@ fn collect_additional_context(
             Err(error) => return Err(error),
         }
     }
-    if contexts.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(contexts.join("\n\n")))
-    }
+    Ok(batch)
 }
 
-fn push_context(contexts: &mut Vec<String>, total: &mut usize, context: &str) -> bool {
-    let separator = usize::from(!contexts.is_empty()) * 2;
-    let Some(next_total) = total
-        .checked_add(separator)
-        .and_then(|value| value.checked_add(context.len()))
-    else {
-        return false;
-    };
-    if next_total > MAX_HOST_CONTEXT_BYTES {
-        return false;
-    }
-    contexts.push(context.to_owned());
-    *total = next_total;
-    true
-}
-
-fn dispatch_oracle_hook(event: &OracleHookEvent) -> Result<Option<String>, SysError> {
-    let Some((hook, expects_context)) = canonical_hook_for_host_event(&event.event) else {
+fn dispatch_hook(
+    event_type: &str,
+    payload: &serde_json::Value,
+) -> Result<Option<HookResult>, SysError> {
+    let Some(mapping) = mapping_for_event(event_type) else {
         return Ok(None);
     };
-    let canonical_payload = CanonicalOraclePayload {
-        principal_id: &event.principal_id,
-        host: &event.host,
-        session_id: &event.session_id,
-        source_event: &event.event,
-        turn_id: event.turn_id.as_deref(),
-        workspace_id: event.workspace_id.as_deref(),
-        payload: &event.payload,
-    };
-    let event_topic = format!("hook.v1.event.{hook}");
-    if !expects_context {
-        let request = HookEventRequest {
-            hook: hook.to_owned(),
-            payload: serde_json::to_string(&canonical_payload)?,
-            correlation_id: None,
-        };
-        ipc::publish_json(&event_topic, &request)?;
+    let event_topic = format!("hook.v1.event.{}", mapping.hook_name);
+    if matches!(mapping.merge, MergeSemantics::None) {
+        ipc::publish_json(
+            &event_topic,
+            &HookEventRequest {
+                hook: mapping.hook_name.to_owned(),
+                payload: serde_json::to_string(payload)?,
+                correlation_id: None,
+            },
+        )?;
         return Ok(None);
     }
 
-    let reply_topic = format!("hook.v1.response.{hook}.{}", event.correlation_id);
-    let subscription = ipc::subscribe(&reply_topic)?;
-    let request = HookEventRequest {
-        hook: hook.to_owned(),
-        payload: serde_json::to_string(&canonical_payload)?,
-        correlation_id: Some(event.correlation_id.clone()),
-    };
-    ipc::publish_json(&event_topic, &request)?;
-    collect_additional_context(&subscription, &reply_topic)
-}
-
-fn handle_oracle_hook(payload: serde_json::Value) -> Result<(), SysError> {
-    let event: OracleHookEvent = match serde_json::from_value(payload) {
-        Ok(event) => event,
-        Err(error) => {
-            log::warn(format!(
-                "hook-bridge: dropping malformed oracle hook: {error}"
-            ));
-            return Ok(());
-        }
-    };
-    if let Err(reason) = validate_oracle_hook(&event) {
-        log::warn(format!(
-            "hook-bridge: dropping invalid {} hook '{}': {reason}",
-            event.host, event.event
-        ));
-        return Ok(());
-    }
+    let correlation = correlation_id()?;
     let caller = runtime::caller()?;
-    if caller.principal.as_deref() != Some(event.principal_id.as_str()) {
-        log::warn(format!(
-            "hook-bridge: dropping hook with principal mismatch for host {}",
-            event.host
-        ));
-        return Ok(());
-    }
-
-    let context = dispatch_oracle_hook(&event)?;
-    let response_topic = format!("oracle.v1.hook.response.{}", event.delivery_id);
+    let reply_topic = format!("hook.v1.response.{}.{}", mapping.hook_name, correlation);
+    let subscription = ipc::subscribe(&reply_topic)?;
     ipc::publish_json(
-        &response_topic,
-        &OracleHookResponse {
-            schema_version: 1,
-            principal_id: &event.principal_id,
-            host: &event.host,
-            session_id: &event.session_id,
-            event: &event.event,
-            correlation_id: &event.correlation_id,
-            route_id: &event.route_id,
-            delivery_id: &event.delivery_id,
-            context,
+        &event_topic,
+        &HookEventRequest {
+            hook: mapping.hook_name.to_owned(),
+            payload: serde_json::to_string(payload)?,
+            correlation_id: Some(correlation),
         },
-    )
+    )?;
+    Ok(Some(merge_batch(
+        &mapping.merge,
+        collect_responses(&subscription, &reply_topic, caller.principal.as_deref())?,
+    )))
 }
 
-// ── Capsule Implementation ─────────────────────────────────────────────────────────
-
-/// Hook Bridge capsule.
-///
-/// Maps lifecycle events to semantic hooks, fans out to subscribers via
-/// IPC, and applies merge strategies to the responses.
+/// Canonical lifecycle hook router.
 #[derive(Default)]
 pub struct HookBridge;
 
-/// Extract event type and dispatch the hook. Used by all interceptor handlers.
 fn handle_lifecycle(
     event_type: &str,
     payload: serde_json::Value,
@@ -634,45 +283,19 @@ fn handle_lifecycle(
 
 #[capsule]
 impl HookBridge {
-    /// Normalize a token-validated Codex host hook onto the canonical hook bus.
-    #[astrid::interceptor("on_codex_hook")]
-    pub fn on_codex_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        handle_oracle_hook(payload)
-    }
-
-    /// Normalize a token-validated Claude host hook onto the canonical hook bus.
-    #[astrid::interceptor("on_claude_hook")]
-    pub fn on_claude_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        handle_oracle_hook(payload)
-    }
-
-    /// Normalize a token-validated Grok host hook onto the canonical hook bus.
-    #[astrid::interceptor("on_grok_hook")]
-    pub fn on_grok_hook(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        handle_oracle_hook(payload)
-    }
-
-    // ── Session lifecycle ──
-
-    /// Handle `session_created` lifecycle event.
+    /// Route session creation.
     #[astrid::interceptor("on_session_created")]
     pub fn on_session_created(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.session_created", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.session_created", payload).map(drop)
     }
 
-    /// Handle `session_ended` lifecycle event.
+    /// Route session completion.
     #[astrid::interceptor("on_session_ended")]
     pub fn on_session_ended(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.session_ended", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.session_ended", payload).map(drop)
     }
 
-    // ── Tool hooks ──
-
-    /// Handle `tool_call_started` — maps to `before_tool_call` hook.
-    ///
-    /// Returns merged result with potential skip/modified_params.
+    /// Route a binding before-tool lifecycle hook.
     #[astrid::interceptor("on_tool_call_started")]
     pub fn on_tool_call_started(
         &self,
@@ -681,7 +304,7 @@ impl HookBridge {
         handle_lifecycle("astrid.v1.lifecycle.tool_call_started", payload)
     }
 
-    /// Handle `tool_call_completed` — maps to `after_tool_call` hook.
+    /// Route tool completion.
     #[astrid::interceptor("on_tool_call_completed")]
     pub fn on_tool_call_completed(
         &self,
@@ -690,7 +313,7 @@ impl HookBridge {
         handle_lifecycle("astrid.v1.lifecycle.tool_call_completed", payload)
     }
 
-    /// Handle `tool_result_persisting` — maps to `tool_result_persist` hook.
+    /// Route tool-result persistence.
     #[astrid::interceptor("on_tool_result_persisting")]
     pub fn on_tool_result_persisting(
         &self,
@@ -699,16 +322,13 @@ impl HookBridge {
         handle_lifecycle("astrid.v1.lifecycle.tool_result_persisting", payload)
     }
 
-    // ── Message hooks ──
-
-    /// Handle `message_received` lifecycle event.
+    /// Route inbound message observation.
     #[astrid::interceptor("on_message_received")]
     pub fn on_message_received(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.message_received", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.message_received", payload).map(drop)
     }
 
-    /// Handle `message_sending` — maps to `message_sending` hook.
+    /// Route a binding message-send hook.
     #[astrid::interceptor("on_message_sending")]
     pub fn on_message_sending(
         &self,
@@ -717,73 +337,58 @@ impl HookBridge {
         handle_lifecycle("astrid.v1.lifecycle.message_sending", payload)
     }
 
-    /// Handle `message_sent` lifecycle event.
+    /// Route sent-message observation.
     #[astrid::interceptor("on_message_sent")]
     pub fn on_message_sent(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.message_sent", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.message_sent", payload).map(drop)
     }
 
-    // ── Sub-agent hooks ──
-
-    /// Handle `sub_agent_spawned` lifecycle event.
+    /// Route sub-agent creation.
     #[astrid::interceptor("on_subagent_spawned")]
     pub fn on_subagent_spawned(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.sub_agent_spawned", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.sub_agent_spawned", payload).map(drop)
     }
 
-    /// Handle `sub_agent_completed` lifecycle event.
+    /// Route successful sub-agent completion.
     #[astrid::interceptor("on_subagent_completed")]
     pub fn on_subagent_completed(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.sub_agent_completed", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.sub_agent_completed", payload).map(drop)
     }
 
-    /// Handle `sub_agent_failed` lifecycle event.
+    /// Route failed sub-agent completion.
     #[astrid::interceptor("on_subagent_failed")]
     pub fn on_subagent_failed(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.sub_agent_failed", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.sub_agent_failed", payload).map(drop)
     }
 
-    /// Handle `sub_agent_cancelled` lifecycle event.
+    /// Route cancelled sub-agent completion.
     #[astrid::interceptor("on_subagent_cancelled")]
     pub fn on_subagent_cancelled(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.sub_agent_cancelled", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.sub_agent_cancelled", payload).map(drop)
     }
 
-    // ── Context compaction ──
-
-    /// Handle `context_compaction_started` lifecycle event.
+    /// Route compaction start.
     #[astrid::interceptor("on_compaction_started")]
     pub fn on_compaction_started(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.context_compaction_started", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.context_compaction_started", payload).map(drop)
     }
 
-    /// Handle `context_compaction_completed` lifecycle event.
+    /// Route compaction completion.
     #[astrid::interceptor("on_compaction_completed")]
     pub fn on_compaction_completed(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.context_compaction_completed", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.context_compaction_completed", payload).map(drop)
     }
 
-    // ── Kernel lifecycle ──
-
-    /// Handle `kernel_started` lifecycle event.
+    /// Route kernel start.
     #[astrid::interceptor("on_kernel_started")]
     pub fn on_kernel_started(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.kernel_started", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.kernel_started", payload).map(drop)
     }
 
-    /// Handle `kernel_shutdown` lifecycle event.
+    /// Route kernel shutdown.
     #[astrid::interceptor("on_kernel_shutdown")]
     pub fn on_kernel_shutdown(&self, payload: serde_json::Value) -> Result<(), SysError> {
-        let _ = handle_lifecycle("astrid.v1.lifecycle.kernel_shutdown", payload)?;
-        Ok(())
+        handle_lifecycle("astrid.v1.lifecycle.kernel_shutdown", payload).map(drop)
     }
 }
 
@@ -791,65 +396,104 @@ impl HookBridge {
 mod tests {
     use super::*;
 
-    fn host_event() -> OracleHookEvent {
-        let route_id = "a".repeat(64);
-        let correlation_id = "b".repeat(32);
-        OracleHookEvent {
-            schema_version: 1,
-            principal_id: "codex-code".to_owned(),
-            host: "codex".to_owned(),
-            session_id: "codex-session".to_owned(),
-            event: "user_prompt_submit".to_owned(),
-            delivery_id: format!("{route_id}-{correlation_id}"),
-            correlation_id,
-            route_id,
-            turn_id: Some("turn-one".to_owned()),
-            workspace_id: Some("workspace-one".to_owned()),
-            payload: serde_json::json!({"prompt": "hello"}),
-        }
+    #[test]
+    fn lifecycle_mappings_keep_binding_and_observation_distinct() {
+        let before = mapping_for_event("astrid.v1.lifecycle.tool_call_started").unwrap();
+        assert_eq!(before.hook_name, "before_tool_call");
+        assert_eq!(before.merge, MergeSemantics::ToolCallBefore);
+        let received = mapping_for_event("astrid.v1.lifecycle.message_received").unwrap();
+        assert_eq!(received.hook_name, "message_received");
+        assert_eq!(received.merge, MergeSemantics::None);
     }
 
     #[test]
-    fn prompt_event_maps_to_context_bearing_message_hook() {
+    fn before_tool_call_is_deny_wins_and_last_transform_wins() {
+        let responses = vec![
+            serde_json::json!({"modified_params": {"value": 1}}),
+            serde_json::json!({"skip": true}),
+            serde_json::json!({"modified_params": {"value": 2}}),
+        ];
         assert_eq!(
-            canonical_hook_for_host_event("user_prompt_submit"),
-            Some(("message_received", true))
-        );
-        assert_eq!(
-            canonical_hook_for_host_event("stop"),
-            Some(("session_end", false))
+            apply_merge(&MergeSemantics::ToolCallBefore, &responses),
+            HookResult {
+                skip: Some(true),
+                data: Some(r#"{"value":2}"#.to_owned()),
+            }
         );
     }
 
     #[test]
-    fn exact_delivery_binding_is_required() {
-        let mut event = host_event();
-        assert!(validate_oracle_hook(&event).is_ok());
-        event.delivery_id = format!("{}-{}", "c".repeat(64), event.correlation_id);
+    fn last_non_null_ignores_nulls() {
+        let responses = vec![
+            serde_json::json!({"modified_content": "first"}),
+            serde_json::json!({"modified_content": null}),
+            serde_json::json!({"modified_content": "last"}),
+        ];
         assert_eq!(
-            validate_oracle_hook(&event),
-            Err("delivery identifier does not bind route and correlation")
+            apply_merge(
+                &MergeSemantics::LastNonNull {
+                    field: "modified_content"
+                },
+                &responses
+            ),
+            HookResult {
+                skip: None,
+                data: Some(r#""last""#.to_owned()),
+            }
         );
     }
 
     #[test]
-    fn event_and_session_cannot_add_topic_segments() {
-        let mut event = host_event();
-        event.session_id = "codex.other".to_owned();
-        assert_eq!(validate_oracle_hook(&event), Err("invalid routed segment"));
+    fn merged_result_uses_the_canonical_hook_wire_shape() {
+        let result = apply_merge(
+            &MergeSemantics::LastNonNull {
+                field: "modified_content",
+            },
+            &[serde_json::json!({"modified_content": {"text": "hello"}})],
+        );
+        assert_eq!(
+            serde_json::to_value(result).unwrap(),
+            serde_json::json!({
+                "data": r#"{"text":"hello"}"#,
+            })
+        );
     }
 
     #[test]
-    fn combined_host_context_stays_inside_relay_limit() {
-        let mut contexts = Vec::new();
-        let mut total = 0;
-        assert!(push_context(
-            &mut contexts,
-            &mut total,
-            &"a".repeat(MAX_HOST_CONTEXT_BYTES - 3)
-        ));
-        assert!(push_context(&mut contexts, &mut total, "b"));
-        assert_eq!(contexts.join("\n\n").len(), MAX_HOST_CONTEXT_BYTES);
-        assert!(!push_context(&mut contexts, &mut total, "c"));
+    fn incomplete_pretool_fanout_fails_closed_without_partial_transform() {
+        let result = merge_batch(
+            &MergeSemantics::ToolCallBefore,
+            ResponseBatch {
+                values: vec![serde_json::json!({"modified_params": {"value": 1}})],
+                complete: false,
+            },
+        );
+        assert_eq!(
+            result,
+            HookResult {
+                skip: Some(true),
+                data: None,
+            }
+        );
+    }
+
+    #[test]
+    fn incomplete_transform_fanout_discards_partial_output() {
+        let result = merge_batch(
+            &MergeSemantics::LastNonNull {
+                field: "modified_content",
+            },
+            ResponseBatch {
+                values: vec![serde_json::json!({"modified_content": "partial"})],
+                complete: false,
+            },
+        );
+        assert_eq!(
+            result,
+            HookResult {
+                skip: None,
+                data: None,
+            }
+        );
     }
 }

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -1203,7 +1203,8 @@ mod tests {
         let encoded = materialize_manifest(&capsule_dir).expect("materialize manifest");
         let decoded: toml::Value = encoded.parse().expect("parse materialized TOML");
         let capsules = decoded["capsule"].as_array().expect("capsule array");
-        assert_eq!(capsules.len(), 21);
+        let expected = capsule_assets_from_manifest().expect("embedded capsule assets");
+        assert_eq!(capsules.len(), expected.len());
         assert!(capsules.iter().all(|capsule| {
             PathBuf::from(capsule["source"].as_str().expect("absolute source")).parent()
                 == Some(capsule_dir.as_path())

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -601,7 +601,16 @@ fn offline_init_keeps_the_runtime_offline_flag_and_uses_only_local_capsules() {
         .parse()
         .expect("parse materialized manifest");
     let capsules = manifest["capsule"].as_array().expect("capsule entries");
-    assert_eq!(capsules.len(), 21);
+    let embedded: toml::Value = include_str!("../../../distros/community/unicity-ce/Distro.toml")
+        .parse()
+        .expect("parse embedded distro fixture");
+    assert_eq!(
+        capsules.len(),
+        embedded["capsule"]
+            .as_array()
+            .expect("embedded capsule entries")
+            .len()
+    );
     let expected_root = fixture
         .home
         .join("releases")

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -108,6 +108,11 @@ source = "capsules/aos-hook-bridge.capsule"
 version = "0.2.0"
 
 [[capsule]]
+name = "aos-hook-adapter-oracle"
+source = "capsules/aos-hook-adapter-oracle.capsule"
+version = "0.1.0"
+
+[[capsule]]
 name = "aos-meta-harness"
 source = "capsules/aos-meta-harness.capsule"
 version = "0.1.0"

--- a/distros/community/unicity-ce/README.md
+++ b/distros/community/unicity-ce/README.md
@@ -26,7 +26,7 @@ local bundle supports `aos init --offline`.
 |----------|----------|
 | **Uplinks** | cli, registry |
 | **LLM providers** | openai-compat (select during init) |
-| **Core** | react, session, identity, users, router, prompt-builder, context-engine, hook-bridge |
+| **Core** | react, session, identity, users, router, prompt-builder, context-engine, hook-bridge, hook-adapter-oracle |
 | **Tools** | shell, http, fs, system |
 | **Extensions** | skills, agents, memory |
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,133 @@
+# Composable frontend hooks
+
+AOS separates frontend protocol translation from canonical hook policy.
+
+```text
+frontend plugin
+  -> authenticated ingress in capsule-mcp
+  -> exact oracle.v1.hook.validated.<frontend> topic
+  -> one frontend adapter
+  -> canonical hook.v1.event.<semantic-hook>
+  -> zero or more independent subscriber capsules
+  -> optional correlation-scoped replies
+  -> adapter-shaped frontend response
+```
+
+`aos-hook-bridge` is the parallel ingress for Astrid-native lifecycle events.
+It does not parse Codex, Claude, or Grok protocols. This keeps the canonical
+hook bus independent of any agent product and lets a new frontend ship as an
+adapter capsule instead of changing the router or kernel.
+
+## Trust boundaries
+
+The frontend process is not trusted to name a principal. `capsule-mcp` verifies
+the host-session token against the kernel-stamped invoking principal and
+publishes a token-free validated envelope. The adapter then:
+
+1. binds each exact validated topic to the expected frontend;
+2. rejects a payload whose `host` does not match that topic;
+3. checks route, delivery, correlation, size, and segment constraints;
+4. checks the kernel-stamped caller principal against `principal_id`;
+5. emits a bounded canonical event; and
+6. accepts correlated replies only from the same verified principal.
+
+The right to publish a validated topic is an install-reviewed IPC capability.
+Only the authenticated ingress capsule should hold it. Adding a second raw
+adapter to the same exact topic is a deployment error: raw protocol ingress has
+one owner, while extension happens downstream on canonical hook topics.
+
+## Response classes
+
+Every mapping declares one response class.
+
+### Observation
+
+The adapter publishes without a correlation ID. Subscribers may observe but
+cannot affect the frontend operation. Session, post-tool, compaction, sub-agent,
+and shutdown events use this class.
+
+`pre_tool_use` and `permission_request` are also observations on the current
+Oracle relay because its outer response schema can return context only. Binding
+native-tool denial stays on `astrid-gate` plus the broker policy responder,
+which has a host-specific deny response. Treating an unrepresentable generic
+reply as binding would be fail-open theater.
+
+### Additional context
+
+`user_prompt_submit` publishes `message_received` with the exact host
+correlation ID. Subscribers may publish `{ "additional_context": "..." }` to
+the response topic. The adapter accepts same-principal replies, combines them
+within 64 KiB, and drops the entire partial result if the response subscription
+reports lag or loss.
+
+### Binding lifecycle result
+
+Astrid-native lifecycle events enter `aos-hook-bridge`. It creates its own
+correlation ID and returns the merged result to the invoking lifecycle
+interceptor:
+
+- `before_tool_call`: any `skip: true` wins; the last non-null
+  `modified_params` wins;
+- `after_tool_call`: last non-null `modified_result` wins;
+- `tool_result_persist`: last non-null `transformed_result` wins; and
+- `message_sending`: last non-null `modified_content` wins.
+
+Replies are accepted only on the exact correlation topic and from the
+kernel-verified invoking principal. Known fan-out loss, lag, route mismatch,
+principal mismatch, oversize, or malformed JSON invalidates the whole batch:
+`before_tool_call` returns `skip: true`, while transformation hooks discard all
+partial output.
+
+A timeout with no reply still means "no mutation requested" because the bus
+does not currently expose an expected-responder registry. Therefore this
+fan-out is not, by itself, proof that every required policy capsule approved.
+Mandatory native-tool security remains the direct `astrid-gate` and broker
+path. A future mandatory lifecycle policy needs explicit required-responder
+registration rather than inferring approval from silence.
+
+These merge rules are protocol policy. A future frontend may bind to them only
+after its own adapter can faithfully translate the merged result into that
+frontend's native response schema. That change needs per-frontend conformance
+tests for deny, allow/no-op, malformed response, timeout, and transport error.
+
+## Priority and layering
+
+Do not assign priorities to observation subscribers. Equal default priority
+keeps independent concurrent fan-out: every subscriber sees the original event
+and one subscriber cannot suppress another.
+
+Do not use priority to order frontend adapters. Each authenticated raw topic has
+one adapter owner.
+
+For an intentionally binding middleware topic, the following bands are
+reserved guidance:
+
+| Band | Purpose | Required behavior |
+|---|---|---|
+| 10-19 | validate and normalize | malformed input returns `Deny`, not `Err`, when safety depends on rejection |
+| 20-39 | safety and policy narrowing | deny may stop the chain; no layer may broaden prior authority |
+| 40-79 | deterministic transformation | transformed payload is explicit and tested |
+| 80-99 | enrichment | must not reinterpret a deny as allow |
+| 100+ | provider/application execution | receives only the prior stage's accepted payload |
+
+Setting one distinct priority converts **all** matching handlers from fan-out
+to one ordered chain. Therefore a capsule must not introduce a priority on an
+existing canonical topic unless that topic is explicitly declared binding and
+every matching capsule is reviewed as middleware. Ordinary handler errors
+continue in an ordered chain; a security layer must return `Deny` for a refusal.
+
+## Adding a frontend
+
+1. Add authenticated ingress and a frontend-specific validated topic.
+2. Add one adapter capsule or one isolated handler table with exact topic/host
+   binding.
+3. Map only events whose semantics are genuinely equivalent.
+4. Classify every mapping as observation, context, or binding.
+5. Keep the original payload nested under canonical provenance rather than
+   flattening untrusted keys into the envelope.
+6. Bound input, canonical output, correlation identifiers, replies, and wait
+   time.
+7. Add negative tests for cross-topic host claims, principal mismatch, topic
+   smuggling, stale routes, oversized payloads, reply loss, and unsupported
+   events.
+8. Do not change the kernel. Translation and policy belong in capsules.

--- a/release/community-capsules.txt
+++ b/release/community-capsules.txt
@@ -14,6 +14,7 @@ capsule-router
 capsule-prompt-builder
 capsule-context-engine
 capsule-hook-bridge
+capsule-hook-adapter-oracle
 capsule-meta-harness
 capsule-shell
 capsule-http

--- a/scripts/test-clean-home-init.sh
+++ b/scripts/test-clean-home-init.sh
@@ -94,8 +94,8 @@ expected = sorted(
     for line in assets_path.read_text(encoding="utf-8").splitlines()
     if line
 )
-if len(expected) != 21 or len(set(expected)) != 21:
-    raise SystemExit("release capsule inventory is not the exact 21-capsule CE set")
+if len(expected) != 22 or len(set(expected)) != 22:
+    raise SystemExit("release capsule inventory is not the exact 22-capsule CE set")
 with lock_path.open("rb") as file:
     lock = tomllib.load(file)
 with profile_path.open("rb") as file:

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -251,7 +251,7 @@ release_dir="$work/home/.aos/releases/2026.1.3"
 test -f "$release_dir/release-manifest.json"
 test -f "$release_dir/Distro.toml"
 test -f "$release_dir/capsule-assets.txt"
-test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 21
+test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 22
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"
@@ -608,7 +608,7 @@ for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
   test "$("$destination")" = "old-$binary"
 done
 test "$(cat "$release_dir/release-manifest.json")" = old-release-manifest
-test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 21
+test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 22
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -69,7 +69,7 @@ tar -tzf "$archive" > "$work/files"
 grep -q '/bin/aos$' "$work/files"
 grep -q '/libexec/install.sh$' "$work/files"
 grep -q '/runtime/bin/astrid-daemon$' "$work/files"
-test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 21
+test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 22
 grep -q '/capsule-assets.txt$' "$work/files"
 grep -q '/Distro.toml$' "$work/files"
 grep -q '/release-manifest.json$' "$work/files"
@@ -77,7 +77,7 @@ grep -q '/release-manifest.json$' "$work/files"
 tar -xzf "$archive" -C "$work"
 manifest=$(find "$work" -path '*/release-manifest.json' -print -quit)
 bundle_root=$(dirname "$manifest")
-test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 21
+test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 22
 if grep -F '@unicity-aos/capsule-' "$bundle_root/Distro.toml" >/dev/null; then
   echo "release archive retained a legacy capsule repository source" >&2
   exit 1
@@ -99,9 +99,9 @@ assert manifest["contracts"]["repository"] == "astrid-runtime/wit"
 assert manifest["contracts"]["commit"] == "278dbca3e32f327d0f2358644fc86559779ba0fd"
 assert manifest["contracts"]["sdk_rust_version"] == "0.7.1"
 assert manifest["contracts"]["sdk_rust_commit"] == "bbbc61c8821d6c536fb25d2068b6b646e759ad35"
-assert manifest["capsules"]["count"] == 21
-assert len(manifest["capsules"]["assets"]) == 21
-assert len(set(manifest["capsules"]["assets"])) == 21
+assert manifest["capsules"]["count"] == 22
+assert len(manifest["capsules"]["assets"]) == 22
+assert len(set(manifest["capsules"]["assets"])) == 22
 PY
 
 unsafe_root="$work/unsafe-runtime"

--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -85,15 +85,15 @@ class CapsuleReleaseTests(unittest.TestCase):
             write_fixture(directory / spec.asset, spec)
 
     def test_source_contract_has_exact_community_set(self) -> None:
-        self.assertEqual(len(self.specs), 21)
-        self.assertEqual(len({spec.asset for spec in self.specs}), 21)
+        self.assertEqual(len(self.specs), 22)
+        self.assertEqual(len({spec.asset for spec in self.specs}), 22)
         assets = {spec.asset for spec in self.specs}
         self.assertIn("aos-forge.capsule", assets)
         self.assertNotIn("aos-telegram.capsule", assets)
         distro = Path(__file__).resolve().parent.parent / "distros/community/unicity-ce/Distro.toml"
         text = distro.read_text(encoding="utf-8")
         self.assertNotIn("@unicity-aos/", text)
-        self.assertEqual(text.count('source = "capsules/'), 21)
+        self.assertEqual(text.count('source = "capsules/'), 22)
         for spec in self.specs:
             self.assertIn(f'source = "capsules/{spec.asset}"', text)
 

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -113,7 +113,7 @@ class ReleasePublicationTests(unittest.TestCase):
             artifacts, compatibility = self.fixture(Path(temp))
             payloads = self.validate(artifacts, compatibility)
             self.assertIn(f"unicity-aos-{VERSION}-release.toml", payloads)
-            self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 21)
+            self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 22)
 
     def test_rejects_missing_asset(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary

Splits frontend-specific hook translation from the canonical Astrid lifecycle bridge.

The bridge now maps Astrid lifecycle events onto stable `hook.v1.*` topics and merges correlated replies. The first protocol adapter translates Oracle frontend hooks into that canonical contract. Other frontends can add sibling adapter capsules without teaching the bridge about their private wire formats.

Related architecture follow-up: #81.

## Changes

- Refactor `aos-hook-bridge` into a frontend-neutral lifecycle router with explicit merge semantics.
- Use the SDK-generated canonical `HookResult` contract so transformed values are returned through Astrid's interceptor chain rather than nested in a lookalike JSON object.
- Add `aos-hook-adapter-oracle` with strict topic, host, event, session, correlation, and payload validation.
- Add hook architecture and extension documentation.
- Include the Oracle adapter in the CE distribution and release capsule inventory.
- Extend clean-home, install, packaging, and release-publication expectations for the new capsule.

## Design boundaries

- Frontend adapters publish only canonical hook events; they do not own lifecycle policy.
- Correlated replies remain principal-bound and arity-fixed in capsule ACLs.
- Incomplete pre-tool fan-out fails closed; partial data transforms are discarded rather than applied.
- Observation-only events stay uncorrelated and cannot mutate the lifecycle payload.
- This PR does not move capsule source repositories; #81 tracks independently releasable capsule artifacts and distribution composition.

## Verification

- `cargo test -p aos-hook-bridge -p aos-hook-adapter-oracle` — 12 tests passed.
- `cargo clippy -p aos-hook-bridge -p aos-hook-adapter-oracle --all-targets --all-features -- -D warnings` passed.
- `python3 scripts/test_capsule_release.py` — 16 tests passed.
- `python3 scripts/test_release_publication.py` — 6 tests passed.
- `aos capsule check capsules/capsule-hook-bridge` passed.
- `aos capsule build capsules/capsule-hook-bridge` produced an installable capsule.

## AI / Tool Assistance

Assisted-by: Codex:GPT-5.6

Codex assisted with architecture review, implementation, adversarial validation, regression tests, documentation, and release-wiring checks. Joshua reviewed and certified the signed commit before publication.
