### PR TITLE
fix(hooks): preserve frontend response events

### DIFF
--- a/capsules/capsule-hook-adapter-oracle/README.md
+++ b/capsules/capsule-hook-adapter-oracle/README.md
@@ -12,11 +12,16 @@ path, whose response schema can express deny.
 
 Frontend response and session events remain distinct. Codex and Claude `stop`
 events carry the completed turn's `last_assistant_message` and publish as
-canonical `message_sent`; only `session_end` publishes as canonical
-`session_end`. Claude `message_display` publishes its rendered `delta` batches
-as canonical `message_displayed`. These response events are observational on
-this relay: downstream policy may inspect and report them, but cannot claim to
-retract text that the frontend has already produced.
+canonical `message_sent`; their explicit `session_end` publishes as canonical
+`session_end`. Grok is an explicit compatibility exception: its current `stop`
+event maps to canonical `session_end` because the installed Grok hook contract
+does not expose a distinct verified termination event. Claude
+`message_display` publishes its rendered `delta` batches as canonical
+`message_displayed`. Adapter responses preserve the source `event` separately
+from this `canonical_hook`, so authenticated route cleanup follows canonical
+lifecycle semantics without erasing frontend provenance. These response events
+are observational on this relay: downstream policy may inspect and report
+them, but cannot claim to retract text that the frontend has already produced.
 
 Canonical hook subscribers should normally omit `priority`, preserving
 independent fan-out. See [`docs/hooks.md`](../../docs/hooks.md) for the complete

--- a/capsules/capsule-hook-adapter-oracle/README.md
+++ b/capsules/capsule-hook-adapter-oracle/README.md
@@ -10,6 +10,14 @@ host turn. `pre_tool_use` and `permission_request` are observation-only on this
 relay; binding native-tool denial remains on the `astrid-gate`/broker decision
 path, whose response schema can express deny.
 
+Frontend response and session events remain distinct. Codex and Claude `stop`
+events carry the completed turn's `last_assistant_message` and publish as
+canonical `message_sent`; only `session_end` publishes as canonical
+`session_end`. Claude `message_display` publishes its rendered `delta` batches
+as canonical `message_displayed`. These response events are observational on
+this relay: downstream policy may inspect and report them, but cannot claim to
+retract text that the frontend has already produced.
+
 Canonical hook subscribers should normally omit `priority`, preserving
 independent fan-out. See [`docs/hooks.md`](../../docs/hooks.md) for the complete
 composition and priority contract.

--- a/capsules/capsule-hook-adapter-oracle/src/lib.rs
+++ b/capsules/capsule-hook-adapter-oracle/src/lib.rs
@@ -144,6 +144,9 @@ struct OracleHookResponse<'a> {
     principal_id: &'a str,
     host: &'a str,
     session_id: &'a str,
+    /// Canonical lifecycle/observation classification selected by this
+    /// frontend adapter. The source frontend event remains in `event`.
+    canonical_hook: &'a str,
     event: &'a str,
     correlation_id: &'a str,
     route_id: &'a str,
@@ -392,6 +395,7 @@ fn handle_oracle_hook(expected: Frontend, payload: serde_json::Value) -> Result<
             principal_id: &event.principal_id,
             host: &event.host,
             session_id: &event.session_id,
+            canonical_hook: mapping.hook,
             event: &event.event,
             correlation_id: &event.correlation_id,
             route_id: &event.route_id,
@@ -487,6 +491,11 @@ mod tests {
             Frontend::Claude.mapping("session_end"),
             Some(observe("session_end"))
         );
+    }
+
+    #[test]
+    fn grok_stop_remains_an_explicit_session_termination_exception() {
+        assert_eq!(Frontend::Grok.mapping("stop"), Some(observe("session_end")));
     }
 
     #[test]

