### PR TITLE
feat: add signed Station v1 publication adapter

### DIFF
--- a/.github/workflows/station-submit.yml
+++ b/.github/workflows/station-submit.yml
@@ -1,4 +1,4 @@
-name: Station v2 adapter contract
+name: Station v1 adapter contract
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   station-v2-contract:
-    name: Fail-closed Station v2 contract
+    name: Fail-closed Station v1 contract
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -56,7 +56,7 @@ jobs:
           test -f "$evidence/unicity-aos-2026.1.3-release.toml"
           test -f "$evidence/BLAKE3SUMS.txt"
           printf 'AOS_CE_EVIDENCE_ASSETS=%s\n' "$evidence" >> "$GITHUB_ENV"
-      - name: Checkout reviewed station-tools v2 interface
+      - name: Checkout reviewed Station publication interface
         id: station_tools_checkout
         continue-on-error: true
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -69,7 +69,7 @@ jobs:
       - name: Report unavailable station-tools pin and fail closed
         if: steps.station_tools_checkout.outcome != 'success'
         run: |
-          echo "::error::station-tools v2 pin fd233f91b40d00c5f721ba99436ce30eca9036ba was not fetchable; need-a-ruling"
+          echo "::error::station-tools publication pin fd233f91b40d00c5f721ba99436ce30eca9036ba was not fetchable; need-a-ruling"
           exit 1
       - name: Verify and stage station-tools input path
         shell: bash

--- a/.github/workflows/station-submit.yml
+++ b/.github/workflows/station-submit.yml
@@ -1,0 +1,143 @@
+name: Station v2 adapter contract
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  station-v2-contract:
+    name: Fail-closed Station v2 contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: "1.95.0"
+      - name: Install pinned BLAKE3 tool
+        run: cargo install b3sum --locked --version 1.8.5
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Checkout tagged 2026.1.3 source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: unicity-aos/aos-ce
+          ref: 2026.1.3
+          path: .ci/aos-ce-2026.1.3
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify and stage tagged source input path
+        shell: bash
+        run: |
+          set -euo pipefail
+          source="$GITHUB_WORKSPACE/.ci/aos-ce-2026.1.3"
+          test "$(git -C "$source" rev-parse '2026.1.3^{commit}')" = "efaa39f3f0ba80cf2c24985fd4383d8d73dd801a"
+          test "$(git -C "$source" rev-parse 'HEAD^{commit}')" = "efaa39f3f0ba80cf2c24985fd4383d8d73dd801a"
+          test "$(git -C "$source" rev-parse 'HEAD^{tree}')" = "46a8a976d54eb82ac922c56ae41d713595895ff5"
+          target="$RUNNER_TEMP/aos-ce-2026.1.3"
+          test ! -e "$target"
+          mv "$source" "$target"
+          printf 'AOS_CE_TAG_SOURCE_ROOT=%s\n' "$target" >> "$GITHUB_ENV"
+      - name: Download signed 2026.1.3 evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/aos-ce-evidence"
+          mkdir -p "$evidence"
+          gh release download 2026.1.3 --repo unicity-aos/aos-ce --dir "$evidence"
+          test -f "$evidence/unicity-aos-2026.1.3-release.toml"
+          test -f "$evidence/BLAKE3SUMS.txt"
+          printf 'AOS_CE_EVIDENCE_ASSETS=%s\n' "$evidence" >> "$GITHUB_ENV"
+      - name: Checkout reviewed station-tools v2 interface
+        id: station_tools_checkout
+        continue-on-error: true
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: astrid-runtime/station-tools
+          ref: fd233f91b40d00c5f721ba99436ce30eca9036ba
+          path: .ci/station-tools-33d1d127
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Report unavailable station-tools pin and fail closed
+        if: steps.station_tools_checkout.outcome != 'success'
+        run: |
+          echo "::error::station-tools v2 pin fd233f91b40d00c5f721ba99436ce30eca9036ba was not fetchable; need-a-ruling"
+          exit 1
+      - name: Verify and stage station-tools input path
+        shell: bash
+        run: |
+          set -euo pipefail
+          station_tools="$GITHUB_WORKSPACE/.ci/station-tools-33d1d127"
+          test "$(git -C "$station_tools" rev-parse 'HEAD^{commit}')" = "fd233f91b40d00c5f721ba99436ce30eca9036ba"
+          test "$(git -C "$station_tools" rev-parse 'HEAD^{tree}')" = "0bf775f225bfb9177d5788ec8c32d5453f75c660"
+          test -z "$(git -C "$station_tools" status --porcelain=v1 --untracked-files=all)"
+          target="$RUNNER_TEMP/station-tools-33d1d127"
+          test ! -e "$target"
+          mv "$station_tools" "$target"
+          printf 'AOS_CE_STATION_TOOLS=%s\n' "$target" >> "$GITHUB_ENV"
+      - name: Provision locked Station dependency graph in a clean Cargo home
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo_home="$RUNNER_TEMP/aos-station-cargo-home"
+          test ! -e "$cargo_home"
+          mkdir -p "$cargo_home"
+          printf 'CARGO_HOME=%s\n' "$cargo_home" >> "$GITHUB_ENV"
+          CARGO_HOME="$cargo_home" cargo fetch \
+            --manifest-path "$AOS_CE_STATION_TOOLS/Cargo.toml" \
+            --locked
+      - name: Assert b3sum-only Cargo home fails closed for Station dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          b3sum_home="$RUNNER_TEMP/aos-b3sum-only-home"
+          test ! -e "$b3sum_home"
+          mkdir -p "$b3sum_home"
+          CARGO_HOME="$b3sum_home" cargo install b3sum --locked --version 1.8.5
+          set +e
+          b3sum_stderr="$RUNNER_TEMP/aos-b3sum-build.stderr"
+          CARGO_HOME="$b3sum_home" cargo build \
+            --manifest-path "$AOS_CE_STATION_TOOLS/Cargo.toml" \
+            --offline --locked \
+            2>"$b3sum_stderr"
+          status=$?
+          set -e
+          test "$status" -eq 101
+          grep -F 'no matching package named `thiserror` found' "$b3sum_stderr"
+          grep -F 'offline mode (--offline)' "$b3sum_stderr"
+      - name: Run adapter boundary regressions
+        run: python3 -m unittest -v scripts/test_aos_station_adapter.py
+      - name: Assert live path remains inert
+        run: |
+          output="$RUNNER_TEMP/aos-station-live-path"
+          set +e
+          python3 scripts/aos_station_adapter.py \
+            --artifacts "$RUNNER_TEMP/missing-assets" \
+            --source-root "$RUNNER_TEMP/missing-source" \
+            --current-main-root "$GITHUB_WORKSPACE" \
+            --station-tools "$RUNNER_TEMP/missing-station-tools" \
+            --output "$output" \
+            >"$RUNNER_TEMP/adapter.stdout" 2>"$RUNNER_TEMP/adapter.stderr"
+          status=$?
+          set -e
+          test "$status" -eq 2
+          test ! -e "$output"
+          grep -F "blocked before writes" "$RUNNER_TEMP/adapter.stderr"
+      - name: Assert publication APIs remain absent from the workflow
+        run: |
+          forbidden_git="git p"
+          forbidden_git="${forbidden_git}ush"
+          forbidden_release="gh release"
+          forbidden_release="${forbidden_release} upload"
+          forbidden_api="write_"
+          forbidden_api="${forbidden_api}submission"
+          ! grep -R -n -E "${forbidden_git}|${forbidden_release}|${forbidden_api}" \
+            scripts/aos_station_adapter.py scripts/aos_station_adapter .github/workflows/station-submit.yml

--- a/release/station/README.md
+++ b/release/station/README.md
@@ -1,0 +1,20 @@
+# AOS CE Station seed
+
+`aos-seed.toml` is the reviewed policy projection for the 19 capsule packages
+released by the exact `2026.1.3` AOS Community Edition tag. Each coordinate is
+the literal `@aos/<package.name>@<package.version>` value from `Capsule.toml`;
+the package version, not the product version, is the record version.
+
+The adapter verifies the tag-bound release metadata, checksums, capsule
+manifests, package versions, and Sigstore workflow identity before producing a
+local proposal tree. It blocks the three current-main extras (`aos-mcp`,
+`aos-hook-adapter-oracle`, and `aos-meta-harness`) until a new signed AOS
+release. `aos-openai`, `aos-telegram`, and legacy `astrid-capsule-*` identities
+are excluded from this seed.
+
+The emitted dry-run tree contains typed `PublicationRecordV2` records and
+content-addressed artifacts prepared by the reviewed `station-publish`
+`prepare_v2` API. They carry a documented local fixture publisher only:
+readiness stays false while the admitting-owner binding is unresolved. The
+adapter never pushes, signs, or publishes Station content; network publication
+is a permanently rejected option. The default/live path exits before writes.

--- a/release/station/aos-seed.toml
+++ b/release/station/aos-seed.toml
@@ -1,0 +1,163 @@
+schema-version = 1
+kind = "aos-ce-station-seed"
+status = "proposal-incomplete"
+
+[station]
+station-id = "aos"
+pages-base-url = "https://unicity-aos.github.io/station/v1"
+reserved-namespace = "aos" # allowlist scope only; no namespace claim is emitted
+
+[source]
+repository = "https://github.com/unicity-aos/aos-ce"
+repository-slug = "unicity-aos/aos-ce"
+github-owner-id = 261740341
+github-repository-id = 1298696137
+commit = "efaa39f3f0ba80cf2c24985fd4383d8d73dd801a"
+tree = "46a8a976d54eb82ac922c56ae41d713595895ff5"
+tag = "2026.1.3"
+workflow-identity = "https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/2026.1.3"
+workflow-issuer = "https://token.actions.githubusercontent.com"
+
+# These 19 entries are an allowlist check only.  The adapter reads package.name
+# and package.version from each exact tagged Capsule.toml and rejects any
+# mismatch before prepare_v2; this file is never a record source.
+[[seed]]
+directory = "capsule-cli"
+package = "aos-cli"
+version = "0.2.0"
+coordinate = "@aos/aos-cli@0.2.0"
+
+[[seed]]
+directory = "capsule-registry"
+package = "aos-registry"
+version = "0.2.0"
+coordinate = "@aos/aos-registry@0.2.0"
+
+[[seed]]
+directory = "capsule-openai-compat"
+package = "aos-openai-compat"
+version = "0.2.0"
+coordinate = "@aos/aos-openai-compat@0.2.0"
+
+[[seed]]
+directory = "capsule-react"
+package = "aos-react"
+version = "0.2.2"
+coordinate = "@aos/aos-react@0.2.2"
+
+[[seed]]
+directory = "capsule-session"
+package = "aos-session"
+version = "0.2.0"
+coordinate = "@aos/aos-session@0.2.0"
+
+[[seed]]
+directory = "capsule-identity"
+package = "aos-identity"
+version = "0.2.0"
+coordinate = "@aos/aos-identity@0.2.0"
+
+[[seed]]
+directory = "capsule-users"
+package = "aos-users"
+version = "0.1.0"
+coordinate = "@aos/aos-users@0.1.0"
+
+[[seed]]
+directory = "capsule-router"
+package = "aos-router"
+version = "0.2.0"
+coordinate = "@aos/aos-router@0.2.0"
+
+[[seed]]
+directory = "capsule-prompt-builder"
+package = "aos-prompt-builder"
+version = "0.2.0"
+coordinate = "@aos/aos-prompt-builder@0.2.0"
+
+[[seed]]
+directory = "capsule-context-engine"
+package = "aos-context-engine"
+version = "0.2.0"
+coordinate = "@aos/aos-context-engine@0.2.0"
+
+[[seed]]
+directory = "capsule-hook-bridge"
+package = "aos-hook-bridge"
+version = "0.2.0"
+coordinate = "@aos/aos-hook-bridge@0.2.0"
+
+[[seed]]
+directory = "capsule-shell"
+package = "aos-shell"
+version = "0.2.0"
+coordinate = "@aos/aos-shell@0.2.0"
+
+[[seed]]
+directory = "capsule-http"
+package = "aos-http"
+version = "0.1.1"
+coordinate = "@aos/aos-http@0.1.1"
+
+[[seed]]
+directory = "capsule-fs"
+package = "aos-fs"
+version = "0.2.0"
+coordinate = "@aos/aos-fs@0.2.0"
+
+[[seed]]
+directory = "capsule-system"
+package = "aos-system"
+version = "0.2.0"
+coordinate = "@aos/aos-system@0.2.0"
+
+[[seed]]
+directory = "capsule-forge"
+package = "aos-forge"
+version = "0.1.0"
+coordinate = "@aos/aos-forge@0.1.0"
+
+[[seed]]
+directory = "capsule-skills"
+package = "aos-skills"
+version = "0.2.0"
+coordinate = "@aos/aos-skills@0.2.0"
+
+[[seed]]
+directory = "capsule-agents"
+package = "aos-agents"
+version = "0.2.0"
+coordinate = "@aos/aos-agents@0.2.0"
+
+[[seed]]
+directory = "capsule-memory"
+package = "aos-memory"
+version = "0.2.0"
+coordinate = "@aos/aos-memory@0.2.0"
+
+[[blocked]]
+directory = "capsule-mcp"
+package = "aos-mcp"
+reason = "current-main extra; wait for a new signed versioned AOS release"
+
+[[blocked]]
+directory = "capsule-hook-adapter-oracle"
+package = "aos-hook-adapter-oracle"
+reason = "current-main extra; wait for a new signed versioned AOS release"
+
+[[blocked]]
+directory = "capsule-meta-harness"
+package = "aos-meta-harness"
+reason = "current-main extra; wait for a new signed versioned AOS release"
+
+[[excluded]]
+package = "aos-openai"
+reason = "not in the 2026.1.3 community seed"
+
+[[excluded]]
+package = "aos-telegram"
+reason = "not in the 2026.1.3 community seed"
+
+[[excluded]]
+package = "astrid-capsule-*"
+reason = "legacy standalone identity; never an AOS CE seed coordinate"

