### PR TITLE
fix(mcp): accept AOS host plugin --workspace argv

### DIFF
--- a/crates/unicity-aos-bootstrap/src/mcp/mod.rs
+++ b/crates/unicity-aos-bootstrap/src/mcp/mod.rs
@@ -21,6 +21,12 @@ pub(crate) struct ServeArgs {
     /// Choose where constrained approval forms are presented.
     #[arg(long, value_enum, default_value_t = InteractionMode::Auto)]
     interaction: InteractionMode,
+    /// Project directory the host plugin attached this session to.
+    #[arg(long, value_name = "PATH")]
+    workspace: Option<std::path::PathBuf>,
+    /// Host-plugin compatibility flag forwarded to the runtime shim.
+    #[arg(long = "request-timeout", value_name = "DURATION")]
+    request_timeout: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
@@ -54,7 +60,7 @@ pub(crate) fn handle_serve(principal: Option<String>, args: ServeArgs) -> ExitCo
             return ExitCode::FAILURE;
         }
     };
-    match runtime.block_on(serve(&home, principal.as_deref(), args.interaction)) {
+    match runtime.block_on(serve(&home, principal.as_deref(), args)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("aos mcp serve: {error}");
@@ -66,14 +72,23 @@ pub(crate) fn handle_serve(principal: Option<String>, args: ServeArgs) -> ExitCo
 async fn serve(
     home: &AosHome,
     principal: Option<&str>,
-    mode: InteractionMode,
+    args: ServeArgs,
 ) -> Result<(), String> {
+    let mode = args.interaction;
     let mut runtime_args = Vec::<OsString>::new();
     if let Some(principal) = principal {
         runtime_args.push(OsString::from("--principal"));
         runtime_args.push(OsString::from(principal));
     }
     runtime_args.extend([OsString::from("mcp"), OsString::from("serve")]);
+    if let Some(workspace) = args.workspace.as_ref() {
+        runtime_args.push(OsString::from("--workspace"));
+        runtime_args.push(workspace.as_os_str().to_os_string());
+    }
+    if let Some(timeout) = args.request_timeout.as_ref() {
+        runtime_args.push(OsString::from("--request-timeout"));
+        runtime_args.push(OsString::from(timeout));
+    }
 
     let mut standard_command = home
         .runtime_command_with_args(&runtime_args)

--- a/crates/unicity-aos-bootstrap/src/mcp/mod.rs
+++ b/crates/unicity-aos-bootstrap/src/mcp/mod.rs
@@ -69,11 +69,7 @@ pub(crate) fn handle_serve(principal: Option<String>, args: ServeArgs) -> ExitCo
     }
 }
 
-async fn serve(
-    home: &AosHome,
-    principal: Option<&str>,
-    args: ServeArgs,
-) -> Result<(), String> {
+async fn serve(home: &AosHome, principal: Option<&str>, args: ServeArgs) -> Result<(), String> {
     let mode = args.interaction;
     let mut runtime_args = Vec::<OsString>::new();
     if let Some(principal) = principal {


### PR DESCRIPTION
Closes #85

## Summary

AOS host plugins pass `--workspace` and `--request-timeout` to `aos mcp serve`.
Those flags were rejected. They are accepted and forwarded to the bundled runtime.

## Changes

- `ServeArgs` grows `--workspace` and `--request-timeout`.
- Forwarded to `astrid mcp serve` so the session attaches to the project even when cwd is the runtime home.

## Verification

- Live probe against layout-2 AOS home: plugin argv from cwd `~/.aos/runtime` returned initialize `serverInfo.name=unicity-aos`.
- Requires matching Astrid `mcp serve --workspace` (astrid-runtime/astrid#1607).

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

## Checklist

- [x] I understand every change in this PR.