--- a/capsules/capsule-hook-adapter-oracle/src/lib.rs
+++ b/capsules/capsule-hook-adapter-oracle/src/lib.rs
@@ -79,6 +79,7 @@ const fn context(hook: &'static str) -> HookMapping {
 fn common_mapping(event: &str) -> Option<HookMapping> {
     match event {
         "session_start" => Some(observe("session_start")),
+        "session_end" => Some(observe("session_end")),
         "user_prompt_submit" => Some(context("message_received")),
         // This relay's outer response schema carries context only. These are
         // observations here; binding native-tool decisions use astrid-gate.
@@ -88,21 +89,36 @@ fn common_mapping(event: &str) -> Option<HookMapping> {
         "post_compact" => Some(observe("on_compaction_completed")),
         "subagent_start" => Some(observe("subagent_start")),
         "subagent_stop" => Some(observe("subagent_stop")),
-        "stop" | "session_end" => Some(observe("session_end")),
         _ => None,
     }
 }
 
 fn codex_mapping(event: &str) -> Option<HookMapping> {
-    common_mapping(event)
+    match event {
+        // Codex Stop is per-turn and carries `last_assistant_message`.
+        "stop" => Some(observe("message_sent")),
+        _ => common_mapping(event),
+    }
 }
 
 fn claude_mapping(event: &str) -> Option<HookMapping> {
-    common_mapping(event)
+    match event {
+        // Claude Stop is per-turn and carries `last_assistant_message`.
+        "stop" => Some(observe("message_sent")),
+        // Claude MessageDisplay carries response text in `delta` while it is
+        // rendered. It is observation-only on this relay.
+        "message_display" => Some(observe("message_displayed")),
+        _ => common_mapping(event),
+    }
 }
 
 fn grok_mapping(event: &str) -> Option<HookMapping> {
-    common_mapping(event)
+    match event {
+        // Preserve the existing Grok interpretation until its upstream hook
+        // contract supplies a distinct, verified per-turn response event.
+        "stop" => Some(observe("session_end")),
+        _ => common_mapping(event),
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -451,6 +467,82 @@ mod tests {
             Frontend::Claude.mapping("pre_tool_use"),
             Some(observe("before_tool_call"))
         );
+    }
+
+    #[test]
+    fn codex_and_claude_stop_are_response_events_not_session_termination() {
+        assert_eq!(
+            Frontend::Codex.mapping("stop"),
+            Some(observe("message_sent"))
+        );
+        assert_eq!(
+            Frontend::Claude.mapping("stop"),
+            Some(observe("message_sent"))
+        );
+        assert_eq!(
+            Frontend::Codex.mapping("session_end"),
+            Some(observe("session_end"))
+        );
+        assert_eq!(
+            Frontend::Claude.mapping("session_end"),
+            Some(observe("session_end"))
+        );
+    }
+
+    #[test]
+    fn claude_message_display_is_response_egress_only() {
+        assert_eq!(
+            Frontend::Claude.mapping("message_display"),
+            Some(observe("message_displayed"))
+        );
+        assert_eq!(Frontend::Codex.mapping("message_display"), None);
+    }
+
+    #[test]
+    fn canonical_events_retain_user_prompt_and_assistant_response_text() {
+        let mut prompt = host_event("codex");
+        prompt.payload = serde_json::json!({"prompt": "inspect this input"});
+        let request = canonical_request(
+            &prompt,
+            Frontend::Codex.mapping("user_prompt_submit").unwrap(),
+        )
+        .unwrap();
+        let payload: serde_json::Value = serde_json::from_str(&request.payload).unwrap();
+        assert_eq!(payload["source_event"], "user_prompt_submit");
+        assert_eq!(payload["payload"]["prompt"], "inspect this input");
+
+        let mut response = host_event("codex");
+        response.event = "stop".to_owned();
+        response.payload = serde_json::json!({
+            "last_assistant_message": "the final assistant response"
+        });
+        let request =
+            canonical_request(&response, Frontend::Codex.mapping("stop").unwrap()).unwrap();
+        assert_eq!(request.hook, "message_sent");
+        let payload: serde_json::Value = serde_json::from_str(&request.payload).unwrap();
+        assert_eq!(payload["source_event"], "stop");
+        assert_eq!(
+            payload["payload"]["last_assistant_message"],
+            "the final assistant response"
+        );
+    }
+
+    #[test]
+    fn canonical_claude_display_event_retains_streamed_delta() {
+        let mut event = host_event("claude");
+        event.event = "message_display".to_owned();
+        event.payload = serde_json::json!({
+            "message_id": "message-one",
+            "index": 0,
+            "final": true,
+            "delta": "rendered assistant response"
+        });
+        let request =
+            canonical_request(&event, Frontend::Claude.mapping("message_display").unwrap())
+                .unwrap();
+        assert_eq!(request.hook, "message_displayed");
+        let payload: serde_json::Value = serde_json::from_str(&request.payload).unwrap();
+        assert_eq!(payload["payload"]["delta"], "rendered assistant response");
     }
 
     #[test]

--- a/capsules/capsule-mcp/src/host_hooks.rs
+++ b/capsules/capsule-mcp/src/host_hooks.rs
@@ -51,6 +51,8 @@ struct HostHookResponse {
     host: String,
     session_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    canonical_hook: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     event: Option<String>,
     correlation_id: String,
     route_id: String,
@@ -165,7 +167,7 @@ pub(crate) fn relay_response(payload: serde_json::Value) -> Result<(), SysError>
         &response,
     )?;
 
-    if response.event.as_deref().is_some_and(retires_session_route)
+    if retires_session_route(&response)
         && let Err(error) = kv::delete(&token_key)
     {
         log::warn(format!(
@@ -196,8 +198,13 @@ fn can_register(event: &str) -> bool {
     matches!(event, "session_start" | "user_prompt_submit")
 }
 
-fn retires_session_route(event: &str) -> bool {
-    event == "session_end"
+fn retires_session_route(response: &HostHookResponse) -> bool {
+    match response.canonical_hook.as_deref() {
+        Some(canonical_hook) => canonical_hook == "session_end",
+        // Staggered upgrades may receive a response from an older adapter.
+        // Only its explicit source session_end is safe to treat as terminal.
+        None => response.event.as_deref() == Some("session_end"),
+    }
 }
 
 fn token_key(host: &str, session: &str) -> String {
@@ -260,8 +267,12 @@ fn validate_response_shape(response: &HostHookResponse) -> Result<(), &'static s
         .event
         .as_deref()
         .is_some_and(|event| !is_segment(event, 128))
+        || response
+            .canonical_hook
+            .as_deref()
+            .is_some_and(|hook| !is_segment(hook, 128))
     {
-        return Err("invalid_event");
+        return Err("invalid_event_classification");
     }
     validate_delivery_fields(
         &response.session_id,
@@ -401,6 +412,7 @@ mod tests {
             principal_id: request.principal_id.clone(),
             host: request.host.clone(),
             session_id: request.session_id.clone(),
+            canonical_hook: Some("message_received".to_owned()),
             event: Some(request.event.clone()),
             correlation_id: request.correlation_id.clone(),
             route_id: request.route_id.clone(),
@@ -474,9 +486,23 @@ mod tests {
 
     #[test]
     fn only_real_session_end_retires_the_authenticated_route() {
-        assert!(retires_session_route("session_end"));
-        assert!(!retires_session_route("stop"));
-        assert!(!retires_session_route("message_display"));
+        let request = request();
+        let mut value = response(&request);
+
+        value.event = Some("stop".to_owned());
+        value.canonical_hook = Some("message_sent".to_owned());
+        assert!(!retires_session_route(&value));
+
+        // Grok currently classifies its source `stop` as session termination.
+        value.canonical_hook = Some("session_end".to_owned());
+        assert!(retires_session_route(&value));
+
+        // Old adapters did not emit canonical_hook. Preserve only the
+        // unambiguous explicit session_end compatibility path.
+        value.canonical_hook = None;
+        assert!(!retires_session_route(&value));
+        value.event = Some("session_end".to_owned());
+        assert!(retires_session_route(&value));
     }
 
     #[test]

--- a/capsules/capsule-mcp/src/host_hooks.rs
+++ b/capsules/capsule-mcp/src/host_hooks.rs
@@ -165,7 +165,7 @@ pub(crate) fn relay_response(payload: serde_json::Value) -> Result<(), SysError>
         &response,
     )?;
 
-    if matches!(response.event.as_deref(), Some("stop" | "session_end"))
+    if response.event.as_deref().is_some_and(retires_session_route)
         && let Err(error) = kv::delete(&token_key)
     {
         log::warn(format!(
@@ -194,6 +194,10 @@ fn authenticate_token(key: &str, request: &HostHookRequest) -> Result<bool, SysE
 
 fn can_register(event: &str) -> bool {
     matches!(event, "session_start" | "user_prompt_submit")
+}
+
+fn retires_session_route(event: &str) -> bool {
+    event == "session_end"
 }
 
 fn token_key(host: &str, session: &str) -> String {
@@ -466,6 +470,13 @@ mod tests {
         assert!(can_register("user_prompt_submit"));
         assert!(!can_register("pre_tool_use"));
         assert!(!can_register("stop"));
+    }
+
+    #[test]
+    fn only_real_session_end_retires_the_authenticated_route() {
+        assert!(retires_session_route("session_end"));
+        assert!(!retires_session_route("stop"));
+        assert!(!retires_session_route("message_display"));
     }
 
     #[test]

--- a/capsules/capsule-mcp/src/host_hooks.rs
+++ b/capsules/capsule-mcp/src/host_hooks.rs
@@ -263,6 +263,9 @@ fn validate_response_shape(response: &HostHookResponse) -> Result<(), &'static s
     if !is_host(&response.host) {
         return Err("unsupported_host");
     }
+    if response.event.is_none() && response.canonical_hook.is_none() {
+        return Err("missing_event_classification");
+    }
     if response
         .event
         .as_deref()
@@ -448,6 +451,18 @@ mod tests {
         let mut value = response(&request);
         value.event = None;
         assert!(validate_response_shape(&value).is_ok());
+    }
+
+    #[test]
+    fn response_requires_a_source_or_canonical_event_classification() {
+        let request = request();
+        let mut value = response(&request);
+        value.event = None;
+        value.canonical_hook = None;
+        assert_eq!(
+            validate_response_shape(&value),
+            Err("missing_event_classification")
+        );
     }
 
     #[test]

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -44,7 +44,18 @@ Every mapping declares one response class.
 
 The adapter publishes without a correlation ID. Subscribers may observe but
 cannot affect the frontend operation. Session, post-tool, compaction, sub-agent,
-and shutdown events use this class.
+completed-response, and shutdown events use this class. Frontend adapters must
+not conflate a per-turn response event with session termination:
+
+- Codex and Claude `stop` map to `message_sent` and retain
+  `last_assistant_message` in the nested frontend payload;
+- Claude `message_display` maps to `message_displayed` and retains its streamed
+  `delta`; and
+- only `session_end` maps to canonical `session_end`.
+
+These hooks expose the submitted user prompt and rendered assistant text, not
+the frontend's complete provider-bound prompt with hidden system, developer,
+tool, or harness context.
 
 `pre_tool_use` and `permission_request` are also observations on the current
 Oracle relay because its outer response schema can return context only. Binding

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -50,8 +50,17 @@ not conflate a per-turn response event with session termination:
 - Codex and Claude `stop` map to `message_sent` and retain
   `last_assistant_message` in the nested frontend payload;
 - Claude `message_display` maps to `message_displayed` and retains its streamed
-  `delta`; and
-- only `session_end` maps to canonical `session_end`.
+  `delta`;
+- Codex and Claude map only their explicit `session_end` event to canonical
+  `session_end`; and
+- Grok currently maps `stop` to canonical `session_end` because its installed
+  hook contract does not expose a distinct verified termination event.
+
+Adapter responses preserve both names: `event` is the source frontend event,
+while `canonical_hook` is the semantic classification used by authenticated
+route lifecycle handling. `capsule-mcp` retires a route only when
+`canonical_hook` is `session_end`; during a staggered upgrade, a legacy response
+without `canonical_hook` retires only on an explicit source `session_end`.
 
 These hooks expose the submitted user prompt and rendered assistant text, not
 the frontend's complete provider-bound prompt with hidden system, developer,


### PR DESCRIPTION
## What changed

- Map Codex and Claude `stop` events to canonical `message_sent` instead of `session_end`.
- Map Claude `message_display` to canonical `message_displayed` while preserving its streamed `delta` payload.
- Keep real `session_end` distinct and retire authenticated Oracle routes only when the session actually terminates.
- Preserve submitted prompts and completed assistant responses inside the canonical provenance envelope.
- Document that frontend hooks expose submitted/rendered text, not the complete hidden provider-bound prompt.

## Why

The shared frontend adapter treated a per-turn `Stop` event as session termination. That caused completed assistant responses to bypass egress-oriented hook subscribers such as Codewall and prematurely destroyed the authenticated route after every response.

## Validation

- `cargo test -p aos-mcp -p aos-hook-adapter-oracle` — 20 tests passed
- `cargo clippy -p aos-mcp -p aos-hook-adapter-oracle --all-features -- -D warnings`
- Plain capsule builds for `aos-mcp` and `aos-hook-adapter-oracle`
- Installable `.capsule` builds for both changed capsules
- `git diff --check`