--- a/scripts/aos_station_adapter.py
+++ b/scripts/aos_station_adapter.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Prepare an inert, deterministic AOS CE 2026.1.3 Station v2 submission.
+"""Prepare an inert, deterministic AOS CE 2026.1.3 Station v1 submission.
 
 The default command is deliberately fail-closed.  An explicit ``--dry-run``
 executes the reviewed ``astrid-station-publish::prepare_v2`` API with a
-non-admitting fixture identity, emits 19 sealed v2 records and artifacts, and
+non-admitting fixture identity, emits 19 sealed publication records and artifacts, and
 round-trips them through the Station protocol. It never signs, pushes, or
 publishes anything.
 """
@@ -55,7 +55,7 @@ def parser() -> argparse.ArgumentParser:
         "--station-tools",
         type=Path,
         required=True,
-        help=f"station-tools checkout at reviewed local v2 interface {policy.STATION_TOOLS_COMMIT}",
+        help=f"station-tools checkout at reviewed publication interface {policy.STATION_TOOLS_COMMIT}",
     )
     root.add_argument("--output", type=Path, required=True, help="fresh local output tree")
     root.add_argument("--b3sum", default="b3sum", help="pinned b3sum executable")
@@ -68,7 +68,7 @@ def parser() -> argparse.ArgumentParser:
     root.add_argument(
         "--dry-run",
         action="store_true",
-        help="emit a deterministic local v2 fixture; readiness and live authority remain false",
+        help="emit a deterministic local publication fixture; readiness and live authority remain false",
     )
     root.add_argument(
         "--publish",
@@ -232,7 +232,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(
             f"proposal-incomplete: verified {report['verification']['seed_count']} capsules; "
-            f"prepared {report['publication']['record_count']} station-v2 records with a non-admitting fixture; "
+            f"prepared {report['publication']['record_count']} Station publication records with a non-admitting fixture; "
             "network publication disabled"
         )
     return 0

--- a/scripts/aos_station_adapter.py
+++ b/scripts/aos_station_adapter.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Prepare an inert, deterministic AOS CE 2026.1.3 Station v2 submission.
+
+The default command is deliberately fail-closed.  An explicit ``--dry-run``
+executes the reviewed ``astrid-station-publish::prepare_v2`` API with a
+non-admitting fixture identity, emits 19 sealed v2 records and artifacts, and
+round-trips them through the Station protocol. It never signs, pushes, or
+publishes anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+from aos_station_adapter import policy
+from aos_station_adapter.adapter import (
+    AdapterError,
+    InertOnlyError,
+    _tree_manifest,
+    emit_submission_skeleton,
+    prepare_v2_records,
+)
+from aos_station_adapter.release import VerificationError, verify_release
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    root.add_argument(
+        "--artifacts",
+        type=Path,
+        required=True,
+        help="local directory containing the exact signed 2026.1.3 release assets",
+    )
+    root.add_argument(
+        "--source-root",
+        type=Path,
+        default=ROOT,
+        help="clean detached exact 2026.1.3 source checkout",
+    )
+    root.add_argument(
+        "--current-main-root",
+        type=Path,
+        default=ROOT,
+        help="current-main checkout used only for the independent 22-vs-19 drift check",
+    )
+    root.add_argument(
+        "--station-tools",
+        type=Path,
+        required=True,
+        help=f"station-tools checkout at reviewed local v2 interface {policy.STATION_TOOLS_COMMIT}",
+    )
+    root.add_argument("--output", type=Path, required=True, help="fresh local output tree")
+    root.add_argument("--b3sum", default="b3sum", help="pinned b3sum executable")
+    root.add_argument("--cosign", default="cosign", help="cosign executable")
+    root.add_argument(
+        "--skip-sigstore",
+        action="store_true",
+        help="skip cryptographic cosign calls for offline fixture inspection (report remains incomplete)",
+    )
+    root.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="emit a deterministic local v2 fixture; readiness and live authority remain false",
+    )
+    root.add_argument(
+        "--publish",
+        action="store_true",
+        help="disabled permanently; network publication is outside this adapter",
+    )
+    root.add_argument("--json", action="store_true", help="print the final report as JSON")
+    return root
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def _blocked_report(output: Path, error: str, *, verification: dict[str, Any] | None = None) -> dict[str, Any]:
+    report = {
+        "schema": "aos-station-adapter-report-v2",
+        "readiness": False,
+        "blockers": ["verification-failed"],
+        "dry_run": True,
+        "network_publish": False,
+        "error": error,
+        "record_count": 0,
+        "event_count": 0,
+    }
+    if verification is not None:
+        report["verification"] = verification
+    # Validation failures may point at caller-owned paths. Never follow a
+    # symlink or append a report to a non-empty tree that the adapter did not
+    # create itself.
+    if output.is_symlink():
+        return report
+    if output.exists() and (not output.is_dir() or any(output.iterdir())):
+        return report
+    output.mkdir(parents=True, exist_ok=True)
+    _write_json(output / "reports" / "adapter-report.json", report)
+    return report
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    if args.publish:
+        raise InertOnlyError(
+            "network publication is permanently disabled; remove --publish and review the inert local tree"
+        )
+    if not args.dry_run:
+        raise InertOnlyError(
+            "admitting owner material is unresolved; default mode exits before any output; use --dry-run for inert inspection"
+        )
+    if args.output.exists() and (args.output.is_symlink() or not args.output.is_dir()):
+        raise AdapterError(f"output path is not a directory: {args.output}")
+    if args.output.exists() and any(args.output.iterdir()):
+        raise AdapterError(f"output path must be fresh or empty: {args.output}")
+
+    verification = verify_release(
+        args.artifacts,
+        args.source_root,
+        b3sum=args.b3sum,
+        cosign=args.cosign,
+        skip_sigstore=args.skip_sigstore,
+        current_main_root=args.current_main_root,
+    )
+    skeleton = emit_submission_skeleton(args.output, verification)
+    publication = prepare_v2_records(
+        args.station_tools,
+        args.artifacts,
+        args.source_root,
+        skeleton["submission"],
+        b3sum=args.b3sum,
+    )
+    repeat_submission = args.output / ".submission-repeat"
+    repeat_submission.mkdir()
+    repeat_publication = prepare_v2_records(
+        args.station_tools,
+        args.artifacts,
+        args.source_root,
+        repeat_submission,
+        b3sum=args.b3sum,
+    )
+    if repeat_publication["records"] != publication["records"]:
+        raise AdapterError("prepare_v2 output is not deterministic")
+    if _tree_manifest(skeleton["submission"] / "records") != _tree_manifest(
+        repeat_submission / "records"
+    ) or _tree_manifest(skeleton["submission"] / "artifacts") != _tree_manifest(
+        repeat_submission / "artifacts"
+    ):
+        raise AdapterError("prepare_v2 record/artifact bytes are not deterministic")
+    shutil.rmtree(repeat_submission)
+    # The record files are the sole per-package contract. Keep this report to
+    # aggregate execution facts so it cannot become a second 19-record schema.
+    publication_report = {
+        "tool": publication["tool"],
+        "interface": publication["interface"],
+        "fixture": publication["fixture"],
+        "record_count": publication["record_count"],
+        "event_count": publication["event_count"],
+    }
+    _write_json(
+        skeleton["reports"] / "publication-v2.json",
+        publication_report,
+    )
+    _write_json(
+        skeleton["reports"] / "readiness.json",
+        {
+            "schema": "aos-station-readiness-v2",
+            "readiness": False,
+            "blockers": ["admission-contract-pending", "owner-binding-unresolved"],
+            "record_count": publication["record_count"],
+            "event_count": publication["event_count"],
+            "publication_schema": "station-v2",
+        },
+    )
+    report = {
+        "schema": "aos-station-adapter-report-v2",
+        "readiness": False,
+        "blockers": ["admission-contract-pending", "owner-binding-unresolved"],
+        "dry_run": args.dry_run,
+        "network_publish": False,
+        "verification": verification,
+        "submission": {
+            "path": str(skeleton["submission"].relative_to(args.output)),
+            "proposal_count": skeleton["proposal_count"],
+            "record_count": publication["record_count"],
+            "event_count": publication["event_count"],
+        },
+        "publication": {
+            "schema": "station-v2",
+            "interface": publication["interface"],
+            "record_count": publication["record_count"],
+            "event_count": publication["event_count"],
+            "fixture_readiness": publication["fixture"]["readiness"],
+            "fixture_binding": publication["fixture"]["binding"],
+        },
+        "consumer": {
+            "interface": "astrid-station-protocol::PublicationRecordV2",
+            "record_paths": publication["record_count"],
+            "artifact_paths": publication["record_count"],
+            "deterministic": True,
+        },
+    }
+    _write_json(args.output / "reports" / "adapter-report.json", report)
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        report = run(args)
+    except InertOnlyError as error:
+        print(f"aos station adapter: blocked before writes: {error}", file=sys.stderr)
+        return 2
+    except (AdapterError, VerificationError, OSError, ValueError) as error:
+        blocked = _blocked_report(args.output, str(error))
+        if args.json:
+            print(json.dumps(blocked, indent=2, sort_keys=True))
+        else:
+            print(f"aos station adapter: blocked: {error}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            f"proposal-incomplete: verified {report['verification']['seed_count']} capsules; "
+            f"prepared {report['publication']['record_count']} station-v2 records with a non-admitting fixture; "
+            "network publication disabled"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/aos_station_adapter/__init__.py
+++ b/scripts/aos_station_adapter/__init__.py
@@ -1,0 +1,1 @@
+"""AOS Community Edition Station adapter implementation."""

--- a/scripts/aos_station_adapter/adapter.py
+++ b/scripts/aos_station_adapter/adapter.py
@@ -1,4 +1,4 @@
-"""Fail-closed AOS Station v2 preparation and deterministic local output."""
+"""Fail-closed AOS Station v1 publication preparation and deterministic local output."""
 
 from __future__ import annotations
 
@@ -278,7 +278,7 @@ def _verify_worktree_tree(station_tools: Path, expected: dict[str, tuple[str, in
 
 
 def check_station_tools_pin(station_tools: Path) -> dict[str, str]:
-    """Require the exact reviewed local v2 interface and immutable tree."""
+    """Require the exact reviewed publication interface and immutable tree."""
     if not station_tools.is_dir() or station_tools.is_symlink():
         raise AdapterError(f"station-tools checkout is not a directory: {station_tools}")
     head = _run(
@@ -291,7 +291,7 @@ def check_station_tools_pin(station_tools: Path) -> dict[str, str]:
     ).stdout.strip()
     if head != policy.STATION_TOOLS_COMMIT or tree != policy.STATION_TOOLS_TREE:
         raise AdapterError(
-            "station-tools checkout is not the reviewed v2 interface "
+            "station-tools checkout is not the reviewed publication interface "
             f"(head={head!r}, tree={tree!r})"
         )
     _index_flags(station_tools)
@@ -372,8 +372,8 @@ def emit_submission_skeleton(root: Path, verification: dict[str, Any]) -> dict[s
     _write_regular(
         submission / "README.md",
         (
-            "# AOS CE Station v2 proposal\n\n"
-            "This local tree is a readiness fixture. It contains sealed v2 "
+            "# AOS CE Station v1 publication proposal\n\n"
+            "This local tree is a readiness fixture. It contains sealed publication "
             "publication records produced by the reviewed `prepare_v2` API, "
             "but readiness remains false: fixture publisher material is not a "
             "namespace owner or live signing authority. This adapter cannot "
@@ -476,7 +476,7 @@ def _freeze_export(export: Path) -> None:
 def _bridge_manifest(station_tools: Path, cargo: str) -> Path:
     """Build only from a verified Git export, never from the operator checkout."""
     if not BRIDGE_SOURCE.is_file() or BRIDGE_SOURCE.is_symlink():
-        raise AdapterError(f"v2 bridge source is missing: {BRIDGE_SOURCE}")
+        raise AdapterError(f"publication bridge source is missing: {BRIDGE_SOURCE}")
     # Re-check at the build boundary so direct callers cannot bypass the
     # worktree and index validation performed by prepare_v2_records.
     check_station_tools_pin(station_tools)
@@ -494,7 +494,7 @@ def _bridge_manifest(station_tools: Path, cargo: str) -> Path:
     manifest = export / "Cargo.toml"
     _run(
         [cargo, "fetch", "--manifest-path", str(manifest), "--locked"],
-        context="station v2 locked dependency fetch",
+        context="Station publication locked dependency fetch",
         env=build_env,
     )
     _run(
@@ -511,12 +511,12 @@ def _bridge_manifest(station_tools: Path, cargo: str) -> Path:
             "--bin",
             "aos-station-v2-bridge",
         ],
-        context="station v2 bridge build",
+        context="Station publication bridge build",
         env=build_env,
     )
     binary = export / "target" / "debug" / "aos-station-v2-bridge"
     if not binary.is_file() or binary.is_symlink():
-        raise AdapterError("station v2 bridge build did not produce an executable")
+        raise AdapterError("Station publication bridge build did not produce an executable")
     return binary
 
 

--- a/scripts/aos_station_adapter/adapter.py
+++ b/scripts/aos_station_adapter/adapter.py
@@ -1,0 +1,671 @@
+"""Fail-closed AOS Station v2 preparation and deterministic local output."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import stat
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+from pathlib import PurePosixPath
+from typing import Any
+
+from . import policy
+
+
+class AdapterError(RuntimeError):
+    """The adapter cannot safely produce the requested local submission."""
+
+
+class InertOnlyError(AdapterError):
+    """The caller did not explicitly select the non-authoritative fixture path."""
+
+
+BRIDGE_SOURCE = Path(__file__).with_name("prepare_v2_bridge.rs")
+
+
+def _git_command(*arguments: str) -> list[str]:
+    """Run Git inspection/export commands without replacement refs."""
+    return ["git", "--no-replace-objects", *arguments]
+
+
+def _canonical_json(value: Any) -> bytes:
+    return (
+        json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+    ).encode("utf-8")
+
+
+def _write_regular(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise AdapterError(f"refusing to overwrite symlink: {path}")
+    path.write_bytes(content)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _tree_manifest(root: Path) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        if path.is_symlink():
+            raise AdapterError(f"output tree contains a symlink: {path}")
+        entries.append(
+            {
+                "path": path.relative_to(root).as_posix(),
+                "sha256": _sha256(path),
+                "size": path.stat().st_size,
+            }
+        )
+    return entries
+
+
+def _run(
+    command: list[str],
+    *,
+    context: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    except OSError as error:
+        raise AdapterError(f"cannot invoke {context}: {error}") from error
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
+        raise AdapterError(f"{context} failed: {detail}")
+    return completed
+
+
+def _run_bytes(command: list[str], *, context: str) -> bytes:
+    """Run a command whose output must remain byte-for-byte intact."""
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+        )
+    except OSError as error:
+        raise AdapterError(f"cannot invoke {context}: {error}") from error
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", "replace").strip() or "unknown error"
+        raise AdapterError(f"{context} failed: {detail}")
+    return completed.stdout
+
+
+def _b3sum_bytes(data: bytes, executable: str) -> str:
+    with tempfile.NamedTemporaryFile(prefix="aos-station-fixture-", delete=False) as handle:
+        path = Path(handle.name)
+        handle.write(data)
+    try:
+        completed = _run([executable, "--", str(path)], context="BLAKE3 fixture digest")
+        value = completed.stdout.split()
+        if not value or len(value[0]) != 64 or any(char not in "0123456789abcdef" for char in value[0]):
+            raise AdapterError("BLAKE3 fixture digest tool returned malformed output")
+        return value[0]
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def _source_tree_digest(source_root: Path, executable: str) -> str:
+    """Hash the exact tagged tree listing used for source provenance."""
+    completed = _run(
+        _git_command(
+            "-C",
+            str(source_root),
+            "ls-tree",
+            "-r",
+            "-l",
+            policy.SOURCE_COMMIT,
+        ),
+        context="tagged source tree listing",
+    )
+    return _b3sum_bytes(completed.stdout.encode("utf-8"), executable)
+
+
+def _git_tree(station_tools: Path) -> dict[str, tuple[str, int, int]]:
+    """Read the expected path, object, and mode directly from the pinned tree."""
+    listing = _run(
+        _git_command(
+            "-C",
+            str(station_tools),
+            "ls-tree",
+            "-r",
+            "-z",
+            "--full-tree",
+            "--long",
+            policy.STATION_TOOLS_COMMIT,
+        ),
+        context="station-tools pinned tree listing",
+    ).stdout
+    expected: dict[str, tuple[str, int, int]] = {}
+    for record in listing.rstrip("\0").split("\0"):
+        if not record:
+            continue
+        metadata, path = record.split("\t", 1)
+        mode, object_type, object_id, size = metadata.split(" ", 3)
+        if object_type != "blob" or mode not in {"100644", "100755"}:
+            raise AdapterError(
+                "station-tools pinned tree contains an unexpected non-regular entry: "
+                f"{mode} {object_type} {path}"
+            )
+        if path == ".git" or path.startswith(".git/"):
+            raise AdapterError(f"station-tools pinned tree contains reserved path: {path}")
+        expected[path] = (object_id, int(size), int(mode, 8) & 0o777)
+    if not expected:
+        raise AdapterError("station-tools pinned tree is empty")
+    return expected
+
+
+def _index_flags(station_tools: Path) -> None:
+    """Reject index optimization flags without relying on index dirt checks."""
+    listing = _run(
+        _git_command("-C", str(station_tools), "ls-files", "-v", "-z"),
+        context="station-tools index flag check",
+    ).stdout
+    for record in listing.rstrip("\0").split("\0"):
+        if not record:
+            continue
+        marker, separator, path = record.partition(" ")
+        if not separator:
+            raise AdapterError("station-tools index listing is malformed")
+        if marker.islower() or marker == "S":
+            raise AdapterError(
+                "station-tools index has assume-unchanged or skip-worktree flag: "
+                f"{path}"
+            )
+
+
+def _git_blob_digest(data: bytes) -> str:
+    header = f"blob {len(data)}\0".encode("ascii")
+    return hashlib.sha1(header + data).hexdigest()
+
+
+def _verify_worktree_tree(station_tools: Path, expected: dict[str, tuple[str, int, int]]) -> None:
+    """Compare every worktree byte and mode to Git objects, including ignored paths."""
+    expected_files = set(expected)
+    expected_dirs = {""}
+    for path in expected_files:
+        parts = path.split("/")
+        expected_dirs.update("/".join(parts[:index]) for index in range(1, len(parts)))
+
+    def check_entry(path: Path, relative: str) -> None:
+        try:
+            metadata = path.lstat()
+        except OSError as error:
+            raise AdapterError(f"cannot inspect station-tools entry {path}: {error}") from error
+        if stat.S_ISLNK(metadata.st_mode):
+            raise AdapterError(f"station-tools checkout contains an unexpected symlink: {relative}")
+        if stat.S_ISDIR(metadata.st_mode):
+            if relative not in expected_dirs:
+                raise AdapterError(f"station-tools checkout has an extra filesystem entry: {relative}")
+            try:
+                entries = list(path.iterdir())
+            except OSError as error:
+                raise AdapterError(f"cannot read station-tools directory {path}: {error}") from error
+            for child in entries:
+                child_relative = child.name if not relative else f"{relative}/{child.name}"
+                if relative or child.name != ".git":
+                    check_entry(child, child_relative)
+            return
+        if not stat.S_ISREG(metadata.st_mode):
+            raise AdapterError(f"station-tools checkout has an unexpected filesystem entry: {relative}")
+        if relative not in expected_files:
+            raise AdapterError(f"station-tools checkout has an extra filesystem entry: {relative}")
+        object_id, expected_size, expected_mode = expected[relative]
+        mode = stat.S_IMODE(metadata.st_mode)
+        if mode != expected_mode:
+            raise AdapterError(
+                f"station-tools mode drift for {relative}: expected {expected_mode:o}, got {mode:o}"
+            )
+        try:
+            content = path.read_bytes()
+        except OSError as error:
+            raise AdapterError(f"cannot read station-tools entry {path}: {error}") from error
+        if len(content) != expected_size or _git_blob_digest(content) != object_id:
+            raise AdapterError(f"station-tools content drift for {relative}")
+
+    if station_tools.is_symlink() or not station_tools.is_dir():
+        raise AdapterError(f"station-tools checkout is not a directory: {station_tools}")
+    for child in station_tools.iterdir():
+        if child.name == ".git":
+            if child.is_symlink():
+                raise AdapterError("station-tools checkout contains an unexpected .git symlink")
+            continue
+        check_entry(child, child.name)
+    actual_files: set[str] = set()
+    actual_dirs: set[str] = {""}
+    for path in station_tools.rglob("*"):
+        relative = path.relative_to(station_tools).as_posix()
+        if relative == ".git" or relative.startswith(".git/"):
+            continue
+        if path.is_symlink():
+            raise AdapterError(f"station-tools checkout contains an unexpected symlink: {relative}")
+        if path.is_dir():
+            actual_dirs.add(relative)
+        elif path.is_file():
+            actual_files.add(relative)
+    if actual_files != expected_files or actual_dirs != expected_dirs:
+        missing = sorted(expected_files - actual_files)
+        extras = sorted(actual_files - expected_files)
+        missing_dirs = sorted(expected_dirs - actual_dirs)
+        extra_dirs = sorted(actual_dirs - expected_dirs)
+        detail = ", ".join(
+            item
+            for item in (
+                f"missing={missing[:3]}" if missing else "",
+                f"extra={extras[:3]}" if extras else "",
+                f"missing_dirs={missing_dirs[:3]}" if missing_dirs else "",
+                f"extra_dirs={extra_dirs[:3]}" if extra_dirs else "",
+            )
+            if item
+        )
+        raise AdapterError(f"station-tools filesystem tree differs from pinned objects: {detail}")
+
+
+def check_station_tools_pin(station_tools: Path) -> dict[str, str]:
+    """Require the exact reviewed local v2 interface and immutable tree."""
+    if not station_tools.is_dir() or station_tools.is_symlink():
+        raise AdapterError(f"station-tools checkout is not a directory: {station_tools}")
+    head = _run(
+        _git_command("-C", str(station_tools), "rev-parse", "HEAD^{commit}"),
+        context="station-tools pin check",
+    ).stdout.strip()
+    tree = _run(
+        _git_command("-C", str(station_tools), "rev-parse", "HEAD^{tree}"),
+        context="station-tools tree check",
+    ).stdout.strip()
+    if head != policy.STATION_TOOLS_COMMIT or tree != policy.STATION_TOOLS_TREE:
+        raise AdapterError(
+            "station-tools checkout is not the reviewed v2 interface "
+            f"(head={head!r}, tree={tree!r})"
+        )
+    _index_flags(station_tools)
+    expected = _git_tree(station_tools)
+    _verify_worktree_tree(station_tools, expected)
+    dirt = _run(
+        _git_command(
+            "-C",
+            str(station_tools),
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+        ),
+        context="station-tools dirt check",
+    ).stdout
+    if dirt.strip():
+        raise AdapterError(
+            "station-tools checkout is dirty; must not compile prepare_v2 from a dirty tree"
+        )
+    manifest = station_tools / "Cargo.toml"
+    if not manifest.is_file() or manifest.is_symlink():
+        raise AdapterError(f"station-tools Cargo.toml is missing: {manifest}")
+    return {
+        "repository": "astrid-runtime/station-tools",
+        "commit": head,
+        "tree": tree,
+        "interface": "astrid-station-publish::prepare_v2",
+    }
+
+
+def emit_submission_skeleton(root: Path, verification: dict[str, Any]) -> dict[str, Any]:
+    """Create the typed submission roots and a non-authoritative proposal."""
+    if root.exists():
+        if root.is_symlink() or not root.is_dir():
+            raise AdapterError(f"output path is not a directory: {root}")
+        if any(root.iterdir()):
+            raise AdapterError(f"output path must be fresh or empty: {root}")
+    root.mkdir(parents=True, exist_ok=True)
+    submission = root / "submission"
+    reports = root / "reports"
+    for directory in (submission, reports):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    proposals = {
+        "schema": "aos-station-v2-proposal-v1",
+        "readiness": False,
+        "blockers": ["admission-contract-pending", "owner-binding-unresolved"],
+        "station_id": policy.STATION_ID,
+        "source": {
+            "repository": policy.SOURCE_REPOSITORY,
+            "commit": policy.SOURCE_COMMIT,
+            "tree": policy.SOURCE_TREE,
+            "tag": policy.SOURCE_TAG,
+            "workflow_identity": policy.SOURCE_WORKFLOW_IDENTITY,
+        },
+        "allowlist_coordinates": [item.coordinate for item in policy.SEED],
+        "allowlist_directories": [item.directory for item in policy.SEED],
+        "blocked": [
+            {
+                "directory": directory,
+                "package": package,
+                "reason": "current-main extra; wait for a new signed versioned AOS release",
+            }
+            for directory, package in sorted(policy.BLOCKED_DIRECTORIES.items())
+        ],
+        "excluded": [
+            {"package": "aos-openai", "reason": "not in the 2026.1.3 community seed"},
+            {"package": "aos-telegram", "reason": "not in the 2026.1.3 community seed"},
+            {
+                "package": "astrid-capsule-*",
+                "reason": "legacy standalone identity; never an AOS CE seed coordinate",
+            },
+        ],
+    }
+    _write_regular(
+        submission / "proposals" / "aos-ce-2026.1.3.json", _canonical_json(proposals)
+    )
+    _write_regular(
+        submission / "README.md",
+        (
+            "# AOS CE Station v2 proposal\n\n"
+            "This local tree is a readiness fixture. It contains sealed v2 "
+            "publication records produced by the reviewed `prepare_v2` API, "
+            "but readiness remains false: fixture publisher material is not a "
+            "namespace owner or live signing authority. This adapter cannot "
+            "activate, push, sign, or publish Station content.\n"
+        ).encode("utf-8"),
+    )
+    _write_regular(reports / "release-verification.json", _canonical_json(verification))
+    for directory in ("records", "events", "namespaces", "artifacts"):
+        (submission / directory).mkdir(parents=True, exist_ok=True)
+    return {
+        "submission": submission,
+        "reports": reports,
+        "proposal_count": len(policy.SEED),
+        "record_count": 0,
+        "event_count": 0,
+    }
+
+
+def _materialize_station_tools(station_tools: Path) -> Path:
+    """Export only pinned Git objects into a fresh tree and verify every byte."""
+    expected = _git_tree(station_tools)
+    archive = _run_bytes(
+        _git_command(
+            "-C",
+            str(station_tools),
+            "archive",
+            "--format=tar",
+            "--prefix=",
+            policy.STATION_TOOLS_COMMIT,
+        ),
+        context="station-tools immutable Git export",
+    )
+    export = Path(tempfile.mkdtemp(prefix="aos-station-tools-export-"))
+    seen_files: set[str] = set()
+    seen_dirs: set[str] = {""}
+    try:
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as reader:
+            for member in reader:
+                name = member.name.rstrip("/")
+                path = PurePosixPath(name)
+                if (
+                    not name
+                    or path.is_absolute()
+                    or ".." in path.parts
+                    or "." in path.parts
+                    or "\\" in name
+                ):
+                    raise AdapterError(f"station-tools Git export contains an unsafe path: {member.name}")
+                relative = path.as_posix()
+                if member.isdir():
+                    seen_dirs.add(relative)
+                    (export / relative).mkdir(parents=True, exist_ok=True)
+                    continue
+                if member.issym() or member.islnk() or not member.isfile():
+                    raise AdapterError(f"station-tools Git export contains an unexpected symlink or entry: {relative}")
+                if relative not in expected:
+                    raise AdapterError(f"station-tools Git export contains an unexpected path: {relative}")
+                stream = reader.extractfile(member)
+                if stream is None:
+                    raise AdapterError(f"station-tools Git export has no content for {relative}")
+                content = stream.read()
+                object_id, expected_size, expected_mode = expected[relative]
+                if (member.mode & 0o111) != (expected_mode & 0o111):
+                    raise AdapterError(f"station-tools Git export mode drift for {relative}")
+                if len(content) != expected_size or _git_blob_digest(content) != object_id:
+                    raise AdapterError(f"station-tools Git export content drift for {relative}")
+                destination = export / relative
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                if destination.exists() or destination.is_symlink():
+                    raise AdapterError(f"station-tools Git export contains duplicate path: {relative}")
+                destination.write_bytes(content)
+                seen_files.add(relative)
+        expected_dirs = {""}
+        for path in expected:
+            parts = path.split("/")
+            expected_dirs.update("/".join(parts[:index]) for index in range(1, len(parts)))
+        if seen_files != set(expected) or seen_dirs != expected_dirs:
+            raise AdapterError("station-tools Git export does not match the pinned tree")
+    except (OSError, tarfile.TarError) as error:
+        raise AdapterError(f"cannot materialize station-tools Git export: {error}") from error
+    return export
+
+
+def _freeze_export(export: Path) -> None:
+    """Make source files immutable while leaving Cargo a writable target root."""
+    for path in sorted(export.rglob("*"), key=lambda value: len(value.parts), reverse=True):
+        if path.is_symlink():
+            raise AdapterError(f"immutable station-tools export contains a symlink: {path}")
+        try:
+            if path.is_dir():
+                path.chmod(0o555)
+            elif path.is_file():
+                path.chmod(0o444)
+            else:
+                raise AdapterError(f"immutable station-tools export contains an unexpected entry: {path}")
+        except OSError as error:
+            raise AdapterError(f"cannot freeze station-tools export {path}: {error}") from error
+
+
+def _bridge_manifest(station_tools: Path, cargo: str) -> Path:
+    """Build only from a verified Git export, never from the operator checkout."""
+    if not BRIDGE_SOURCE.is_file() or BRIDGE_SOURCE.is_symlink():
+        raise AdapterError(f"v2 bridge source is missing: {BRIDGE_SOURCE}")
+    # Re-check at the build boundary so direct callers cannot bypass the
+    # worktree and index validation performed by prepare_v2_records.
+    check_station_tools_pin(station_tools)
+    export = _materialize_station_tools(station_tools)
+    station_publish = export / "crates" / "station-publish"
+    station_protocol = export / "crates" / "station-protocol"
+    if not station_publish.is_dir() or not station_protocol.is_dir():
+        raise AdapterError("reviewed Station export lacks station-publish/protocol crates")
+    bridge_source = station_publish / "src" / "bin" / "aos-station-v2-bridge.rs"
+    bridge_source.parent.mkdir(parents=True, exist_ok=True)
+    bridge_source.write_bytes(BRIDGE_SOURCE.read_bytes())
+    _freeze_export(export)
+    build_env = os.environ.copy()
+    build_env["CARGO_TARGET_DIR"] = str(export / "target")
+    manifest = export / "Cargo.toml"
+    _run(
+        [cargo, "fetch", "--manifest-path", str(manifest), "--locked"],
+        context="station v2 locked dependency fetch",
+        env=build_env,
+    )
+    _run(
+        [
+            cargo,
+            "build",
+            "--quiet",
+            "--offline",
+            "--locked",
+            "--manifest-path",
+            str(manifest),
+            "--package",
+            "astrid-station-publish",
+            "--bin",
+            "aos-station-v2-bridge",
+        ],
+        context="station v2 bridge build",
+        env=build_env,
+    )
+    binary = export / "target" / "debug" / "aos-station-v2-bridge"
+    if not binary.is_file() or binary.is_symlink():
+        raise AdapterError("station v2 bridge build did not produce an executable")
+    return binary
+
+
+def _record_summary(value: dict[str, Any], item: policy.SeedPackage) -> dict[str, Any]:
+    if value.get("schema") != "aos-station-prepare-v2-result-v1":
+        raise AdapterError(f"{item.package}: bridge returned an unknown result schema")
+    if value.get("readiness") is not False or value.get("fixture") is not True:
+        raise AdapterError(f"{item.package}: bridge result is not the non-admitting fixture")
+    required = {
+        "record",
+        "artifact",
+        "coordinate",
+        "version",
+        "publication_digest",
+        "package_digest",
+        "manifest_digest",
+        "content_digest",
+        "artifact_size",
+        "classification",
+        "readiness",
+        "fixture",
+        "schema",
+    }
+    if set(value) != required:
+        raise AdapterError(f"{item.package}: bridge returned unknown or missing fields")
+    expected_coordinate = f"@{policy.RESERVED_NAMESPACE}/{item.package}"
+    if value["coordinate"] != expected_coordinate or value["version"] != item.version:
+        raise AdapterError(f"{item.package}: bridge coordinate/version mismatch")
+    if value["classification"] != "New":
+        raise AdapterError(f"{item.package}: unexpected publication classification")
+    return {
+        "coordinate": value["coordinate"],
+        "version": value["version"],
+        "record": value["record"],
+        "artifact": value["artifact"],
+        "publication_digest": value["publication_digest"],
+        "package_digest": value["package_digest"],
+        "manifest_digest": value["manifest_digest"],
+        "content_digest": value["content_digest"],
+        "artifact_size": value["artifact_size"],
+        "readiness": False,
+        "fixture": True,
+    }
+
+
+def prepare_v2_records(
+    station_tools: Path,
+    artifacts: Path,
+    source_root: Path,
+    submission: Path,
+    *,
+    b3sum: str = "b3sum",
+    cargo: str = "cargo",
+) -> dict[str, Any]:
+    """Call `prepare_v2` once per seed package with explicit fixture identity."""
+    tool = check_station_tools_pin(station_tools)
+    bridge = _bridge_manifest(station_tools, cargo)
+    source_digest = _source_tree_digest(source_root, b3sum)
+    statement_digest = _b3sum_bytes(b"aos-ce-station-v2-readiness-fixture", b3sum)
+    publisher_digest = _b3sum_bytes(b"aos-ce-station-v2-fixture-publisher", b3sum)
+    summaries: list[dict[str, Any]] = []
+    for item in policy.SEED:
+        capsule = artifacts / item.asset
+        if not capsule.is_file() or capsule.is_symlink():
+            raise AdapterError(f"missing capsule artifact for {item.package}: {capsule}")
+        manifest = source_root / "capsules" / item.directory / "Capsule.toml"
+        try:
+            import tomllib
+
+            with manifest.open("rb") as handle:
+                tagged_manifest = tomllib.load(handle)
+                package_table = tagged_manifest.get("package", {})
+        except (OSError, ValueError) as error:
+            raise AdapterError(f"cannot read runtime requirement from {manifest}: {error}") from error
+        tagged_name = package_table.get("name")
+        tagged_version = package_table.get("version")
+        if tagged_name != item.package or tagged_version != item.version:
+            raise AdapterError(
+                f"{item.directory}: tagged Capsule.toml identity does not match the 19-entry allowlist"
+            )
+        coordinate = f"@{policy.RESERVED_NAMESPACE}/{tagged_name}"
+        runtime = package_table.get("astrid-version", "*")
+        if not isinstance(runtime, str) or not runtime:
+            raise AdapterError(f"{item.package}: invalid package.astrid-version")
+        command = [
+            str(bridge),
+            "--artifact",
+            str(capsule),
+            "--output",
+            str(submission),
+            "--station-id",
+            policy.STATION_ID,
+            "--station-base",
+            policy.STATION_BASE_URL,
+            "--coordinate",
+            coordinate,
+            "--version",
+            tagged_version,
+            "--publisher",
+            "fixture:aos-ce-readiness-v2",
+            "--publisher-digest",
+            f"blake3:{publisher_digest}",
+            "--source-repository",
+            policy.SOURCE_REPOSITORY,
+            "--github-owner-id",
+            str(policy.SOURCE_OWNER_ID),
+            "--github-repository-id",
+            str(policy.SOURCE_REPOSITORY_ID),
+            "--source-commit",
+            policy.SOURCE_COMMIT,
+            "--source-tree",
+            policy.SOURCE_TREE,
+            "--source-tag",
+            policy.SOURCE_TAG,
+            "--source-digest",
+            f"blake3:{source_digest}",
+            "--predicate-type",
+            "https://slsa.dev/provenance/v1",
+            "--statement-digest",
+            f"blake3:{statement_digest}",
+            "--builder-identity",
+            "https://example.invalid/aos-ce-readiness-fixture",
+            "--attestation-identity",
+            "fixture:aos-ce-readiness-v2",
+            "--runtime",
+            runtime,
+            "--abi",
+            "component-model-v1",
+        ]
+        completed = _run(command, context=f"prepare_v2 for {item.coordinate}")
+        try:
+            value = json.loads(completed.stdout)
+        except json.JSONDecodeError as error:
+            raise AdapterError(f"{item.package}: prepare_v2 bridge returned non-JSON output") from error
+        if not isinstance(value, dict):
+            raise AdapterError(f"{item.package}: prepare_v2 bridge result is not an object")
+        summaries.append(_record_summary(value, item))
+    if len(summaries) != len(policy.SEED):
+        raise AdapterError("prepare_v2 did not produce exactly the canonical 19 records")
+    records = sorted(summaries, key=lambda value: value["coordinate"])
+    return {
+        "tool": tool,
+        "interface": "astrid-station-publish::prepare_v2",
+        "fixture": {
+            "readiness": False,
+            "publisher": "fixture:aos-ce-readiness-v2",
+            "binding": "non-admitting; structural fixture only",
+        },
+        "records": records,
+        "record_count": len(records),
+        "event_count": 0,
+    }

--- a/scripts/aos_station_adapter/policy.py
+++ b/scripts/aos_station_adapter/policy.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-# This is the reviewed local v2 interface supplied to the adapter.  It is not
+# This is the reviewed publication interface supplied to the adapter.  It is not
 # a public Station repository/configuration pin; publication remains disabled.
 STATION_TOOLS_COMMIT = "fd233f91b40d00c5f721ba99436ce30eca9036ba"
 STATION_TOOLS_TREE = "0bf775f225bfb9177d5788ec8c32d5453f75c660"

--- a/scripts/aos_station_adapter/policy.py
+++ b/scripts/aos_station_adapter/policy.py
@@ -1,0 +1,83 @@
+"""Pinned AOS Community Edition to Station policy.
+
+The values in this module mirror ``release/station/aos-seed.toml``.  Keeping
+the policy in code as well as in the reader-facing file lets the adapter fail
+closed before parsing mutable current-main release lists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# This is the reviewed local v2 interface supplied to the adapter.  It is not
+# a public Station repository/configuration pin; publication remains disabled.
+STATION_TOOLS_COMMIT = "fd233f91b40d00c5f721ba99436ce30eca9036ba"
+STATION_TOOLS_TREE = "0bf775f225bfb9177d5788ec8c32d5453f75c660"
+PRODUCT_VERSION = "2026.1.3"
+SOURCE_COMMIT = "efaa39f3f0ba80cf2c24985fd4383d8d73dd801a"
+SOURCE_TREE = "46a8a976d54eb82ac922c56ae41d713595895ff5"
+SOURCE_TAG = "2026.1.3"
+SOURCE_REPOSITORY = "https://github.com/unicity-aos/aos-ce"
+SOURCE_REPOSITORY_SLUG = "unicity-aos/aos-ce"
+SOURCE_OWNER_ID = 261740341
+SOURCE_REPOSITORY_ID = 1298696137
+SOURCE_WORKFLOW_IDENTITY = (
+    "https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml"
+    "@refs/tags/2026.1.3"
+)
+SIGSTORE_ISSUER = "https://token.actions.githubusercontent.com"
+STATION_ID = "aos"
+STATION_BASE_URL = "https://unicity-aos.github.io/station/v1"
+RESERVED_NAMESPACE = "aos"
+BLOCKED_DIRECTORIES = {
+    "capsule-mcp": "aos-mcp",
+    "capsule-hook-adapter-oracle": "aos-hook-adapter-oracle",
+    "capsule-meta-harness": "aos-meta-harness",
+}
+
+
+@dataclass(frozen=True)
+class SeedPackage:
+    directory: str
+    package: str
+    version: str
+
+    @property
+    def coordinate(self) -> str:
+        return f"@{RESERVED_NAMESPACE}/{self.package}@{self.version}"
+
+    @property
+    def asset(self) -> str:
+        return f"{self.package}.capsule"
+
+
+SEED: tuple[SeedPackage, ...] = (
+    SeedPackage("capsule-cli", "aos-cli", "0.2.0"),
+    SeedPackage("capsule-registry", "aos-registry", "0.2.0"),
+    SeedPackage("capsule-openai-compat", "aos-openai-compat", "0.2.0"),
+    SeedPackage("capsule-react", "aos-react", "0.2.2"),
+    SeedPackage("capsule-session", "aos-session", "0.2.0"),
+    SeedPackage("capsule-identity", "aos-identity", "0.2.0"),
+    SeedPackage("capsule-users", "aos-users", "0.1.0"),
+    SeedPackage("capsule-router", "aos-router", "0.2.0"),
+    SeedPackage("capsule-prompt-builder", "aos-prompt-builder", "0.2.0"),
+    SeedPackage("capsule-context-engine", "aos-context-engine", "0.2.0"),
+    SeedPackage("capsule-hook-bridge", "aos-hook-bridge", "0.2.0"),
+    SeedPackage("capsule-shell", "aos-shell", "0.2.0"),
+    SeedPackage("capsule-http", "aos-http", "0.1.1"),
+    SeedPackage("capsule-fs", "aos-fs", "0.2.0"),
+    SeedPackage("capsule-system", "aos-system", "0.2.0"),
+    SeedPackage("capsule-forge", "aos-forge", "0.1.0"),
+    SeedPackage("capsule-skills", "aos-skills", "0.2.0"),
+    SeedPackage("capsule-agents", "aos-agents", "0.2.0"),
+    SeedPackage("capsule-memory", "aos-memory", "0.2.0"),
+)
+
+SEED_BY_ASSET = {item.asset: item for item in SEED}
+SEED_BY_PACKAGE = {item.package: item for item in SEED}
+
+
+def mapping_path(root: Path) -> Path:
+    return root / "release" / "station" / "aos-seed.toml"

--- a/scripts/aos_station_adapter/prepare_v2_bridge.rs
+++ b/scripts/aos_station_adapter/prepare_v2_bridge.rs
@@ -1,4 +1,4 @@
-//! Tiny, generated-at-runtime bridge to the reviewed Station v2 publisher.
+//! Tiny, generated-at-runtime bridge to the reviewed Station publication interface.
 //!
 //! This source intentionally lives in the AOS adapter rather than in the
 //! Station repository.  The adapter exports and freezes the exact reviewed Git

--- a/scripts/aos_station_adapter/prepare_v2_bridge.rs
+++ b/scripts/aos_station_adapter/prepare_v2_bridge.rs
@@ -1,0 +1,118 @@
+//! Tiny, generated-at-runtime bridge to the reviewed Station v2 publisher.
+//!
+//! This source intentionally lives in the AOS adapter rather than in the
+//! Station repository.  The adapter exports and freezes the exact reviewed Git
+//! objects (commit `fd233f91b40d00c5f721ba99436ce30eca9036ba`, tree
+//! `0bf775f225bfb9177d5788ec8c32d5453f75c660`), so the call below cannot
+//! silently resolve a different tool version or live checkout path.
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use astrid_station_protocol::{
+    ActorId, BuildProvenance, CanonicalSemVer, Coordinate, Digest, GitObjectId, MirrorUrl,
+    PublicationRecordV2, PublisherIdentity, SourceProvenance, StationId,
+};
+use astrid_station_publish::{prepare_v2, EmptyPreflightV2, PublishOptions};
+
+fn argument(name: &str) -> String {
+    let mut args = env::args().skip(1);
+    while let Some(value) = args.next() {
+        if value == name {
+            return args
+                .next()
+                .unwrap_or_else(|| panic!("missing value for {name}"));
+        }
+    }
+    panic!("missing required argument {name}");
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let artifact = PathBuf::from(argument("--artifact"));
+    let output = PathBuf::from(argument("--output"));
+    let coordinate = Coordinate::from_str(&argument("--coordinate"))?;
+    let version = CanonicalSemVer::parse(&argument("--version"))?;
+    let station_id = StationId::new(argument("--station-id"))?;
+    let station_base = MirrorUrl::new(argument("--station-base"))?;
+    let source_repository = MirrorUrl::new(argument("--source-repository"))?;
+    let source_commit = GitObjectId::new(argument("--source-commit"))?;
+    let source_tree = GitObjectId::new(argument("--source-tree"))?;
+    let source_tag = argument("--source-tag");
+    let source_digest = Digest::parse(&argument("--source-digest"))?;
+    let statement_digest = Digest::parse(&argument("--statement-digest"))?;
+    let publisher_digest = Digest::parse(&argument("--publisher-digest"))?;
+    let publisher = PublisherIdentity::new(
+        ActorId::new(argument("--publisher"))?,
+        publisher_digest,
+    );
+    let source = SourceProvenance::new(
+        source_repository,
+        argument("--github-owner-id").parse()?,
+        argument("--github-repository-id").parse()?,
+        source_commit,
+        source_tree,
+        source_tag,
+        None,
+        source_digest,
+    )?;
+    let provenance = BuildProvenance::new(
+        argument("--predicate-type"),
+        statement_digest,
+        MirrorUrl::new(argument("--builder-identity"))?,
+        argument("--attestation-identity"),
+    )?;
+    let options = PublishOptions::new(
+        &artifact,
+        station_id,
+        station_base,
+        coordinate,
+        version,
+        Vec::new(),
+        publisher,
+        source,
+        provenance,
+        argument("--runtime"),
+        argument("--abi"),
+        &output,
+    );
+    let prepared = prepare_v2(&options, &EmptyPreflightV2)?;
+    let record_path = prepared.output_path().to_path_buf();
+    let artifact_path = prepared.artifact_output_path().to_path_buf();
+    let record_bytes = prepared.json_bytes()?;
+    let decoded: PublicationRecordV2 = serde_json::from_slice(&record_bytes)?;
+    if decoded.publication_digest() != prepared.record().publication_digest() {
+        return Err("serialized PublicationRecordV2 did not round-trip".into());
+    }
+    write_regular(&record_path, &record_bytes)?;
+    write_regular(&artifact_path, prepared.artifact_bytes())?;
+    let result = serde_json::json!({
+        "schema": "aos-station-prepare-v2-result-v1",
+        "record": record_path.strip_prefix(&output)?.to_string_lossy(),
+        "artifact": artifact_path.strip_prefix(&output)?.to_string_lossy(),
+        "coordinate": prepared.record().coordinate().to_string(),
+        "version": prepared.record().version(),
+        "publication_digest": prepared.record().publication_digest(),
+        "package_digest": prepared.record().package().embedded_identity.package_digest(),
+        "manifest_digest": prepared.record().package().manifest_digest,
+        "content_digest": prepared.record().package().capsule_content_digest,
+        "artifact_size": prepared.record().artifact().size,
+        "classification": format!("{:?}", prepared.classification()),
+        "readiness": false,
+        "fixture": true,
+    });
+    println!("{}", serde_json::to_string_pretty(&result)?);
+    Ok(())
+}
+
+fn write_regular(path: &Path, bytes: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if path.is_symlink() {
+        return Err(format!("refusing to overwrite symlink {}", path.display()).into());
+    }
+    fs::write(path, bytes)?;
+    Ok(())
+}

--- a/scripts/aos_station_adapter/release.py
+++ b/scripts/aos_station_adapter/release.py
@@ -1,0 +1,516 @@
+"""Strict local verification for the signed 2026.1.3 AOS release assets."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import tarfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
+
+from . import policy
+from .adapter import _git_command
+
+
+class VerificationError(RuntimeError):
+    """A release input did not satisfy the immutable adapter contract."""
+
+
+def _release_metadata_module():
+    scripts = Path(__file__).resolve().parents[1]
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    try:
+        import release_metadata
+    except ImportError as error:  # pragma: no cover - repository corruption
+        raise VerificationError(f"cannot load release metadata validator: {error}") from error
+    return release_metadata
+
+
+def _read_toml(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as source:
+            value = tomllib.load(source)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise VerificationError(f"{path}: invalid TOML: {error}") from error
+    if not isinstance(value, dict):
+        raise VerificationError(f"{path}: TOML root must be a table")
+    return value
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            while chunk := source.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError as error:
+        raise VerificationError(f"cannot hash {path}: {error}") from error
+    return digest.hexdigest()
+
+
+def _blake3(path: Path, executable: str) -> str:
+    try:
+        completed = subprocess.run(
+            [executable, "--", str(path)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise VerificationError(f"cannot run {executable} for {path}: {error}") from error
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
+        raise VerificationError(f"{executable} failed for {path}: {detail}")
+    fields = completed.stdout.split()
+    if not fields or re.fullmatch(r"[0-9a-f]{64}", fields[0]) is None:
+        raise VerificationError(f"{executable} returned malformed digest for {path}")
+    return fields[0]
+
+
+def _checksum_manifest(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        raise VerificationError(f"cannot read {path}: {error}") from error
+    for number, line in enumerate(lines, 1):
+        match = re.fullmatch(r"([0-9a-f]{64})  ([A-Za-z0-9_.+-]+)", line)
+        if match is None:
+            raise VerificationError(f"{path}:{number}: malformed checksum entry")
+        digest, asset = match.groups()
+        if asset in values:
+            raise VerificationError(f"{path}: duplicate checksum entry for {asset}")
+        values[asset] = digest
+    return values
+
+
+def _canonical_member_name(member: tarfile.TarInfo, asset: Path) -> str:
+    raw = member.name[:-1] if member.isdir() and member.name.endswith("/") else member.name
+    path = PurePosixPath(raw)
+    parts = raw.split("/")
+    if (
+        not raw
+        or path.is_absolute()
+        or any(part in ("", ".", "..") for part in parts)
+        or path.as_posix() != raw
+    ):
+        raise VerificationError(f"{asset}: unsafe archive path {member.name!r}")
+    return raw
+
+
+def _load_source_manifest(
+    source_root: Path, item: policy.SeedPackage
+) -> tuple[dict[str, Any], bytes]:
+    path = source_root / "capsules" / item.directory / "Capsule.toml"
+    if not path.is_file() or path.is_symlink():
+        raise VerificationError(f"missing exact source manifest for {item.package}: {path}")
+    try:
+        manifest_bytes = path.read_bytes()
+    except OSError as error:
+        raise VerificationError(f"cannot read exact source manifest {path}: {error}") from error
+    manifest = _read_toml(path)
+    allowed_top_level = {
+        "package",
+        "component",
+        "imports",
+        "exports",
+        "publish",
+        "subscribe",
+        "tool",
+        "capabilities",
+        "env",
+        "context_file",
+        "command",
+        "mcp_server",
+        "skill",
+        "uplink",
+    }
+    unknown_top_level = sorted(set(manifest) - allowed_top_level)
+    if unknown_top_level:
+        raise VerificationError(
+            f"{path}: unknown top-level Capsule.toml fields: {unknown_top_level}"
+        )
+
+    def reject_forbidden_tables(value: Any, location: str) -> None:
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                if key in {"authority", "registry", "checkpoint", "event-head"}:
+                    raise VerificationError(
+                        f"{path}: unsupported {key!r} table at {location}"
+                    )
+                reject_forbidden_tables(nested, f"{location}.{key}")
+        elif isinstance(value, list):
+            for index, nested in enumerate(value):
+                reject_forbidden_tables(nested, f"{location}[{index}]")
+
+    reject_forbidden_tables(manifest, "Capsule.toml")
+    package = manifest.get("package")
+    if not isinstance(package, dict):
+        raise VerificationError(f"{path}: package table is missing")
+    if package.get("name") != item.package or package.get("version") != item.version:
+        raise VerificationError(
+            f"{path}: package identity/version differs from pinned seed "
+            f"{item.package} {item.version}"
+        )
+    return manifest, manifest_bytes
+
+
+def _verify_capsule(
+    path: Path,
+    item: policy.SeedPackage,
+    source_manifest: dict[str, Any],
+    source_manifest_bytes: bytes,
+) -> dict[str, Any]:
+    try:
+        archive = tarfile.open(path, mode="r:gz")
+    except (OSError, tarfile.TarError) as error:
+        raise VerificationError(f"{path}: invalid capsule archive: {error}") from error
+    with archive:
+        members = archive.getmembers()
+        by_name: dict[str, tarfile.TarInfo] = {}
+        for member in members:
+            if not (member.isfile() or member.isdir()):
+                raise VerificationError(f"{path}: links and special files are forbidden")
+            name = _canonical_member_name(member, path)
+            if name in by_name:
+                raise VerificationError(f"{path}: duplicate archive path {name!r}")
+            by_name[name] = member
+
+        manifest_member = by_name.get("Capsule.toml")
+        if manifest_member is None or not manifest_member.isfile():
+            raise VerificationError(f"{path}: Capsule.toml is missing")
+        stream = archive.extractfile(manifest_member)
+        if stream is None:
+            raise VerificationError(f"{path}: Capsule.toml is not readable")
+        try:
+            embedded_bytes = stream.read()
+            embedded = tomllib.loads(embedded_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, tomllib.TOMLDecodeError) as error:
+            raise VerificationError(f"{path}: embedded Capsule.toml is invalid: {error}") from error
+        if embedded_bytes != source_manifest_bytes:
+            raise VerificationError(
+                f"{path}: embedded Capsule.toml bytes differ from exact tagged source bytes"
+            )
+        if embedded != source_manifest:
+            raise VerificationError(f"{path}: embedded Capsule.toml differs from exact source manifest")
+
+        components = embedded.get("component")
+        if not isinstance(components, list) or not components:
+            raise VerificationError(f"{path}: at least one [[component]] is required")
+        component_names: list[str] = []
+        for component in components:
+            if not isinstance(component, dict):
+                raise VerificationError(f"{path}: component entry is not a table")
+            filename = component.get("file", component.get("entrypoint"))
+            if (
+                not isinstance(filename, str)
+                or not filename.endswith(".wasm")
+                or PurePosixPath(filename).name != filename
+            ):
+                raise VerificationError(f"{path}: unsafe component filename {filename!r}")
+            if filename in component_names:
+                raise VerificationError(f"{path}: duplicate component filename {filename!r}")
+            component_names.append(filename)
+            member = by_name.get(filename)
+            if member is None or not member.isfile():
+                raise VerificationError(f"{path}: component {filename!r} is missing")
+
+        expected_members = {"Capsule.toml", *component_names}
+        if set(by_name) != expected_members:
+            raise VerificationError(
+                f"{path}: archive member set differs; missing={sorted(expected_members - set(by_name))}, "
+                f"unexpected={sorted(set(by_name) - expected_members)}"
+            )
+        return {
+            "directory": item.directory,
+            "package": item.package,
+            "version": item.version,
+            "coordinate": item.coordinate,
+            "asset": item.asset,
+            "components": component_names,
+            "sha256": _sha256(path),
+            "size": path.stat().st_size,
+        }
+
+
+def verify_source_tree(source_root: Path) -> dict[str, str]:
+    if not source_root.is_dir() or source_root.is_symlink():
+        raise VerificationError(f"source root is not a directory: {source_root}")
+    try:
+        branch = subprocess.run(
+            _git_command(
+                "-C", str(source_root), "symbolic-ref", "--quiet", "--short", "HEAD"
+            ),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        status = subprocess.run(
+            _git_command("-C", str(source_root), "status", "--porcelain"),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        head = subprocess.run(
+            _git_command("-C", str(source_root), "rev-parse", "HEAD^{commit}"),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        tree = subprocess.run(
+            _git_command(
+                "-C", str(source_root), "rev-parse", f"{policy.SOURCE_COMMIT}^{{tree}}"
+            ),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise VerificationError(f"cannot invoke git for source verification: {error}") from error
+    if branch.returncode == 0 or branch.stdout.strip():
+        raise VerificationError(
+            "source checkout must be detached; a branch name cannot prove the immutable release tag"
+        )
+    if status.returncode != 0:
+        raise VerificationError(f"cannot inspect source checkout status: {status.stderr.strip()}")
+    if status.stdout.strip():
+        raise VerificationError("source checkout is dirty; immutable release verification requires a clean tree")
+    if head.returncode != 0:
+        raise VerificationError(f"source root is not a git checkout: {source_root}")
+    actual_head = head.stdout.strip()
+    if actual_head != policy.SOURCE_COMMIT:
+        raise VerificationError(
+            f"source checkout HEAD {actual_head!r} is not pinned {policy.SOURCE_COMMIT}"
+        )
+    if tree.returncode != 0 or tree.stdout.strip() != policy.SOURCE_TREE:
+        raise VerificationError(
+            f"source tree does not resolve to pinned {policy.SOURCE_TREE}; "
+            f"got {tree.stdout.strip()!r}"
+        )
+    return {"commit": actual_head, "tree": tree.stdout.strip(), "tag": policy.SOURCE_TAG}
+
+
+def verify_current_main_drift(current_main_root: Path) -> dict[str, Any]:
+    """Check current main independently from the detached release proof.
+
+    This check is deliberately a separate input and result.  Current main is
+    not evidence for the tagged release; it only proves that the three newer
+    capsules remain outside the 19-package seed until a signed release exists.
+    """
+    if not current_main_root.is_dir() or current_main_root.is_symlink():
+        raise VerificationError(f"current-main root is not a directory: {current_main_root}")
+    allowlist_path = current_main_root / "release" / "community-capsules.txt"
+    try:
+        directories = [
+            line.strip()
+            for line in allowlist_path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+    except OSError as error:
+        raise VerificationError(f"cannot read current-main capsule allowlist: {error}") from error
+    expected = [item.directory for item in policy.SEED]
+    extras = sorted(set(directories) - set(expected))
+    required = sorted(policy.BLOCKED_DIRECTORIES)
+    if not set(required).issubset(directories):
+        raise VerificationError(
+            "current-main drift check is missing blocked additions: "
+            f"expected={required}, actual={directories}"
+        )
+    if directories == expected:
+        raise VerificationError("current-main drift check unexpectedly matches the 19-package release seed")
+    return {
+        "repository": policy.SOURCE_REPOSITORY_SLUG,
+        "allowlist": directories,
+        "seed_directories": expected,
+        "blocked_additions": extras,
+        "separate_from_release_proof": True,
+    }
+
+
+def _verify_sigstore(
+    artifacts: Path,
+    payloads: list[str],
+    *,
+    cosign: str,
+    skip: bool,
+) -> dict[str, Any]:
+    bundles = []
+    failures: list[str] = []
+    for name in payloads:
+        payload = artifacts / name
+        bundle = artifacts / f"{name}.sigstore.json"
+        if not bundle.is_file() or bundle.is_symlink():
+            failures.append(f"missing Sigstore bundle {bundle.name}")
+            continue
+        try:
+            value = json.loads(bundle.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            failures.append(f"invalid Sigstore bundle {bundle.name}: {error}")
+            continue
+        if not isinstance(value, dict) or not value:
+            failures.append(f"Sigstore bundle {bundle.name} is empty")
+            continue
+        if skip:
+            bundles.append({"asset": name, "bundle": bundle.name, "verified": False, "skipped": True})
+            continue
+        try:
+            completed = subprocess.run(
+                [
+                    cosign,
+                    "verify-blob",
+                    "--bundle",
+                    str(bundle),
+                    "--certificate-oidc-issuer",
+                    policy.SIGSTORE_ISSUER,
+                    "--certificate-identity",
+                    policy.SOURCE_WORKFLOW_IDENTITY,
+                    str(payload),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except OSError as error:
+            failures.append(f"cannot invoke {cosign}: {error}")
+            continue
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip() or "verification failed"
+            failures.append(f"{name}: {detail}")
+            continue
+        bundles.append({"asset": name, "bundle": bundle.name, "verified": True, "skipped": False})
+    if failures and not skip:
+        raise VerificationError("Sigstore verification failed: " + "; ".join(failures))
+    return {
+        "issuer": policy.SIGSTORE_ISSUER,
+        "identity": policy.SOURCE_WORKFLOW_IDENTITY,
+        "verified": not skip and not failures and len(bundles) == len(payloads),
+        "skipped": skip,
+        "bundles": bundles,
+        "failures": failures,
+    }
+
+
+def verify_release(
+    artifacts: Path,
+    source_root: Path,
+    *,
+    b3sum: str = "b3sum",
+    cosign: str = "cosign",
+    skip_sigstore: bool = False,
+    current_main_root: Path | None = None,
+) -> dict[str, Any]:
+    """Verify the exact 2026.1.3 release and return a deterministic report."""
+    if not artifacts.is_dir() or artifacts.is_symlink():
+        raise VerificationError(f"release artifact directory is not a directory: {artifacts}")
+    for entry in artifacts.iterdir():
+        if entry.is_symlink() or not entry.is_file():
+            raise VerificationError(f"release artifacts contain non-regular entry: {entry.name}")
+
+    source_identity = verify_source_tree(source_root)
+    drift = verify_current_main_drift(current_main_root) if current_main_root is not None else None
+    metadata_name = f"unicity-aos-{policy.PRODUCT_VERSION}-release.toml"
+    metadata_path = artifacts / metadata_name
+    release_metadata = _release_metadata_module()
+    try:
+        metadata = release_metadata.validate_release(
+            release_metadata.load(metadata_path), require_ready=True
+        )
+    except (KeyError, OSError, ValueError) as error:
+        raise VerificationError(f"invalid release metadata: {error}") from error
+    if metadata["version"] != policy.PRODUCT_VERSION or metadata["tag"] != policy.SOURCE_TAG:
+        raise VerificationError("release metadata version/tag is not the pinned 2026.1.3 release")
+    if metadata["source-commit"] != policy.SOURCE_COMMIT:
+        raise VerificationError("release metadata source commit is not the pinned tag commit")
+    if metadata["release-workflow-identity"] != policy.SOURCE_WORKFLOW_IDENTITY:
+        raise VerificationError("release metadata workflow identity is not the pinned tag identity")
+
+    target_assets = sorted(item["asset"] for item in metadata["targets"].values())
+    capsule_assets = [item.asset for item in policy.SEED]
+    payloads = sorted(
+        set(capsule_assets)
+        | set(target_assets)
+        | {"BLAKE3SUMS.txt", "SHA256SUMS.txt", "runtime-compatibility.toml", metadata_name}
+    )
+    expected = set(payloads) | {f"{name}.sigstore.json" for name in payloads}
+    actual = {path.name for path in artifacts.iterdir()}
+    if actual != expected:
+        raise VerificationError(
+            "release asset set differs from the 2026.1.3 seed; "
+            f"missing={sorted(expected - actual)}, unexpected={sorted(actual - expected)}"
+        )
+
+    sha256 = _checksum_manifest(artifacts / "SHA256SUMS.txt")
+    blake3 = _checksum_manifest(artifacts / "BLAKE3SUMS.txt")
+    checksummed = set(capsule_assets) | set(target_assets)
+    if set(sha256) != checksummed:
+        raise VerificationError("SHA256SUMS.txt does not cover exactly the 19 capsules and targets")
+    if set(blake3) != checksummed:
+        raise VerificationError("BLAKE3SUMS.txt does not cover exactly the 19 capsules and targets")
+
+    source_compatibility = source_root / "release" / "runtime-compatibility.toml"
+    try:
+        if (artifacts / "runtime-compatibility.toml").read_bytes() != source_compatibility.read_bytes():
+            raise VerificationError("published runtime compatibility differs from the exact tag source")
+    except OSError as error:
+        raise VerificationError(f"runtime compatibility evidence is unreadable: {error}") from error
+
+    capsules: list[dict[str, Any]] = []
+    for item in policy.SEED:
+        manifest, manifest_bytes = _load_source_manifest(source_root, item)
+        capsule = _verify_capsule(artifacts / item.asset, item, manifest, manifest_bytes)
+        capsule["runtime"] = manifest.get("package", {}).get("astrid-version", "*")
+        expected_sha = sha256[item.asset]
+        if capsule["sha256"] != expected_sha:
+            raise VerificationError(f"SHA-256 mismatch for {item.asset}")
+        capsule["blake3"] = _blake3(artifacts / item.asset, b3sum)
+        if capsule["blake3"] != blake3[item.asset]:
+            raise VerificationError(f"BLAKE3 mismatch for {item.asset}")
+        capsules.append(capsule)
+
+    targets: list[dict[str, Any]] = []
+    for item in metadata["targets"].values():
+        asset = item["asset"]
+        path = artifacts / asset
+        actual_sha = _sha256(path)
+        actual_b3 = _blake3(path, b3sum)
+        if actual_sha != sha256[asset] or actual_b3 != blake3[asset]:
+            raise VerificationError(f"target digest mismatch for {asset}")
+        if item["sha256"] != actual_sha or item["blake3"] != actual_b3:
+            raise VerificationError(f"release metadata digest mismatch for {asset}")
+        if item["size"] != path.stat().st_size:
+            raise VerificationError(f"release metadata size mismatch for {asset}")
+        targets.append({"asset": asset, "sha256": actual_sha, "blake3": actual_b3, "size": path.stat().st_size})
+
+    sigstore = _verify_sigstore(
+        artifacts,
+        payloads,
+        cosign=cosign,
+        skip=skip_sigstore,
+    )
+    return {
+        "schema": "aos-station-adapter-verification-v1",
+        "product": "unicity-aos-ce",
+        "version": policy.PRODUCT_VERSION,
+        "source": {
+            **source_identity,
+            "repository": policy.SOURCE_REPOSITORY,
+            "repository_slug": policy.SOURCE_REPOSITORY_SLUG,
+            "owner_id": policy.SOURCE_OWNER_ID,
+            "repository_id": policy.SOURCE_REPOSITORY_ID,
+            "workflow_identity": policy.SOURCE_WORKFLOW_IDENTITY,
+        },
+        "assets": {"payloads": payloads, "capsules": capsules, "targets": sorted(targets, key=lambda value: value["asset"])},
+        "sigstore": sigstore,
+        "seed_count": len(capsules),
+        "blocked": sorted(policy.BLOCKED_DIRECTORIES.items()),
+        "current_main_drift": drift,
+    }

--- a/scripts/test_aos_station_adapter.py
+++ b/scripts/test_aos_station_adapter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Adversarial and fail-closed tests for the Station v2 adapter."""
+"""Adversarial and fail-closed tests for the Station v1 publication adapter."""
 
 from __future__ import annotations
 

--- a/scripts/test_aos_station_adapter.py
+++ b/scripts/test_aos_station_adapter.py
@@ -1,0 +1,946 @@
+#!/usr/bin/env python3
+"""Adversarial and fail-closed tests for the Station v2 adapter."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from aos_station_adapter import policy
+from aos_station_adapter import adapter as adapter_module
+from aos_station_adapter.adapter import (
+    AdapterError,
+    _record_summary,
+    check_station_tools_pin,
+    prepare_v2_records,
+)
+from aos_station_adapter.release import (
+    VerificationError,
+    _load_source_manifest,
+    _verify_capsule,
+    verify_current_main_drift,
+    verify_release,
+    verify_source_tree,
+)
+
+
+ROOT = Path(__file__).resolve().parent.parent
+TAG_ROOT = (
+    Path(os.environ["AOS_CE_TAG_SOURCE_ROOT"])
+    if os.environ.get("AOS_CE_TAG_SOURCE_ROOT")
+    else None
+)
+EVIDENCE_ASSETS = (
+    Path(os.environ["AOS_CE_EVIDENCE_ASSETS"])
+    if os.environ.get("AOS_CE_EVIDENCE_ASSETS")
+    else None
+)
+STATION_TOOLS = (
+    Path(os.environ["AOS_CE_STATION_TOOLS"])
+    if os.environ.get("AOS_CE_STATION_TOOLS")
+    else None
+)
+B3SUM = shutil.which("b3sum") or "b3sum"
+
+
+def _copy_entry(source: str, destination: str) -> None:
+    """Hard-link immutable fixture inputs; copy only when a filesystem forbids it."""
+    try:
+        os.link(source, destination)
+    except OSError:
+        shutil.copy2(source, destination)
+
+
+def _replace_file(path: Path, content: str | bytes) -> None:
+    # Fixtures are often hard-linked to the read-only evidence directory.
+    path.unlink()
+    if isinstance(content, bytes):
+        path.write_bytes(content)
+    else:
+        path.write_text(content, encoding="utf-8")
+
+
+class StationAdapterTests(unittest.TestCase):
+    def _require_directory(
+        self,
+        value: Path | None,
+        variable: str,
+        message: str,
+    ) -> Path:
+        if value is None or not value.is_dir():
+            if os.environ.get("GITHUB_ACTIONS"):
+                self.fail(f"{variable} must be provisioned when GITHUB_ACTIONS is set")
+            self.skipTest(message)
+        return value
+
+    def require_tag(self) -> Path:
+        return self._require_directory(
+            TAG_ROOT,
+            "AOS_CE_TAG_SOURCE_ROOT",
+            "set AOS_CE_TAG_SOURCE_ROOT to the detached 2026.1.3 checkout",
+        )
+
+    def require_assets(self) -> Path:
+        return self._require_directory(
+            EVIDENCE_ASSETS,
+            "AOS_CE_EVIDENCE_ASSETS",
+            "set AOS_CE_EVIDENCE_ASSETS to the release evidence assets",
+        )
+
+    def require_station_tools(self) -> Path:
+        return self._require_directory(
+            STATION_TOOLS,
+            "AOS_CE_STATION_TOOLS",
+            "set AOS_CE_STATION_TOOLS to the reviewed local Station checkout",
+        )
+
+    def clone_station_tools(self, root: Path) -> Path:
+        source = self.require_station_tools()
+        destination = root / "station-tools"
+        cloned = subprocess.run(
+            ["git", "clone", "--local", "--no-hardlinks", str(source), str(destination)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(cloned.returncode, 0, cloned.stderr)
+        detached = subprocess.run(
+            ["git", "-C", str(destination), "checkout", "--detach", policy.STATION_TOOLS_COMMIT],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(detached.returncode, 0, detached.stderr)
+        return destination
+
+    def clone_assets(self, root: Path) -> Path:
+        destination = root / "assets"
+        shutil.copytree(self.require_assets(), destination, copy_function=_copy_entry)
+        return destination
+
+    def verify_fixture(self, assets: Path) -> dict[str, object]:
+        return verify_release(
+            assets,
+            self.require_tag(),
+            b3sum=B3SUM,
+            skip_sigstore=True,
+            current_main_root=ROOT,
+        )
+
+    def test_ci_inputs_are_required_when_running_in_github_actions(self) -> None:
+        if not os.environ.get("GITHUB_ACTIONS"):
+            return
+        missing = [
+            name
+            for name, value in (
+                ("AOS_CE_TAG_SOURCE_ROOT", TAG_ROOT),
+                ("AOS_CE_EVIDENCE_ASSETS", EVIDENCE_ASSETS),
+                ("AOS_CE_STATION_TOOLS", STATION_TOOLS),
+            )
+            if value is None
+        ]
+        self.assertEqual(missing, [], f"CI inputs were not provisioned: {missing}")
+
+    def test_station_tools_clean_pin_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            checkout = self.clone_station_tools(Path(temporary))
+            result = check_station_tools_pin(checkout)
+            self.assertEqual(result["commit"], policy.STATION_TOOLS_COMMIT)
+            self.assertEqual(result["tree"], policy.STATION_TOOLS_TREE)
+
+    def test_station_tools_replacement_ref_rejects_before_bridge_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            checkout = self.clone_station_tools(root)
+            tracked = "crates/station-publish/src/v2.rs"
+            replacement = subprocess.run(
+                ["git", "-C", str(checkout), "hash-object", "-w", "--stdin"],
+                input=b"replacement object fixture\n",
+                check=False,
+                capture_output=True,
+            )
+            self.assertEqual(replacement.returncode, 0, replacement.stderr.decode())
+            replacement_blob = replacement.stdout.decode("ascii").strip()
+            self.assertEqual(len(replacement_blob), 40)
+
+            for command in (
+                ["git", "-C", str(checkout), "read-tree", policy.STATION_TOOLS_TREE],
+                [
+                    "git",
+                    "-C",
+                    str(checkout),
+                    "update-index",
+                    "--add",
+                    "--cacheinfo",
+                    f"100644,{replacement_blob},{tracked}",
+                ],
+            ):
+                completed = subprocess.run(command, check=False, capture_output=True, text=True)
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+            replacement_tree_result = subprocess.run(
+                ["git", "-C", str(checkout), "write-tree"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replacement_tree_result.returncode, 0, replacement_tree_result.stderr)
+            replacement_tree = replacement_tree_result.stdout.strip()
+            self.assertEqual(len(replacement_tree), 40)
+
+            replaced = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(checkout),
+                    "replace",
+                    policy.STATION_TOOLS_TREE,
+                    replacement_tree,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replaced.returncode, 0, replaced.stderr)
+            for command in (
+                ["git", "-C", str(checkout), "read-tree", "--reset", replacement_tree],
+                ["git", "-C", str(checkout), "checkout-index", "--all", "--force"],
+            ):
+                completed = subprocess.run(command, check=False, capture_output=True, text=True)
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+
+            porcelain = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(checkout),
+                    "status",
+                    "--porcelain=v1",
+                    "--untracked-files=all",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(porcelain.returncode, 0, porcelain.stderr)
+            self.assertEqual(porcelain.stdout.strip(), "")
+            self.assertEqual(
+                subprocess.run(
+                    ["git", "-C", str(checkout), "rev-parse", "HEAD^{tree}"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                ).stdout.strip(),
+                policy.STATION_TOOLS_TREE,
+            )
+            no_replace_porcelain = subprocess.run(
+                [
+                    "git",
+                    "--no-replace-objects",
+                    "-C",
+                    str(checkout),
+                    "status",
+                    "--porcelain=v1",
+                    "--untracked-files=all",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(no_replace_porcelain.returncode, 0, no_replace_porcelain.stderr)
+            self.assertIn(tracked, no_replace_porcelain.stdout)
+
+            with self.assertRaisesRegex(AdapterError, "content drift"):
+                check_station_tools_pin(checkout)
+            with patch.object(adapter_module, "_bridge_manifest") as bridge:
+                with self.assertRaisesRegex(AdapterError, "content drift"):
+                    prepare_v2_records(
+                        checkout,
+                        root / "assets",
+                        root / "source",
+                        root / "submission",
+                    )
+                bridge.assert_not_called()
+
+    def test_tagged_source_replacement_ref_rejects_before_bridge_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = self.require_tag()
+            checkout = root / "source"
+            cloned = subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    "--local",
+                    "--no-hardlinks",
+                    str(source),
+                    str(checkout),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(cloned.returncode, 0, cloned.stderr)
+            detached = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(checkout),
+                    "checkout",
+                    "--detach",
+                    policy.SOURCE_COMMIT,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(detached.returncode, 0, detached.stderr)
+
+            tracked = "capsules/capsule-cli/Capsule.toml"
+            original = subprocess.run(
+                [
+                    "git",
+                    "--no-replace-objects",
+                    "-C",
+                    str(checkout),
+                    "show",
+                    f"{policy.SOURCE_TREE}:{tracked}",
+                ],
+                check=False,
+                capture_output=True,
+            )
+            self.assertEqual(original.returncode, 0, original.stderr.decode())
+            replacement = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(checkout),
+                    "hash-object",
+                    "-w",
+                    "--stdin",
+                ],
+                input=original.stdout + b"\n# replacement object fixture\n",
+                check=False,
+                capture_output=True,
+            )
+            self.assertEqual(replacement.returncode, 0, replacement.stderr.decode())
+            replacement_blob = replacement.stdout.decode("ascii").strip()
+            self.assertEqual(len(replacement_blob), 40)
+
+            for command in (
+                ["git", "-C", str(checkout), "read-tree", policy.SOURCE_TREE],
+                [
+                    "git",
+                    "-C",
+                    str(checkout),
+                    "update-index",
+                    "--add",
+                    "--cacheinfo",
+                    f"100644,{replacement_blob},{tracked}",
+                ],
+            ):
+                completed = subprocess.run(command, check=False, capture_output=True, text=True)
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+            replacement_tree_result = subprocess.run(
+                ["git", "-C", str(checkout), "write-tree"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replacement_tree_result.returncode, 0, replacement_tree_result.stderr)
+            replacement_tree = replacement_tree_result.stdout.strip()
+            self.assertEqual(len(replacement_tree), 40)
+
+            replaced = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(checkout),
+                    "replace",
+                    policy.SOURCE_TREE,
+                    replacement_tree,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(replaced.returncode, 0, replaced.stderr)
+            for command in (
+                ["git", "-C", str(checkout), "read-tree", "--reset", replacement_tree],
+                ["git", "-C", str(checkout), "checkout-index", "--all", "--force"],
+            ):
+                completed = subprocess.run(command, check=False, capture_output=True, text=True)
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+
+            porcelain = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(checkout),
+                    "status",
+                    "--porcelain=v1",
+                    "--untracked-files=all",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(porcelain.returncode, 0, porcelain.stderr)
+            self.assertEqual(porcelain.stdout.strip(), "")
+            default_head = subprocess.run(
+                ["git", "-C", str(checkout), "rev-parse", "HEAD^{commit}"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(default_head.returncode, 0, default_head.stderr)
+            self.assertEqual(default_head.stdout.strip(), policy.SOURCE_COMMIT)
+            default_tree = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(checkout),
+                    "rev-parse",
+                    f"{policy.SOURCE_COMMIT}^{{tree}}",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(default_tree.returncode, 0, default_tree.stderr)
+            self.assertEqual(default_tree.stdout.strip(), policy.SOURCE_TREE)
+            no_replace_porcelain = subprocess.run(
+                [
+                    "git",
+                    "--no-replace-objects",
+                    "-C",
+                    str(checkout),
+                    "status",
+                    "--porcelain=v1",
+                    "--untracked-files=all",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(no_replace_porcelain.returncode, 0, no_replace_porcelain.stderr)
+            self.assertIn(tracked, no_replace_porcelain.stdout)
+
+            with patch.object(adapter_module, "_bridge_manifest") as bridge:
+                assets = self.clone_assets(root)
+                with self.assertRaisesRegex(VerificationError, "source checkout is dirty"):
+                    verify_source_tree(checkout)
+                with self.assertRaisesRegex(VerificationError, "source checkout is dirty"):
+                    verify_release(
+                        assets,
+                        checkout,
+                        b3sum=B3SUM,
+                        skip_sigstore=True,
+                        current_main_root=ROOT,
+                    )
+                bridge.assert_not_called()
+
+    def test_station_tools_tracked_dirt_rejects_before_bridge_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            checkout = self.clone_station_tools(root)
+            tracked = checkout / "Cargo.toml"
+            tracked.write_text(tracked.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+            with patch.object(adapter_module, "_bridge_manifest") as bridge:
+                with self.assertRaisesRegex(
+                    AdapterError,
+                    "(checkout is dirty|content drift).*",
+                ):
+                    prepare_v2_records(
+                        checkout,
+                        root / "assets",
+                        root / "source",
+                        root / "submission",
+                    )
+                bridge.assert_not_called()
+
+    def test_station_tools_untracked_dirt_rejects_before_bridge_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            checkout = self.clone_station_tools(root)
+            (checkout / "untracked-dirt.txt").write_text("dirty\n", encoding="utf-8")
+            with patch.object(adapter_module, "_bridge_manifest") as bridge:
+                with self.assertRaisesRegex(
+                    AdapterError,
+                    "(checkout is dirty|extra filesystem entry).*",
+                ):
+                    prepare_v2_records(
+                        checkout,
+                        root / "assets",
+                        root / "source",
+                        root / "submission",
+                    )
+                bridge.assert_not_called()
+
+    def test_station_tools_station_publish_v2_content_drift_rejects_before_bridge_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            checkout = self.clone_station_tools(root)
+            tracked = checkout / "crates" / "station-publish" / "src" / "v2.rs"
+            tracked.write_text(tracked.read_text(encoding="utf-8") + "\n// drift\n", encoding="utf-8")
+            with patch.object(adapter_module, "_bridge_manifest") as bridge:
+                with self.assertRaisesRegex(
+                    AdapterError,
+                    "(checkout is dirty|content drift).*",
+                ):
+                    prepare_v2_records(
+                        checkout,
+                        root / "assets",
+                        root / "source",
+                        root / "submission",
+                    )
+                bridge.assert_not_called()
+
+    def test_station_tools_ignored_extra_rejects_before_bridge_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            checkout = self.clone_station_tools(root)
+            ignored = checkout / "ignored-extra.capsule"
+            ignored.write_bytes(b"ignored\n")
+            with patch.object(adapter_module, "_bridge_manifest") as bridge:
+                with self.assertRaisesRegex(AdapterError, "extra filesystem entry.*ignored-extra.capsule"):
+                    prepare_v2_records(
+                        checkout,
+                        root / "assets",
+                        root / "source",
+                        root / "submission",
+                    )
+                bridge.assert_not_called()
+
+    def test_station_tools_symlink_and_mode_drift_reject_before_bridge_build(self) -> None:
+        for mutation, expected in (("symlink", "unexpected symlink"), ("mode", "mode drift")):
+            with self.subTest(mutation=mutation), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                checkout = self.clone_station_tools(root)
+                target = checkout / "Cargo.toml"
+                if mutation == "symlink":
+                    target.unlink()
+                    target.symlink_to("README.md")
+                else:
+                    target.chmod(0o755)
+                with patch.object(adapter_module, "_bridge_manifest") as bridge:
+                    with self.assertRaisesRegex(AdapterError, expected):
+                        prepare_v2_records(
+                            checkout,
+                            root / "assets",
+                            root / "source",
+                            root / "submission",
+                        )
+                    bridge.assert_not_called()
+
+    def test_station_tools_index_optimization_flags_reject_before_bridge_build(self) -> None:
+        for flag in ("assume", "skip"):
+            with self.subTest(flag=flag), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                checkout = self.clone_station_tools(root)
+                tracked = "crates/station-publish/src/v2.rs"
+                command = ["git", "-C", str(checkout), "update-index"]
+                command.append("--assume-unchanged" if flag == "assume" else "--skip-worktree")
+                command.append(tracked)
+                changed = subprocess.run(command, check=False, capture_output=True, text=True)
+                self.assertEqual(changed.returncode, 0, changed.stderr)
+                with patch.object(adapter_module, "_bridge_manifest") as bridge:
+                    with self.assertRaisesRegex(AdapterError, "assume-unchanged or skip-worktree"):
+                        prepare_v2_records(
+                            checkout,
+                            root / "assets",
+                            root / "source",
+                            root / "submission",
+                        )
+                    bridge.assert_not_called()
+
+    def test_tagged_capsule_identity_matrix_uses_detached_tree(self) -> None:
+        source = self.require_tag()
+        self.assertEqual(
+            verify_source_tree(source),
+            {
+                "commit": policy.SOURCE_COMMIT,
+                "tree": "46a8a976d54eb82ac922c56ae41d713595895ff5",
+                "tag": policy.SOURCE_TAG,
+            },
+        )
+        identities: list[tuple[str, str]] = []
+        for item in policy.SEED:
+            with self.subTest(directory=item.directory):
+                manifest, manifest_bytes = _load_source_manifest(source, item)
+                package = manifest["package"]
+                self.assertEqual(package["name"], item.package)
+                self.assertEqual(package["version"], item.version)
+                self.assertGreater(len(manifest_bytes), 0)
+                identities.append((package["name"], package["version"]))
+        self.assertEqual(len(identities), 19)
+        self.assertEqual(len(set(identities)), 19)
+
+    def test_tagged_capsule_archives_verify_as_canonical_nineteen(self) -> None:
+        source = self.require_tag()
+        assets = self.require_assets()
+        verified = []
+        for item in policy.SEED:
+            with self.subTest(package=item.package):
+                manifest, manifest_bytes = _load_source_manifest(source, item)
+                verified.append(
+                    _verify_capsule(assets / item.asset, item, manifest, manifest_bytes)
+                )
+        self.assertEqual(len(verified), 19)
+        self.assertEqual(
+            {entry["package"] for entry in verified},
+            {item.package for item in policy.SEED},
+        )
+
+    def test_current_main_drift_is_separate_and_contains_three_blocked_additions(self) -> None:
+        drift = verify_current_main_drift(ROOT)
+        self.assertTrue(drift["separate_from_release_proof"])
+        self.assertEqual(len(drift["seed_directories"]), 19)
+        self.assertEqual(len(drift["allowlist"]), 22)
+        self.assertEqual(
+            set(drift["blocked_additions"]),
+            {"capsule-mcp", "capsule-hook-adapter-oracle", "capsule-meta-harness"},
+        )
+
+    def test_default_live_path_exits_before_any_output_or_station_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            output = root / "output"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts" / "aos_station_adapter.py"),
+                    "--artifacts",
+                    str(root / "missing-assets"),
+                    "--source-root",
+                    str(root / "missing-source"),
+                    "--current-main-root",
+                    str(root / "missing-main"),
+                    "--station-tools",
+                    str(root / "missing-station-tools"),
+                    "--output",
+                    str(output),
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertFalse(output.exists())
+            self.assertIn("blocked before writes", result.stderr)
+            self.assertNotIn("write_submission", result.stderr)
+
+    def test_publish_option_is_permanently_disabled_before_any_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            output = root / "output"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts" / "aos_station_adapter.py"),
+                    "--artifacts",
+                    str(root / "missing-assets"),
+                    "--station-tools",
+                    str(root / "missing-station-tools"),
+                    "--output",
+                    str(output),
+                    "--publish",
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertFalse(output.exists())
+            self.assertIn("blocked before writes", result.stderr)
+
+    def test_failed_dry_run_does_not_follow_symlink_or_modify_nonempty_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            existing = root / "existing"
+            existing.mkdir()
+            sentinel = existing / "sentinel"
+            sentinel.write_text("preserve", encoding="utf-8")
+            args = [
+                sys.executable,
+                str(ROOT / "scripts" / "aos_station_adapter.py"),
+                "--artifacts",
+                str(root / "missing-assets"),
+                "--source-root",
+                str(root / "missing-source"),
+                "--current-main-root",
+                str(root / "missing-main"),
+                "--station-tools",
+                str(root / "missing-station-tools"),
+                "--output",
+                str(existing),
+                "--dry-run",
+            ]
+            result = subprocess.run(args, cwd=ROOT, check=False, capture_output=True, text=True)
+            self.assertEqual(result.returncode, 2)
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve")
+            self.assertEqual(list(existing.iterdir()), [sentinel])
+
+            linked = root / "linked"
+            linked.symlink_to(existing, target_is_directory=True)
+            linked_args = list(args)
+            linked_args[-2] = str(linked)
+            result = subprocess.run(
+                linked_args,
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertEqual(list(existing.iterdir()), [sentinel])
+
+    def test_dry_run_fixture_is_not_ready_and_has_only_typed_record_files(self) -> None:
+        source = self.require_tag()
+        assets = self.require_assets()
+        station_tools = self.require_station_tools()
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "output"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts" / "aos_station_adapter.py"),
+                    "--artifacts",
+                    str(assets),
+                    "--source-root",
+                    str(source),
+                    "--current-main-root",
+                    str(ROOT),
+                    "--station-tools",
+                    str(station_tools),
+                    "--output",
+                    str(output),
+                    "--skip-sigstore",
+                    "--dry-run",
+                    "--json",
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            report = json.loads(result.stdout)
+            self.assertFalse(report["readiness"])
+            self.assertEqual(report["publication"]["record_count"], 19)
+            self.assertFalse(report["publication"]["fixture_readiness"])
+            records = list((output / "submission" / "records").rglob("*.json"))
+            artifacts = list((output / "submission" / "artifacts").rglob("*.capsule"))
+            self.assertEqual(len(records), 19)
+            self.assertEqual(len(artifacts), 19)
+            publication_report = json.loads(
+                (output / "reports" / "publication-v2.json").read_text(encoding="utf-8")
+            )
+            self.assertNotIn("records", publication_report)
+            proposal = json.loads(
+                (output / "submission" / "proposals" / "aos-ce-2026.1.3.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(len(proposal["allowlist_coordinates"]), 19)
+            self.assertNotIn("package", proposal)
+
+    def test_forbidden_authority_registry_checkpoint_and_event_head_tables_at_any_depth(self) -> None:
+        item = policy.SEED[0]
+        for key in ("authority", "registry", "checkpoint", "event-head"):
+            with self.subTest(key=key):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    manifest = root / "capsules" / item.directory / "Capsule.toml"
+                    manifest.parent.mkdir(parents=True)
+                    manifest.write_text(
+                        f'[package]\nname = "{item.package}"\nversion = "{item.version}"\n'
+                        f"\n[{key}]\nmarker = \"unexpected\"\n",
+                        encoding="utf-8",
+                    )
+                    with self.assertRaisesRegex(VerificationError, key):
+                        _load_source_manifest(root, item)
+
+                    nested = root / "nested" / "capsules" / item.directory / "Capsule.toml"
+                    nested.parent.mkdir(parents=True)
+                    nested.write_text(
+                        f'[package]\nname = "{item.package}"\nversion = "{item.version}"\n'
+                        f"\n[package.metadata]\n{key} = \"unexpected\"\n",
+                        encoding="utf-8",
+                    )
+                    with self.assertRaisesRegex(VerificationError, key):
+                        _load_source_manifest(root / "nested", item)
+
+    def test_unknown_top_level_manifest_field_is_rejected(self) -> None:
+        item = policy.SEED[0]
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest = root / "capsules" / item.directory / "Capsule.toml"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                f'[package]\nname = "{item.package}"\nversion = "{item.version}"\n'
+                '\n[future_contract]\nvalue = "unexpected"\n',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(VerificationError, "unknown top-level"):
+                _load_source_manifest(root, item)
+
+    def test_manifest_name_and_version_mismatch_are_rejected(self) -> None:
+        item = policy.SEED[0]
+        for field, value in (("name", "not-aos"), ("version", "9.9.9")):
+            with self.subTest(field=field):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    manifest = root / "capsules" / item.directory / "Capsule.toml"
+                    manifest.parent.mkdir(parents=True)
+                    name = value if field == "name" else item.package
+                    version = value if field == "version" else item.version
+                    manifest.write_text(
+                        f'[package]\nname = "{name}"\nversion = "{version}"\n',
+                        encoding="utf-8",
+                    )
+                    with self.assertRaisesRegex(VerificationError, "identity/version"):
+                        _load_source_manifest(root, item)
+
+    def test_wrong_tree_is_rejected_before_capsule_processing(self) -> None:
+        source = self.require_tag()
+        with patch.object(policy, "SOURCE_TREE", "0" * 40):
+            with self.assertRaisesRegex(VerificationError, "source tree"):
+                verify_source_tree(source)
+
+    def test_wrong_tag_and_workflow_identity_are_rejected(self) -> None:
+        self.require_tag()
+        cases = (
+            ("tag", 'tag = "2026.1.3"', 'tag = "2026.1.2"', "tag"),
+            (
+                "workflow",
+                'release-workflow-identity = "https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/2026.1.3"',
+                'release-workflow-identity = "https://example.invalid/workflow"',
+                "workflow identity",
+            ),
+        )
+        for field, old, new, message in cases:
+            with self.subTest(field=field):
+                with tempfile.TemporaryDirectory() as temporary:
+                    assets = self.clone_assets(Path(temporary))
+                    metadata = assets / "unicity-aos-2026.1.3-release.toml"
+                    text = metadata.read_text(encoding="utf-8")
+                    self.assertIn(old, text)
+                    _replace_file(metadata, text.replace(old, new, 1))
+                    with self.assertRaisesRegex(VerificationError, message):
+                        self.verify_fixture(assets)
+
+    def test_wrong_bundle_is_rejected_by_exact_asset_inventory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            assets = self.clone_assets(Path(temporary))
+            (assets / "aos-cli.capsule.sigstore.json").unlink()
+            with self.assertRaisesRegex(VerificationError, "asset set differs"):
+                self.verify_fixture(assets)
+
+    def test_wrong_digest_is_rejected_by_executable_blake3_check(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            assets = self.clone_assets(Path(temporary))
+            checksums = assets / "BLAKE3SUMS.txt"
+            lines = checksums.read_text(encoding="utf-8").splitlines()
+            for index, line in enumerate(lines):
+                if line.endswith("  aos-cli.capsule"):
+                    lines[index] = f"{'0' * 64}  aos-cli.capsule"
+                    break
+            else:  # pragma: no cover - fixture corruption
+                self.fail("aos-cli checksum was not present")
+            _replace_file(checksums, "\n".join(lines) + "\n")
+            with self.assertRaisesRegex(VerificationError, "BLAKE3 mismatch"):
+                self.verify_fixture(assets)
+
+    def test_archive_embedded_manifest_bytes_must_match_tagged_source(self) -> None:
+        source = self.require_tag()
+        assets = self.require_assets()
+        item = policy.SEED[0]
+        manifest, manifest_bytes = _load_source_manifest(source, item)
+        with tempfile.TemporaryDirectory() as temporary:
+            changed = Path(temporary) / item.asset
+            with tarfile.open(assets / item.asset, "r:gz") as reader, tarfile.open(
+                changed, "w:gz"
+            ) as writer:
+                for member in reader.getmembers():
+                    if member.isfile():
+                        stream = reader.extractfile(member)
+                        self.assertIsNotNone(stream)
+                        payload = stream.read() if stream is not None else b""
+                        if member.name == "Capsule.toml":
+                            payload += b"\n# structural mismatch\n"
+                        member.size = len(payload)
+                        writer.addfile(member, io.BytesIO(payload))
+                    else:
+                        writer.addfile(member)
+            with self.assertRaisesRegex(VerificationError, "bytes differ"):
+                _verify_capsule(changed, item, manifest, manifest_bytes)
+
+    def test_equivocation_classification_is_rejected_at_record_boundary(self) -> None:
+        item = policy.SEED[0]
+        value = {
+            "record": "records/aos/aos-cli/0.2.0.json",
+            "artifact": "artifacts/blake3/00/fixture.capsule",
+            "coordinate": "@aos/aos-cli",
+            "version": item.version,
+            "publication_digest": "blake3:" + "0" * 64,
+            "package_digest": "blake3:" + "1" * 64,
+            "manifest_digest": "blake3:" + "2" * 64,
+            "content_digest": "blake3:" + "3" * 64,
+            "artifact_size": 1,
+            "classification": "Equivocation",
+            "readiness": False,
+            "fixture": True,
+            "schema": "aos-station-prepare-v2-result-v1",
+        }
+        with self.assertRaisesRegex(AdapterError, "unexpected publication classification"):
+            _record_summary(value, item)
+
+    def test_adapter_sources_have_no_v1_write_or_network_publish_surface(self) -> None:
+        paths = [
+            ROOT / "scripts" / "aos_station_adapter.py",
+            *sorted((ROOT / "scripts" / "aos_station_adapter").glob("*.py")),
+            ROOT / "scripts" / "aos_station_adapter" / "prepare_v2_bridge.rs",
+        ]
+        for path in paths:
+            content = path.read_text(encoding="utf-8")
+            self.assertNotIn("write_submission", content, path.as_posix())
+            self.assertNotIn("git push", content, path.as_posix())
+            self.assertNotIn("gh release upload", content, path.as_posix())
+
+    def test_workflow_provisions_locked_graph_and_b3sum_only_failure_path(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "station-submit.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("CARGO_HOME", workflow)
+        self.assertIn("cargo fetch", workflow)
+        self.assertIn("--manifest-path \"$AOS_CE_STATION_TOOLS/Cargo.toml\"", workflow)
+        self.assertIn("--offline --locked", workflow)
+        self.assertIn("cargo install b3sum --locked --version 1.8.5", workflow)
+        self.assertIn('b3sum_stderr="$RUNNER_TEMP/aos-b3sum-build.stderr"', workflow)
+        self.assertIn('test "$status" -eq 101', workflow)
+        self.assertIn(
+            "grep -F 'no matching package named `thiserror` found' \"$b3sum_stderr\"",
+            workflow,
+        )
+        self.assertIn(
+            "grep -F 'offline mode (--offline)' \"$b3sum_stderr\"",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #88

Parent campaign: astrid-runtime/astrid#1563

## Summary

- adds the fail-closed AOS release-to-Station v1 publication adapter
- validates the canonical 19-package Capsule.toml set and public evidence assets
- compiles the bridge from immutable Git objects with replacement refs disabled
- binds the adapter to signed Station interface commit fd233f91b40d00c5f721ba99436ce30eca9036ba and tree 0bf775f225bfb9177d5788ec8c32d5453f75c660
- corrects product-facing language while preserving internal v2.rs, prepare_v2, schema, report, binary, and domain identifiers

## Evidence

- both commits have good GPG signatures from Joshua J. Bouw with matching DCO sign-offs
- 28/28 adapter tests pass against a fresh GitHub clone of the signed Station interface, with no skips
- prior independent GLM accepted the adapter tree before the dependency SHA was replaced by its signed, tree-identical successor
- fresh exact-head review accepted terminology tip 7d6023fc; the adapter matrix and hosted CI are green

## Boundaries

The workflow fails closed. This PR does not submit a PublicationRecord, write Station state, change the public pin, or activate Station.

## AI / Tool Assistance

Assisted-by: Codex: GPT-5

Codex implemented and tested the adapter and terminology correction. Joshua J. Bouw reviewed and authorized DCO/GPG certification and publication of the review branch.