### PR TITLE
feat(shell): add detached adaptive workspace semantic runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "adaptive-shell"
+version = "0.1.0"
+dependencies = [
+ "blake3",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "apps/adaptive-shell",
     "crates/unicity-aos-bootstrap",
     "crates/aos-mcp-broker",
     "capsules/capsule-agents",

--- a/apps/adaptive-shell/Cargo.toml
+++ b/apps/adaptive-shell/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "adaptive-shell"
+version = "0.1.0"
+edition = "2024"
+description = "Native Rust reference shell for the AOS Adaptive Workspace"
+publish = false
+license.workspace = true
+
+[lib]
+name = "adaptive_shell"
+path = "src/lib.rs"
+
+[[bin]]
+name = "adaptive-shell"
+path = "src/main.rs"
+
+[dependencies]
+blake3 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/apps/adaptive-shell/README.md
+++ b/apps/adaptive-shell/README.md
@@ -1,0 +1,26 @@
+# Adaptive Shell
+
+`adaptive-shell` is the native Rust reference runner for the AOS Adaptive
+Workspace. It opens on an activity, not a chat prompt, and keeps durable
+activity/recipe intent separate from an ephemeral retained semantic surface.
+
+The current tranche is intentionally headless. It provides:
+
+- all 62 `aos.catalog/1` semantic component identities;
+- bounded, deterministic activity, recipe, surface, and reviewed patch models;
+- keyed reconciliation with stable node identity and focus;
+- desktop master-plus-stack, grid, single, focus, and phone layout rules;
+- Fieldglass dark, light, and high-contrast themes with density, text scale,
+  and reduced-motion settings;
+- a backend-neutral display list and deterministic snapshot runner;
+- an honest `NativePortal::Unavailable` fixture state.
+
+No browser, DOM, WebView, JavaScript, daemon, network, LLM, process, or
+authority integration is present. A future winit/GPU adapter can consume the
+display list without entering the semantic model.
+
+```text
+cargo run -p adaptive-shell -- --headless --fixture desktop
+cargo run -p adaptive-shell -- --headless --fixture phone --theme light --json
+cargo run -p adaptive-shell -- --headless --fixture theme-lab --density open
+```

--- a/apps/adaptive-shell/src/activity.rs
+++ b/apps/adaptive-shell/src/activity.rs
@@ -1,0 +1,1137 @@
+//! Activity, recipe, surface, and reviewed semantic patch models.
+
+use crate::components::{NodeId, PropValue, SceneError, SemanticNode, StateSet};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Maximum number of patch operations accepted by the fixture store.
+pub const MAX_PATCH_OPS: usize = 64;
+/// Maximum bytes in patch metadata strings.
+pub const MAX_PATCH_TEXT_BYTES: usize = 4096;
+/// Maximum recipe metadata entries.
+pub const MAX_RECIPE_METADATA: usize = 16;
+/// Maximum UTF-8 bytes in recipe metadata keys and text values.
+pub const MAX_RECIPE_METADATA_BYTES: usize = 2048;
+/// Maximum UTF-8 bytes in an opaque owner identifier.
+pub const MAX_OWNER_REF_BYTES: usize = 256;
+/// Maximum UTF-8 bytes in an activity identifier.
+pub const MAX_ACTIVITY_ID_BYTES: usize = 256;
+/// Maximum UTF-8 bytes in an activity title.
+pub const MAX_ACTIVITY_TITLE_BYTES: usize = crate::components::MAX_SEMANTIC_TEXT_BYTES;
+
+fn bounded_nonempty(value: &str, maximum: usize) -> bool {
+    !value.is_empty() && value.len() <= maximum
+}
+
+/// An opaque reference to an Astrid-owned workspace owner.
+///
+/// The shell stores the identity it was given, but never derives ownership
+/// from a path, HOME, XDG, shell label, or process identity.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", content = "id")]
+pub enum OpaqueOwnerRef {
+    /// Human-owned personal state.
+    User(String),
+    /// Agent-private state.
+    Principal(String),
+    /// Deliberately shared team/fleet state.
+    Fleet(String),
+}
+
+impl OpaqueOwnerRef {
+    /// Return the opaque identifier without interpreting it as a path.
+    pub fn id(&self) -> &str {
+        match self {
+            Self::User(id) | Self::Principal(id) | Self::Fleet(id) => id,
+        }
+    }
+}
+
+/// Stable, typed ephemeral surface target.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct SurfaceId(String);
+
+impl SurfaceId {
+    /// Construct and bound a stable surface identifier.
+    pub fn new(value: impl Into<String>) -> Result<Self, SceneError> {
+        let value = value.into();
+        if value.is_empty() || value.len() > 256 {
+            return Err(SceneError::InvalidSurfaceId);
+        }
+        Ok(Self(value))
+    }
+
+    /// Stable string form.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SurfaceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for SurfaceId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+fn value_text_len(value: &PropValue) -> usize {
+    match value {
+        PropValue::Text(value) | PropValue::Token(value) => value.len(),
+        PropValue::Number(value) if value.is_finite() => 8,
+        PropValue::Number(_) => usize::MAX,
+        PropValue::Bool(_) => 1,
+    }
+}
+
+impl<'de> Deserialize<'de> for OpaqueOwnerRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(tag = "kind", content = "id")]
+        enum Raw {
+            User(String),
+            Principal(String),
+            Fleet(String),
+        }
+        match Raw::deserialize(deserializer)? {
+            Raw::User(value) if bounded_nonempty(&value, MAX_OWNER_REF_BYTES) => {
+                Ok(Self::User(value))
+            }
+            Raw::Principal(value) if bounded_nonempty(&value, MAX_OWNER_REF_BYTES) => {
+                Ok(Self::Principal(value))
+            }
+            Raw::Fleet(value) if bounded_nonempty(&value, MAX_OWNER_REF_BYTES) => {
+                Ok(Self::Fleet(value))
+            }
+            _ => Err(serde::de::Error::custom("invalid opaque owner reference")),
+        }
+    }
+}
+
+/// Durable identity and owner reference for an activity.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "ActivityInput")]
+pub struct Activity {
+    /// Schema identifier.
+    pub schema: String,
+    /// Stable activity identity.
+    pub activity_id: String,
+    /// Astrid-supplied opaque owner reference.
+    pub owner_ref: OpaqueOwnerRef,
+    /// Human-facing title.
+    pub title: String,
+    /// Durable recipe identity.
+    pub recipe_id: String,
+    /// Current ephemeral surface, when materialized.
+    pub current_surface: Option<SurfaceId>,
+}
+
+impl Activity {
+    /// Construct a fixture activity.
+    pub fn new(
+        activity_id: impl Into<String>,
+        owner_ref: OpaqueOwnerRef,
+        title: impl Into<String>,
+        recipe_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema: "aos.activity@1".to_owned(),
+            activity_id: activity_id.into(),
+            owner_ref,
+            title: title.into(),
+            recipe_id: recipe_id.into(),
+            current_surface: None,
+        }
+    }
+
+    fn validate(&self) -> Result<(), PatchError> {
+        if self.schema != "aos.activity@1"
+            || !bounded_nonempty(self.activity_id.as_str(), MAX_ACTIVITY_ID_BYTES)
+            || !bounded_nonempty(self.owner_ref.id(), MAX_OWNER_REF_BYTES)
+            || !bounded_nonempty(self.title.as_str(), MAX_ACTIVITY_TITLE_BYTES)
+            || !bounded_nonempty(self.recipe_id.as_str(), MAX_ACTIVITY_ID_BYTES)
+        {
+            return Err(PatchError::InvalidActivity);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+struct ActivityInput {
+    schema: String,
+    activity_id: String,
+    owner_ref: OpaqueOwnerRef,
+    title: String,
+    recipe_id: String,
+    current_surface: Option<SurfaceId>,
+}
+
+impl TryFrom<ActivityInput> for Activity {
+    type Error = PatchError;
+
+    fn try_from(input: ActivityInput) -> Result<Self, Self::Error> {
+        let activity = Self {
+            schema: input.schema,
+            activity_id: input.activity_id,
+            owner_ref: input.owner_ref,
+            title: input.title,
+            recipe_id: input.recipe_id,
+            current_surface: input.current_surface,
+        };
+        activity.validate()?;
+        Ok(activity)
+    }
+}
+
+/// Durable semantic intent and restore truth.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(try_from = "RecipeInput")]
+pub struct Recipe {
+    /// Schema identifier.
+    pub schema: String,
+    /// Astrid-supplied opaque owner. Ownership is never inferred locally.
+    pub owner_ref: OpaqueOwnerRef,
+    /// Stable recipe identity.
+    pub recipe_id: String,
+    /// Monotonic accepted revision.
+    pub revision: u64,
+    /// Digest of the canonical semantic content.
+    pub digest: String,
+    /// Semantic theme identifier.
+    pub theme_id: String,
+    /// Explicit nonvisual recipe facts. They never become scene draw commands.
+    #[serde(default)]
+    pub metadata: BTreeMap<String, PropValue>,
+    /// Root semantic node.
+    pub root: SemanticNode,
+}
+
+impl Recipe {
+    /// Construct a recipe and calculate its deterministic digest.
+    pub fn new(
+        owner_ref: OpaqueOwnerRef,
+        recipe_id: impl Into<String>,
+        theme_id: impl Into<String>,
+        root: SemanticNode,
+    ) -> Result<Self, RecipeValidationError> {
+        let mut recipe = Self {
+            schema: "aos.recipe@1".to_owned(),
+            owner_ref,
+            recipe_id: recipe_id.into(),
+            revision: 1,
+            digest: String::new(),
+            theme_id: theme_id.into(),
+            metadata: BTreeMap::new(),
+            root,
+        };
+        recipe.validate()?;
+        recipe.refresh_digest();
+        Ok(recipe)
+    }
+
+    /// Compute the digest over semantic content, excluding the digest itself.
+    pub fn computed_digest(&self) -> String {
+        let canonical = serde_json::to_vec(&(
+            &self.schema,
+            &self.recipe_id,
+            self.revision,
+            &self.theme_id,
+            &self.root,
+            &self.metadata,
+        ))
+        .expect("semantic recipe is serializable");
+        blake3::hash(&canonical).to_hex().to_string()
+    }
+
+    fn refresh_digest(&mut self) {
+        self.digest = self.computed_digest();
+    }
+
+    /// Validate recipe invariants, semantic bounds, and metadata bounds.
+    pub fn validate(&self) -> Result<(), RecipeValidationError> {
+        if self.schema != "aos.recipe@1" {
+            return Err(RecipeValidationError::Schema);
+        }
+        if !bounded_nonempty(self.owner_ref.id(), MAX_OWNER_REF_BYTES)
+            || !bounded_nonempty(self.recipe_id.as_str(), 256)
+            || self.theme_id.is_empty()
+            || self.theme_id.len() > 128
+            || self.revision == 0
+        {
+            return Err(RecipeValidationError::Identity);
+        }
+        if self.metadata.len() > MAX_RECIPE_METADATA {
+            return Err(RecipeValidationError::MetadataTooLarge);
+        }
+        let metadata_bytes = self
+            .metadata
+            .iter()
+            .map(|(key, value)| key.len() + value_text_len(value))
+            .sum::<usize>();
+        if metadata_bytes > MAX_RECIPE_METADATA_BYTES {
+            return Err(RecipeValidationError::MetadataTooLarge);
+        }
+        self.root
+            .validate()
+            .map(|_| ())
+            .map_err(RecipeValidationError::Scene)
+    }
+
+    /// Materialize a new ephemeral incarnation from this recipe.
+    pub fn surface(&self, surface_id: SurfaceId, incarnation: u64) -> Surface {
+        Surface {
+            schema: "aos.surface@1".to_owned(),
+            surface_id,
+            recipe_id: self.recipe_id.clone(),
+            recipe_revision: self.revision,
+            incarnation,
+            root: self.root.clone(),
+        }
+    }
+}
+
+/// Ephemeral materialized surface.  It is not restore truth.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Surface {
+    /// Schema identifier.
+    pub schema: String,
+    /// Ephemeral surface identity.
+    pub surface_id: SurfaceId,
+    /// Source recipe identity.
+    pub recipe_id: String,
+    /// Recipe revision used for materialization.
+    pub recipe_revision: u64,
+    /// Monotonic incarnation number.
+    pub incarnation: u64,
+    /// Materialized semantic root.
+    pub root: SemanticNode,
+}
+
+#[derive(Deserialize)]
+struct RecipeInput {
+    schema: String,
+    owner_ref: OpaqueOwnerRef,
+    recipe_id: String,
+    revision: u64,
+    #[serde(default)]
+    digest: String,
+    theme_id: String,
+    #[serde(default)]
+    metadata: BTreeMap<String, PropValue>,
+    root: SemanticNode,
+}
+
+impl TryFrom<RecipeInput> for Recipe {
+    type Error = RecipeValidationError;
+
+    fn try_from(input: RecipeInput) -> Result<Self, Self::Error> {
+        let mut recipe = Self {
+            schema: input.schema,
+            owner_ref: input.owner_ref,
+            recipe_id: input.recipe_id,
+            revision: input.revision,
+            digest: input.digest,
+            theme_id: input.theme_id,
+            metadata: input.metadata,
+            root: input.root,
+        };
+        recipe.validate()?;
+        recipe.refresh_digest();
+        Ok(recipe)
+    }
+}
+
+/// Recipe invariant validation failure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RecipeValidationError {
+    /// Unsupported recipe schema.
+    Schema,
+    /// Empty or oversized identity, or nonmonotonic revision.
+    Identity,
+    /// Recipe metadata exceeds bounded semantic storage.
+    MetadataTooLarge,
+    /// Semantic root failed validation.
+    Scene(SceneError),
+}
+
+impl fmt::Display for RecipeValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Schema => f.write_str("unsupported recipe schema"),
+            Self::Identity => f.write_str("invalid recipe identity or revision"),
+            Self::MetadataTooLarge => f.write_str("recipe metadata exceeds bound"),
+            Self::Scene(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for RecipeValidationError {}
+
+impl From<RecipeValidationError> for PatchError {
+    fn from(error: RecipeValidationError) -> Self {
+        match error {
+            RecipeValidationError::Scene(error) => Self::Scene(error),
+            _ => Self::InvalidRecipe,
+        }
+    }
+}
+
+/// Bounded semantic operations in a reviewed patch.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum PatchOp {
+    /// Replace one node's interaction/status flags.
+    SetState {
+        /// Target node identity.
+        node_id: NodeId,
+        /// Replacement state flags.
+        state: StateSet,
+    },
+    /// Set one bounded semantic property.
+    SetProperty {
+        /// Target node identity.
+        node_id: NodeId,
+        /// Property key.
+        key: String,
+        /// Property value.
+        value: PropValue,
+    },
+    /// Change the recipe's semantic theme reference.
+    SetTheme {
+        /// Semantic theme identifier.
+        theme_id: String,
+    },
+    /// Set explicitly nonvisual recipe metadata.
+    SetRecipeMetadata {
+        /// Stable metadata key.
+        key: String,
+        /// Bounded metadata value.
+        value: PropValue,
+    },
+}
+
+/// Astrid-supplied acting principal, separate from the workspace owner.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", content = "id")]
+pub enum OpaquePrincipalRef {
+    /// Human principal.
+    User(String),
+    /// Agent principal.
+    Agent(String),
+    /// Automation or service principal.
+    Service(String),
+}
+
+impl OpaquePrincipalRef {
+    fn validate(&self) -> Result<(), PatchError> {
+        let id = match self {
+            Self::User(id) | Self::Agent(id) | Self::Service(id) => id,
+        };
+        if id.is_empty() || id.len() > 256 {
+            Err(PatchError::InvalidPrincipal)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for OpaquePrincipalRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(tag = "kind", content = "id")]
+        enum Raw {
+            User(String),
+            Agent(String),
+            Service(String),
+        }
+        fn bounded(value: &str) -> bool {
+            !value.is_empty() && value.len() <= 256
+        }
+        match Raw::deserialize(deserializer)? {
+            Raw::User(value) if bounded(&value) => Ok(Self::User(value)),
+            Raw::Agent(value) if bounded(&value) => Ok(Self::Agent(value)),
+            Raw::Service(value) if bounded(&value) => Ok(Self::Service(value)),
+            _ => Err(serde::de::Error::custom("invalid opaque principal")),
+        }
+    }
+}
+
+/// Explicit accepted review attached before a semantic CAS.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ReviewAcceptance {
+    /// Reviewing principal.
+    pub reviewer: OpaquePrincipalRef,
+    /// Opaque review receipt supplied by the review boundary.
+    pub receipt: String,
+}
+
+/// A bounded, idempotent compare-and-swap recipe patch.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(try_from = "PatchInput")]
+pub struct Patch {
+    /// Schema identifier.
+    pub schema: String,
+    /// Owner of the target recipe.
+    pub owner_ref: OpaqueOwnerRef,
+    /// Principal requesting CAS, distinct from the owner and reviewer.
+    pub acting_principal: OpaquePrincipalRef,
+    /// Stable proposal identity.
+    pub proposal_id: String,
+    /// Explicit review acceptance.
+    pub review: ReviewAcceptance,
+    /// Stable idempotency key.
+    pub patch_id: String,
+    /// Recipe targeted by this patch.
+    pub recipe_id: String,
+    /// Expected base revision.
+    pub base_revision: u64,
+    /// Expected base digest.
+    pub base_digest: String,
+    /// Human sentence shown before acceptance.
+    pub summary: String,
+    /// Ordered semantic operations.
+    pub operations: Vec<PatchOp>,
+}
+
+#[derive(Deserialize)]
+struct PatchInput {
+    schema: String,
+    owner_ref: OpaqueOwnerRef,
+    acting_principal: OpaquePrincipalRef,
+    proposal_id: String,
+    review: ReviewAcceptance,
+    patch_id: String,
+    recipe_id: String,
+    base_revision: u64,
+    base_digest: String,
+    summary: String,
+    operations: Vec<PatchOp>,
+}
+
+impl TryFrom<PatchInput> for Patch {
+    type Error = PatchError;
+
+    fn try_from(input: PatchInput) -> Result<Self, Self::Error> {
+        let patch = Self {
+            schema: input.schema,
+            owner_ref: input.owner_ref,
+            acting_principal: input.acting_principal,
+            proposal_id: input.proposal_id,
+            review: input.review,
+            patch_id: input.patch_id,
+            recipe_id: input.recipe_id,
+            base_revision: input.base_revision,
+            base_digest: input.base_digest,
+            summary: input.summary,
+            operations: input.operations,
+        };
+        patch.validate()?;
+        Ok(patch)
+    }
+}
+
+impl Patch {
+    /// Validate patch bounds and metadata before attempting CAS.
+    pub fn validate(&self) -> Result<(), PatchError> {
+        if self.schema != "aos.patch@1" {
+            return Err(PatchError::InvalidSchema);
+        }
+        self.acting_principal.validate()?;
+        self.review.reviewer.validate()?;
+        if self.acting_principal == self.review.reviewer {
+            return Err(PatchError::SelfApproved);
+        }
+        for text in [
+            self.patch_id.as_str(),
+            self.recipe_id.as_str(),
+            self.proposal_id.as_str(),
+            self.review.receipt.as_str(),
+            self.base_digest.as_str(),
+        ] {
+            if text.is_empty() || text.len() > 256 {
+                return Err(PatchError::MetadataTooLarge);
+            }
+        }
+        if self.operations.is_empty() || self.operations.len() > MAX_PATCH_OPS {
+            return Err(PatchError::TooManyOperations);
+        }
+        let metadata_bytes = self.patch_id.len()
+            + self.recipe_id.len()
+            + self.proposal_id.len()
+            + self.review.receipt.len()
+            + self.base_digest.len()
+            + self.summary.len();
+        if metadata_bytes > MAX_PATCH_TEXT_BYTES {
+            return Err(PatchError::MetadataTooLarge);
+        }
+        for operation in &self.operations {
+            if let PatchOp::SetProperty { key, .. } = operation
+                && (key.is_empty() || key.len() > 128)
+            {
+                return Err(PatchError::InvalidProperty);
+            }
+            if let PatchOp::SetTheme { theme_id } = operation
+                && (theme_id.is_empty() || theme_id.len() > 128)
+            {
+                return Err(PatchError::InvalidTheme);
+            }
+            if let PatchOp::SetRecipeMetadata { key, value } = operation
+                && (key.is_empty() || key.len() > 128 || value_text_len(value) > 1024)
+            {
+                return Err(PatchError::InvalidRecipeMetadata);
+            }
+        }
+        Ok(())
+    }
+
+    /// Identity of target plus exact operation/content intent, excluding idempotency key.
+    pub fn intent_digest(&self) -> String {
+        let canonical = serde_json::to_vec(&(
+            &self.owner_ref,
+            &self.recipe_id,
+            self.base_revision,
+            &self.base_digest,
+            &self.operations,
+        ))
+        .expect("patch operations are serializable");
+        blake3::hash(&canonical).to_hex().to_string()
+    }
+}
+
+/// Result of applying a reviewed patch.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PatchOutcome {
+    /// Patch accepted and a new recipe is available.
+    Applied {
+        /// Canonical accepted recipe.
+        recipe: Recipe,
+        /// Whether any accepted operation changed visual semantic surface.
+        visual_changed: bool,
+    },
+    /// Same idempotency key was already accepted; no second mutation occurred.
+    AlreadyApplied(Recipe),
+}
+
+/// In-memory recipe store used by the deterministic fixture runner.
+#[derive(Clone, Debug, Default)]
+pub struct RecipeStore {
+    recipes: BTreeMap<String, Recipe>,
+    applied_patches: BTreeMap<String, String>,
+}
+
+impl RecipeStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a recipe fixture.
+    pub fn insert(&mut self, recipe: Recipe) -> Result<(), PatchError> {
+        if recipe.schema != "aos.recipe@1" || recipe.recipe_id.is_empty() {
+            return Err(PatchError::InvalidRecipe);
+        }
+        recipe.validate()?;
+        let mut recipe = recipe;
+        recipe.refresh_digest();
+        self.recipes.insert(recipe.recipe_id.clone(), recipe);
+        Ok(())
+    }
+
+    /// Read a recipe by stable identity.
+    pub fn get(&self, recipe_id: &str) -> Option<&Recipe> {
+        self.recipes.get(recipe_id)
+    }
+
+    /// Apply a reviewed patch with revision and digest CAS.
+    pub fn apply_patch(&mut self, patch: &Patch) -> Result<PatchOutcome, PatchError> {
+        patch.validate()?;
+        let intent = patch.intent_digest();
+        if let Some(previous_intent) = self.applied_patches.get(&patch.patch_id) {
+            if previous_intent != &intent {
+                return Err(PatchError::PatchIdConflict {
+                    patch_id: patch.patch_id.clone(),
+                });
+            }
+            let recipe = self
+                .recipes
+                .get(&patch.recipe_id)
+                .ok_or(PatchError::UnknownRecipe)?
+                .clone();
+            return Ok(PatchOutcome::AlreadyApplied(recipe));
+        }
+        let recipe = self
+            .recipes
+            .get(&patch.recipe_id)
+            .ok_or(PatchError::UnknownRecipe)?;
+        if recipe.owner_ref != patch.owner_ref {
+            return Err(PatchError::OwnerMismatch);
+        }
+        if recipe.revision != patch.base_revision || recipe.digest != patch.base_digest {
+            return Err(PatchError::Conflict {
+                current_revision: recipe.revision,
+                current_digest: recipe.digest.clone(),
+            });
+        }
+
+        let mut candidate = recipe.clone();
+        let mut visual_changed = false;
+        for operation in &patch.operations {
+            match operation {
+                PatchOp::SetState { node_id, state } => {
+                    let node = find_node_mut(&mut candidate.root, *node_id)
+                        .ok_or(PatchError::UnknownNode(*node_id))?;
+                    node.state = *state;
+                    visual_changed = true;
+                }
+                PatchOp::SetProperty {
+                    node_id,
+                    key,
+                    value,
+                } => {
+                    let node = find_node_mut(&mut candidate.root, *node_id)
+                        .ok_or(PatchError::UnknownNode(*node_id))?;
+                    node.props = node
+                        .props
+                        .clone()
+                        .with(key.clone(), value.clone())
+                        .map_err(PatchError::Props)?;
+                    visual_changed = true;
+                }
+                PatchOp::SetTheme { theme_id } => candidate.theme_id = theme_id.clone(),
+                PatchOp::SetRecipeMetadata { key, value } => {
+                    candidate.metadata.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        candidate.revision = candidate
+            .revision
+            .checked_add(1)
+            .ok_or(PatchError::RevisionOverflow)?;
+        candidate.refresh_digest();
+        candidate.validate()?;
+        self.recipes
+            .insert(candidate.recipe_id.clone(), candidate.clone());
+        self.applied_patches
+            .insert(patch.patch_id.clone(), patch.intent_digest());
+        Ok(PatchOutcome::Applied {
+            recipe: candidate,
+            visual_changed,
+        })
+    }
+}
+
+/// Bounded registry of activities and their durable recipe.
+#[derive(Clone, Debug, Default)]
+pub struct ActivityRegistry {
+    entries: BTreeMap<String, (Activity, String)>,
+}
+
+impl ActivityRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an activity to a recipe owned by the same opaque owner.
+    pub fn register(&mut self, activity: Activity, recipe: &Recipe) -> Result<(), PatchError> {
+        activity.validate()?;
+        if activity.owner_ref != recipe.owner_ref || activity.recipe_id != recipe.recipe_id {
+            return Err(PatchError::OwnerMismatch);
+        }
+        if self.entries.contains_key(&activity.activity_id) {
+            return Err(PatchError::DuplicateActivity {
+                activity_id: activity.activity_id.clone(),
+            });
+        }
+        if self.entries.len() >= 64 {
+            return Err(PatchError::MetadataTooLarge);
+        }
+        self.entries.insert(
+            activity.activity_id.clone(),
+            (activity, recipe.recipe_id.clone()),
+        );
+        Ok(())
+    }
+
+    /// Rematerialize the selected activity's current recipe incarnation.
+    pub fn rematerialize(
+        &self,
+        activity_id: &str,
+        recipes: &RecipeStore,
+        next_incarnation: u64,
+    ) -> Result<Surface, PatchError> {
+        let (_, recipe_id) = self
+            .entries
+            .get(activity_id)
+            .ok_or(PatchError::UnknownRecipe)?;
+        let recipe = recipes.get(recipe_id).ok_or(PatchError::UnknownRecipe)?;
+        let incarnation = next_incarnation
+            .checked_add(1)
+            .ok_or(PatchError::IncarnationOverflow)?;
+        let surface_id = SurfaceId::new(format!("{activity_id}:{incarnation}"))
+            .map_err(|_| PatchError::InvalidRecipe)?;
+        Ok(recipe.surface(surface_id, incarnation))
+    }
+}
+
+fn find_node_mut(node: &mut SemanticNode, target: NodeId) -> Option<&mut SemanticNode> {
+    if node.id == target {
+        return Some(node);
+    }
+    for child in &mut node.children {
+        if let Some(found) = find_node_mut(child, target) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Recipe/patch failure.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PatchError {
+    /// Patch schema was not `aos.patch@1`.
+    InvalidSchema,
+    /// Patch operation count is outside bounds.
+    TooManyOperations,
+    /// Patch metadata exceeds bounds.
+    MetadataTooLarge,
+    /// Property key is invalid.
+    InvalidProperty,
+    /// Theme identifier is invalid.
+    InvalidTheme,
+    /// Target recipe does not exist.
+    UnknownRecipe,
+    /// Target node does not exist.
+    UnknownNode(NodeId),
+    /// Base revision or digest does not match.
+    Conflict {
+        /// Current revision.
+        current_revision: u64,
+        /// Current digest.
+        current_digest: String,
+    },
+    /// Scene validation failed.
+    Scene(SceneError),
+    /// Property validation failed.
+    Props(crate::components::PropsError),
+    /// Recipe invariant failed.
+    InvalidRecipe,
+    /// Acting principal is invalid.
+    InvalidPrincipal,
+    /// Activity identity, owner, or title violated its bounds.
+    InvalidActivity,
+    /// A patch may not review itself.
+    SelfApproved,
+    /// Nonvisual metadata operation is invalid.
+    InvalidRecipeMetadata,
+    /// Same patch id was reused for different intent.
+    PatchIdConflict {
+        /// Reused idempotency key.
+        patch_id: String,
+    },
+    /// Patch owner does not target recipe owner.
+    OwnerMismatch,
+    /// Monotonic revision exhausted u64.
+    RevisionOverflow,
+    /// Ephemeral surface incarnation exhausted u64.
+    IncarnationOverflow,
+    /// Activity identity was already registered.
+    DuplicateActivity {
+        /// Reused activity identity.
+        activity_id: String,
+    },
+}
+
+impl fmt::Display for PatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSchema => write!(f, "unsupported patch schema"),
+            Self::TooManyOperations => write!(f, "patch operation bound exceeded"),
+            Self::MetadataTooLarge => write!(f, "patch metadata bound exceeded"),
+            Self::InvalidProperty => write!(f, "invalid property key"),
+            Self::InvalidTheme => write!(f, "invalid theme id"),
+            Self::UnknownRecipe => write!(f, "unknown recipe"),
+            Self::UnknownNode(id) => write!(f, "unknown semantic node {id}"),
+            Self::Conflict {
+                current_revision,
+                current_digest,
+            } => write!(
+                f,
+                "recipe conflict at revision {current_revision} ({current_digest})"
+            ),
+            Self::Scene(error) => error.fmt(f),
+            Self::Props(error) => error.fmt(f),
+            Self::InvalidRecipe => write!(f, "invalid recipe invariants"),
+            Self::InvalidPrincipal => write!(f, "invalid acting principal"),
+            Self::InvalidActivity => write!(f, "invalid activity identity or title"),
+            Self::SelfApproved => write!(f, "acting principal may not review its own patch"),
+            Self::InvalidRecipeMetadata => write!(f, "invalid nonvisual recipe metadata"),
+            Self::PatchIdConflict { patch_id } => {
+                write!(f, "patch id {patch_id} was reused with different intent")
+            }
+            Self::OwnerMismatch => write!(f, "patch owner does not match recipe owner"),
+            Self::RevisionOverflow => write!(f, "recipe revision overflow"),
+            Self::IncarnationOverflow => write!(f, "surface incarnation overflow"),
+            Self::DuplicateActivity { activity_id } => {
+                write!(f, "activity id {activity_id} is already registered")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PatchError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::{ComponentKind, SemanticNode};
+
+    fn recipe() -> Recipe {
+        Recipe::new(
+            OpaqueOwnerRef::Principal("fixture-owner".to_owned()),
+            "cat-break",
+            "fieldglass-dark",
+            SemanticNode::new("root", ComponentKind::Region, "Cat break"),
+        )
+        .expect("valid fixture")
+    }
+
+    #[test]
+    fn patch_is_cas_and_idempotent() {
+        let recipe = recipe();
+        let root_id = recipe.root.id;
+        let mut store = RecipeStore::new();
+        store.insert(recipe.clone()).expect("insert");
+        let patch = Patch {
+            schema: "aos.patch@1".to_owned(),
+            owner_ref: OpaqueOwnerRef::Principal("fixture-owner".to_owned()),
+            acting_principal: OpaquePrincipalRef::Agent("fixture-agent".to_owned()),
+            proposal_id: "proposal-1".to_owned(),
+            review: ReviewAcceptance {
+                reviewer: OpaquePrincipalRef::User("fixture-reviewer".to_owned()),
+                receipt: "review-1".to_owned(),
+            },
+            patch_id: "patch-1".to_owned(),
+            recipe_id: recipe.recipe_id.clone(),
+            base_revision: recipe.revision,
+            base_digest: recipe.digest.clone(),
+            summary: "focus the activity".to_owned(),
+            operations: vec![PatchOp::SetState {
+                node_id: root_id,
+                state: StateSet::empty().with(StateSet::FOCUS, true),
+            }],
+        };
+        let applied = store.apply_patch(&patch).expect("accepted");
+        let second = store.apply_patch(&patch).expect("idempotent");
+        assert!(matches!(
+            applied,
+            PatchOutcome::Applied {
+                visual_changed: true,
+                ..
+            }
+        ));
+        assert!(matches!(second, PatchOutcome::AlreadyApplied(_)));
+        let stale = Patch {
+            base_revision: recipe.revision,
+            base_digest: recipe.digest,
+            patch_id: "patch-2".to_owned(),
+            ..patch
+        };
+        assert!(matches!(
+            store.apply_patch(&stale),
+            Err(PatchError::Conflict { .. })
+        ));
+    }
+
+    #[test]
+    fn patch_ids_reject_changed_intent_and_self_review() {
+        let recipe = recipe();
+        let root_id = recipe.root.id;
+        let owner = OpaqueOwnerRef::Principal("fixture-owner".to_owned());
+        let make_patch = |id: &str, state: u16| Patch {
+            schema: "aos.patch@1".to_owned(),
+            owner_ref: owner.clone(),
+            acting_principal: OpaquePrincipalRef::Agent("agent".to_owned()),
+            proposal_id: "proposal".to_owned(),
+            review: ReviewAcceptance {
+                reviewer: OpaquePrincipalRef::User("reviewer".to_owned()),
+                receipt: "receipt".to_owned(),
+            },
+            patch_id: id.to_owned(),
+            recipe_id: recipe.recipe_id.clone(),
+            base_revision: recipe.revision,
+            base_digest: recipe.digest.clone(),
+            summary: "reviewed".to_owned(),
+            operations: vec![PatchOp::SetState {
+                node_id: root_id,
+                state: StateSet::from_bits(state).expect("state"),
+            }],
+        };
+        let mut store = RecipeStore::new();
+        store.insert(recipe.clone()).expect("insert");
+        store
+            .apply_patch(&make_patch("same-id", StateSet::FOCUS))
+            .expect("accepted");
+        assert!(matches!(
+            store.apply_patch(&make_patch("same-id", StateSet::PRESSED)),
+            Err(PatchError::PatchIdConflict { .. })
+        ));
+        let mut self_review = make_patch("self", StateSet::FOCUS);
+        self_review.review = ReviewAcceptance {
+            reviewer: self_review.acting_principal.clone(),
+            receipt: "self".to_owned(),
+        };
+        assert_eq!(self_review.validate(), Err(PatchError::SelfApproved));
+    }
+
+    #[test]
+    fn activity_registry_rematerializes_typed_surface() {
+        let recipe = recipe();
+        let mut activity = Activity::new(
+            "cats",
+            OpaqueOwnerRef::Principal("fixture-owner".to_owned()),
+            "Cat break",
+            recipe.recipe_id.clone(),
+        );
+        activity.owner_ref = recipe.owner_ref.clone();
+        let mut registry = ActivityRegistry::new();
+        registry.register(activity, &recipe).expect("register");
+        let mut store = RecipeStore::new();
+        store.insert(recipe).expect("insert");
+        let surface = registry.rematerialize("cats", &store, 1).expect("surface");
+        assert_eq!(surface.incarnation, 2);
+        assert_eq!(surface.surface_id.as_str(), "cats:2");
+    }
+
+    #[test]
+    fn recipe_validation_bounds_owner_reference() {
+        let mut recipe = recipe();
+        recipe.owner_ref = OpaqueOwnerRef::Principal("o".repeat(MAX_OWNER_REF_BYTES + 1));
+        assert_eq!(recipe.validate(), Err(RecipeValidationError::Identity));
+    }
+
+    #[test]
+    fn activity_registry_rejects_oversized_identity_and_title() {
+        let recipe = recipe();
+        let oversized = [
+            Activity::new(
+                "cats",
+                OpaqueOwnerRef::Principal("o".repeat(MAX_OWNER_REF_BYTES + 1)),
+                "Cat break",
+                recipe.recipe_id.clone(),
+            ),
+            Activity::new(
+                "a".repeat(MAX_ACTIVITY_ID_BYTES + 1),
+                recipe.owner_ref.clone(),
+                "Cat break",
+                recipe.recipe_id.clone(),
+            ),
+            Activity::new(
+                "cats",
+                recipe.owner_ref.clone(),
+                "t".repeat(MAX_ACTIVITY_TITLE_BYTES + 1),
+                recipe.recipe_id.clone(),
+            ),
+        ];
+        for activity in oversized {
+            let mut registry = ActivityRegistry::new();
+            assert_eq!(
+                registry.register(activity, &recipe),
+                Err(PatchError::InvalidActivity)
+            );
+        }
+    }
+
+    #[test]
+    fn activity_registry_rejects_duplicate_identity() {
+        let recipe = recipe();
+        let mut registry = ActivityRegistry::new();
+        let first = Activity::new(
+            "cats",
+            recipe.owner_ref.clone(),
+            "Cat break",
+            recipe.recipe_id.clone(),
+        );
+        registry
+            .register(first, &recipe)
+            .expect("first registration");
+        let replacement = Activity::new(
+            "cats",
+            recipe.owner_ref.clone(),
+            "Replacement",
+            recipe.recipe_id.clone(),
+        );
+        assert_eq!(
+            registry.register(replacement, &recipe),
+            Err(PatchError::DuplicateActivity {
+                activity_id: "cats".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn recipe_revision_overflow_is_reported() {
+        let mut recipe = recipe();
+        recipe.revision = u64::MAX;
+        let mut store = RecipeStore::new();
+        store
+            .insert(recipe.clone())
+            .expect("max revision remains valid");
+        let stored = store.get(&recipe.recipe_id).expect("stored recipe").clone();
+        let patch = Patch {
+            schema: "aos.patch@1".to_owned(),
+            owner_ref: stored.owner_ref.clone(),
+            acting_principal: OpaquePrincipalRef::Agent("fixture-agent".to_owned()),
+            proposal_id: "overflow-proposal".to_owned(),
+            review: ReviewAcceptance {
+                reviewer: OpaquePrincipalRef::User("fixture-reviewer".to_owned()),
+                receipt: "overflow-review".to_owned(),
+            },
+            patch_id: "overflow-patch".to_owned(),
+            recipe_id: stored.recipe_id.clone(),
+            base_revision: stored.revision,
+            base_digest: stored.digest.clone(),
+            summary: "exercise revision overflow".to_owned(),
+            operations: vec![PatchOp::SetState {
+                node_id: stored.root.id,
+                state: StateSet::empty().with(StateSet::FOCUS, true),
+            }],
+        };
+        assert_eq!(store.apply_patch(&patch), Err(PatchError::RevisionOverflow));
+    }
+
+    #[test]
+    fn activity_incarnation_overflow_is_reported() {
+        let recipe = recipe();
+        let mut registry = ActivityRegistry::new();
+        let activity = Activity::new(
+            "cats",
+            recipe.owner_ref.clone(),
+            "Cat break",
+            recipe.recipe_id.clone(),
+        );
+        registry.register(activity, &recipe).expect("registration");
+        let mut store = RecipeStore::new();
+        store.insert(recipe).expect("recipe");
+        assert_eq!(
+            registry.rematerialize("cats", &store, u64::MAX),
+            Err(PatchError::IncarnationOverflow)
+        );
+    }
+}

--- a/apps/adaptive-shell/src/components.rs
+++ b/apps/adaptive-shell/src/components.rs
@@ -1,0 +1,961 @@
+//! Semantic component identities and the retained scene graph.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+/// Maximum number of children a semantic node may contain.
+pub const MAX_CHILDREN: usize = 64;
+/// Maximum depth of a semantic scene.
+pub const MAX_DEPTH: usize = 32;
+/// Maximum number of nodes in one scene.
+pub const MAX_NODES: usize = 512;
+/// Maximum number of properties on a node.
+pub const MAX_PROPS: usize = 32;
+/// Maximum UTF-8 bytes in all properties of one node.
+pub const MAX_PROP_BYTES: usize = 4096;
+/// Maximum UTF-8 bytes in one accessibility string or semantic property key.
+pub const MAX_SEMANTIC_TEXT_BYTES: usize = 512;
+/// Union of all semantic state bits accepted by the catalog.
+pub const KNOWN_STATE_BITS: u16 = (1 << 12) - 1;
+
+/// The finite semantic catalog shipped by the reference shell.
+///
+/// These are semantic names, not renderer widgets.  In particular, a native
+/// portal describes an external surface; it is never treated as an A2UI
+/// component or a source of authority.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ComponentKind {
+    /// A named semantic region.
+    Region,
+    /// An ordered vertical or horizontal stack.
+    Stack,
+    /// A grid of semantic children.
+    Grid,
+    /// A resizable split.
+    Split,
+    /// Navigation sidebar.
+    Sidebar,
+    /// Action row.
+    ActionBar,
+    /// Framed content card.
+    Card,
+    /// Preference or content group.
+    Group,
+    /// Collapsible content.
+    Collapse,
+    /// Repeated bounded children.
+    Repeater,
+    /// Scrollable semantic region.
+    ScrollRegion,
+    /// A semantic divider.
+    Divider,
+    /// A heading.
+    Heading,
+    /// Body or inline text.
+    Text,
+    /// Inline rich content.
+    InlineContent,
+    /// Source/code text.
+    CodeBlock,
+    /// Compact label.
+    Badge,
+    /// Prominent numeric fact.
+    KeyFigure,
+    /// Empty-result explanation.
+    EmptyState,
+    /// A named icon.
+    Icon,
+    /// An action control.  Icon-only controls use its icon slot.
+    Button,
+    /// Single-line text entry.
+    TextField,
+    /// Multi-line text entry.
+    TextArea,
+    /// Numeric entry.
+    NumberField,
+    /// Single selection.
+    Select,
+    /// Multiple selection.
+    MultiSelect,
+    /// Boolean switch.
+    Switch,
+    /// Boolean checkbox.
+    Checkbox,
+    /// Bounded range input.
+    Slider,
+    /// Date/time entry.
+    DateTimeField,
+    /// Tabular data.
+    Table,
+    /// Concise record summary.
+    RecordSummary,
+    /// Data chart with a textual equivalent.
+    DatasetChart,
+    /// Ordered events.
+    Timeline,
+    /// Before/after difference.
+    Difference,
+    /// Progress indicator.
+    Progress,
+    /// Tab navigation.
+    Tabs,
+    /// Hierarchical navigation.
+    Breadcrumb,
+    /// Context menu.
+    Menu,
+    /// Page navigation.
+    Pager,
+    /// A semantic link.
+    Link,
+    /// Non-blocking alert.
+    Alert,
+    /// Temporary notification.
+    Toast,
+    /// Inline feedback.
+    InlineMessage,
+    /// Loading placeholder.
+    Skeleton,
+    /// Busy indicator.
+    Spinner,
+    /// Small status indicator.
+    StatusDot,
+    /// Modal dialog.
+    Dialog,
+    /// Capability description, never a grant.
+    CapabilityCard,
+    /// Consent request, never consent itself.
+    ConsentForm,
+    /// Deliberate secure-input prompt.
+    SecurePrompt,
+    /// Governed file selection request.
+    FilePicker,
+    /// Image media.
+    ImageView,
+    /// Audio media.
+    AudioPlayer,
+    /// Video media.
+    VideoPlayer,
+    /// File metadata.
+    FileDetails,
+    /// Embedded media reference.
+    MediaEmbed,
+    /// Free-form drawing stage.
+    CanvasStage,
+    /// Diagram surface.
+    DiagramView,
+    /// Annotation layer.
+    AnnotationLayer,
+    /// Bounded terminal output.
+    TerminalView,
+    /// External application surface state.
+    NativePortal,
+}
+
+impl ComponentKind {
+    /// Every catalog kind in stable order.
+    pub const ALL: [Self; 62] = [
+        Self::Region,
+        Self::Stack,
+        Self::Grid,
+        Self::Split,
+        Self::Sidebar,
+        Self::ActionBar,
+        Self::Card,
+        Self::Group,
+        Self::Collapse,
+        Self::Repeater,
+        Self::ScrollRegion,
+        Self::Divider,
+        Self::Heading,
+        Self::Text,
+        Self::InlineContent,
+        Self::CodeBlock,
+        Self::Badge,
+        Self::KeyFigure,
+        Self::EmptyState,
+        Self::Icon,
+        Self::Button,
+        Self::TextField,
+        Self::TextArea,
+        Self::NumberField,
+        Self::Select,
+        Self::MultiSelect,
+        Self::Switch,
+        Self::Checkbox,
+        Self::Slider,
+        Self::DateTimeField,
+        Self::Table,
+        Self::RecordSummary,
+        Self::DatasetChart,
+        Self::Timeline,
+        Self::Difference,
+        Self::Progress,
+        Self::Tabs,
+        Self::Breadcrumb,
+        Self::Menu,
+        Self::Pager,
+        Self::Link,
+        Self::Alert,
+        Self::Toast,
+        Self::InlineMessage,
+        Self::Skeleton,
+        Self::Spinner,
+        Self::StatusDot,
+        Self::Dialog,
+        Self::CapabilityCard,
+        Self::ConsentForm,
+        Self::SecurePrompt,
+        Self::FilePicker,
+        Self::ImageView,
+        Self::AudioPlayer,
+        Self::VideoPlayer,
+        Self::FileDetails,
+        Self::MediaEmbed,
+        Self::CanvasStage,
+        Self::DiagramView,
+        Self::AnnotationLayer,
+        Self::TerminalView,
+        Self::NativePortal,
+    ];
+
+    /// Return the catalog family used by the Theme Lab.
+    pub const fn family(self) -> &'static str {
+        match self {
+            Self::Region
+            | Self::Stack
+            | Self::Grid
+            | Self::Split
+            | Self::Sidebar
+            | Self::ActionBar
+            | Self::Card
+            | Self::Group
+            | Self::Collapse
+            | Self::Repeater
+            | Self::ScrollRegion
+            | Self::Divider => "Structure",
+            Self::Heading
+            | Self::Text
+            | Self::InlineContent
+            | Self::CodeBlock
+            | Self::Badge
+            | Self::KeyFigure
+            | Self::EmptyState
+            | Self::Icon => "Content",
+            Self::Button
+            | Self::TextField
+            | Self::TextArea
+            | Self::NumberField
+            | Self::Select
+            | Self::MultiSelect
+            | Self::Switch
+            | Self::Checkbox
+            | Self::Slider
+            | Self::DateTimeField => "Input",
+            Self::Table
+            | Self::RecordSummary
+            | Self::DatasetChart
+            | Self::Timeline
+            | Self::Difference
+            | Self::Progress => "Data",
+            Self::Tabs | Self::Breadcrumb | Self::Menu | Self::Pager | Self::Link => "Navigation",
+            Self::Alert
+            | Self::Toast
+            | Self::InlineMessage
+            | Self::Skeleton
+            | Self::Spinner
+            | Self::StatusDot
+            | Self::Dialog => "Feedback",
+            Self::CapabilityCard | Self::ConsentForm | Self::SecurePrompt | Self::FilePicker => {
+                "Governed"
+            }
+            Self::ImageView
+            | Self::AudioPlayer
+            | Self::VideoPlayer
+            | Self::FileDetails
+            | Self::MediaEmbed => "Media",
+            Self::CanvasStage | Self::DiagramView | Self::AnnotationLayer => "Canvas",
+            Self::TerminalView => "Terminal",
+            Self::NativePortal => "Native",
+        }
+    }
+}
+
+const INTERACTION: u16 = StateSet::HOVER | StateSet::PRESSED | StateSet::FOCUS | StateSet::DISABLED;
+const SELECTABLE: u16 = INTERACTION | StateSet::SELECTED;
+const STATUS: u16 = StateSet::LOADING
+    | StateSet::ERROR
+    | StateSet::EMPTY
+    | StateSet::SUCCESS
+    | StateSet::WARNING
+    | StateSet::DANGER;
+const RUNTIME_ONLY: u16 = INTERACTION | STATUS;
+const GENERAL_PROPS: &[&str] = &[
+    "title",
+    "label",
+    "name",
+    "subtitle",
+    "placeholder",
+    "status",
+    "value",
+    "source",
+    "text",
+    "language",
+    "alt",
+    "duration",
+    "action",
+    "min",
+    "max",
+    "step",
+    "options",
+    "columns",
+    "uri",
+    "mime",
+    "size",
+    "modified",
+    "progress",
+    "collapse",
+    "gap",
+    "role",
+];
+const NO_CHILDREN: usize = 0;
+
+/// Stable semantic identity derived from an activity-local key.
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize,
+)]
+#[serde(transparent)]
+pub struct NodeId(u64);
+
+impl NodeId {
+    /// Derive an identity without depending on insertion order.
+    pub fn from_key(key: &str) -> Self {
+        let digest = blake3::hash(key.as_bytes());
+        let mut bytes = [0_u8; 8];
+        bytes.copy_from_slice(&digest.as_bytes()[..8]);
+        Self(u64::from_le_bytes(bytes))
+    }
+
+    /// Expose the compact value for display-list and snapshot serializers.
+    pub const fn value(self) -> u64 {
+        self.0
+    }
+}
+
+impl fmt::Display for NodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "n{:016x}", self.0)
+    }
+}
+
+/// A bounded scalar property value.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PropValue {
+    /// UTF-8 text, bounded by the containing property map.
+    Text(String),
+    /// Numeric value.
+    Number(f64),
+    /// Boolean value.
+    Bool(bool),
+    /// Semantic token reference.
+    Token(String),
+}
+
+impl PropValue {
+    fn byte_len(&self) -> usize {
+        match self {
+            Self::Text(value) | Self::Token(value) => value.len(),
+            Self::Number(_) | Self::Bool(_) => 0,
+        }
+    }
+}
+
+/// Bounded node properties with deterministic key order.
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct BoundedProps(BTreeMap<String, PropValue>);
+
+impl BoundedProps {
+    /// Build a property set while enforcing count and byte limits.
+    pub fn new(values: BTreeMap<String, PropValue>) -> Result<Self, PropsError> {
+        if values.len() > MAX_PROPS {
+            return Err(PropsError::TooMany);
+        }
+        let bytes = values
+            .iter()
+            .map(|(key, value)| key.len() + value.byte_len())
+            .sum::<usize>();
+        if bytes > MAX_PROP_BYTES {
+            return Err(PropsError::TooLarge);
+        }
+        Ok(Self(values))
+    }
+
+    /// Return an empty property set.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Add or replace one property, preserving the bounds.
+    pub fn with(mut self, key: impl Into<String>, value: PropValue) -> Result<Self, PropsError> {
+        self.0.insert(key.into(), value);
+        Self::new(self.0)
+    }
+
+    /// Read a property.
+    pub fn get(&self, key: &str) -> Option<&PropValue> {
+        self.0.get(key)
+    }
+
+    /// Iterate in stable order.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &PropValue)> {
+        self.0.iter()
+    }
+}
+
+/// Property validation failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PropsError {
+    /// More than [`MAX_PROPS`] keys were supplied.
+    TooMany,
+    /// Combined key and text bytes exceed [`MAX_PROP_BYTES`].
+    TooLarge,
+}
+
+impl fmt::Display for PropsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooMany => write!(f, "component has too many properties"),
+            Self::TooLarge => write!(f, "component properties exceed byte limit"),
+        }
+    }
+}
+
+impl std::error::Error for PropsError {}
+
+/// Interaction and semantic state flags.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct StateSet(u16);
+
+impl StateSet {
+    /// Pointer is over the component.
+    pub const HOVER: u16 = 1 << 0;
+    /// Pointer or keyboard activation is in progress.
+    pub const PRESSED: u16 = 1 << 1;
+    /// Component owns keyboard focus.
+    pub const FOCUS: u16 = 1 << 2;
+    /// Component cannot be activated.
+    pub const DISABLED: u16 = 1 << 3;
+    /// Component is selected.
+    pub const SELECTED: u16 = 1 << 4;
+    /// Component is waiting for work.
+    pub const LOADING: u16 = 1 << 5;
+    /// Component reports an error.
+    pub const ERROR: u16 = 1 << 6;
+    /// Component has no content.
+    pub const EMPTY: u16 = 1 << 7;
+    /// Operation succeeded.
+    pub const SUCCESS: u16 = 1 << 8;
+    /// Non-fatal warning.
+    pub const WARNING: u16 = 1 << 9;
+    /// Dangerous or destructive state.
+    pub const DANGER: u16 = 1 << 10;
+    /// Reserved validation bit, intentionally outside every component contract.
+    pub const VALIDATION_ONLY: u16 = 1 << 11;
+
+    /// Return an empty state set.
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// Set or clear one flag.
+    pub const fn with(self, flag: u16, enabled: bool) -> Self {
+        if enabled {
+            Self(self.0 | flag)
+        } else {
+            Self(self.0 & !flag)
+        }
+    }
+
+    /// Test one flag.
+    pub const fn contains(self, flag: u16) -> bool {
+        self.0 & flag != 0
+    }
+
+    /// Compact serialized value.
+    pub const fn bits(self) -> u16 {
+        self.0
+    }
+
+    /// Construct from serialized bits, rejecting undefined flags.
+    pub const fn from_bits(bits: u16) -> Result<Self, SceneError> {
+        if bits & !KNOWN_STATE_BITS != 0 {
+            Err(SceneError::InvalidState)
+        } else {
+            Ok(Self(bits))
+        }
+    }
+}
+
+impl TryFrom<u16> for StateSet {
+    type Error = SceneError;
+
+    fn try_from(bits: u16) -> Result<Self, Self::Error> {
+        Self::from_bits(bits)
+    }
+}
+
+impl Serialize for StateSet {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for StateSet {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bits = u16::deserialize(deserializer)?;
+        Self::from_bits(bits).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Accessible semantic metadata kept beside the rendered node.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct Accessibility {
+    /// Semantic role exposed to an accessibility adapter.
+    pub role: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Optional description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl Accessibility {
+    /// Construct a named semantic role.
+    pub fn named(role: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            role: role.into(),
+            name: name.into(),
+            description: None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Accessibility {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Raw {
+            role: String,
+            name: String,
+            description: Option<String>,
+        }
+        let raw = Raw::deserialize(deserializer)?;
+        if raw.role.is_empty() || raw.role.len() > MAX_SEMANTIC_TEXT_BYTES {
+            return Err(serde::de::Error::custom("invalid accessibility role"));
+        }
+        if raw.name.is_empty() || raw.name.len() > MAX_SEMANTIC_TEXT_BYTES {
+            return Err(serde::de::Error::custom("invalid accessibility name"));
+        }
+        if raw
+            .description
+            .as_ref()
+            .is_some_and(|text| text.len() > MAX_SEMANTIC_TEXT_BYTES)
+        {
+            return Err(serde::de::Error::custom(
+                "invalid accessibility description",
+            ));
+        }
+        Ok(Self {
+            role: raw.role,
+            name: raw.name,
+            description: raw.description,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for BoundedProps {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let values = BTreeMap::<String, PropValue>::deserialize(deserializer)?;
+        Self::new(values).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A retained semantic node.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct SemanticNode {
+    /// Stable identity used by reconciliation and focus.
+    pub id: NodeId,
+    /// Semantic component kind.
+    pub kind: ComponentKind,
+    /// Bounded semantic properties.
+    #[serde(default)]
+    pub props: BoundedProps,
+    /// Interaction and status state.
+    #[serde(default)]
+    pub state: StateSet,
+    /// Accessible role/name/state metadata.
+    #[serde(default)]
+    pub accessibility: Accessibility,
+    /// Ordered child nodes.
+    #[serde(default)]
+    pub children: Vec<Self>,
+}
+
+impl<'de> Deserialize<'de> for SemanticNode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawNode {
+            id: NodeId,
+            kind: ComponentKind,
+            #[serde(default)]
+            props: BoundedProps,
+            #[serde(default)]
+            state: StateSet,
+            #[serde(default)]
+            accessibility: Accessibility,
+            #[serde(default)]
+            children: Vec<RawNode>,
+        }
+
+        fn validate(
+            node: &RawNode,
+            depth: usize,
+            parent: Option<NodeId>,
+            seen: &mut BTreeSet<NodeId>,
+        ) -> Result<usize, SceneError> {
+            if depth > MAX_DEPTH {
+                return Err(SceneError::TooDeep(node.id));
+            }
+            if parent == Some(node.id) {
+                return Err(SceneError::SelfParent(node.id));
+            }
+            if !seen.insert(node.id) {
+                return Err(SceneError::DuplicateNode(node.id));
+            }
+            let contract = node.kind.contract();
+            if node.children.len() > contract.max_children {
+                return Err(SceneError::TooManyChildren(node.id));
+            }
+            if node.state.bits() & !contract.allowed_state != 0 {
+                return Err(SceneError::UnsupportedState(node.id, node.kind));
+            }
+            for key in contract.required_props {
+                if node.props.get(key).is_none() {
+                    return Err(SceneError::MissingProperty(node.id, node.kind, key));
+                }
+            }
+            for key in node.props.iter().map(|(key, _)| key.as_str()) {
+                if !contract.allowed_props.contains(&key) {
+                    return Err(SceneError::UnknownProperty(
+                        node.id,
+                        node.kind,
+                        key.to_owned(),
+                    ));
+                }
+            }
+            let mut total = 1_usize;
+            for child in &node.children {
+                total = total
+                    .checked_add(validate(child, depth + 1, Some(node.id), seen)?)
+                    .ok_or(SceneError::TooManyNodes)?;
+                if total > MAX_NODES {
+                    return Err(SceneError::TooManyNodes);
+                }
+            }
+            Ok(total)
+        }
+
+        fn expand(node: RawNode) -> SemanticNode {
+            SemanticNode {
+                id: node.id,
+                kind: node.kind,
+                props: node.props,
+                state: node.state,
+                accessibility: node.accessibility,
+                children: node.children.into_iter().map(expand).collect(),
+            }
+        }
+
+        let raw = RawNode::deserialize(deserializer)?;
+        let mut seen = BTreeSet::new();
+        validate(&raw, 0, None, &mut seen).map_err(serde::de::Error::custom)?;
+        Ok(expand(raw))
+    }
+}
+
+/// Typed construction/validation contract for one catalog identity.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ComponentContract {
+    /// Stable family name.
+    pub family: &'static str,
+    /// Properties that must be present for a meaningful semantic node.
+    pub required_props: &'static [&'static str],
+    /// Properties accepted by this identity.
+    pub allowed_props: &'static [&'static str],
+    /// State flags accepted by this identity.
+    pub allowed_state: u16,
+    /// Maximum children accepted by this identity.
+    pub max_children: usize,
+}
+
+impl SemanticNode {
+    /// Create a node with a stable key and no children.
+    pub fn new(key: &str, kind: ComponentKind, name: &str) -> Self {
+        Self {
+            id: NodeId::from_key(key),
+            kind,
+            props: BoundedProps::default(),
+            state: StateSet::empty(),
+            accessibility: Accessibility::named(kind.family(), name),
+            children: Vec::new(),
+        }
+    }
+
+    /// Attach a child, enforcing the local count bound.
+    pub fn push(&mut self, child: Self) -> Result<(), SceneError> {
+        if self.children.len() >= MAX_CHILDREN {
+            return Err(SceneError::TooManyChildren(self.id));
+        }
+        self.children.push(child);
+        Ok(())
+    }
+
+    /// Validate depth, fan-out, and total node count.
+    pub fn validate(&self) -> Result<usize, SceneError> {
+        let mut seen = BTreeSet::new();
+        self.validate_at(0, &mut seen)
+    }
+
+    fn validate_at(&self, depth: usize, seen: &mut BTreeSet<NodeId>) -> Result<usize, SceneError> {
+        if depth > MAX_DEPTH {
+            return Err(SceneError::TooDeep(self.id));
+        }
+        if !seen.insert(self.id) {
+            return Err(SceneError::DuplicateNode(self.id));
+        }
+        let contract = self.kind.contract();
+        if self.children.len() > contract.max_children {
+            return Err(SceneError::TooManyChildren(self.id));
+        }
+        if self.state.bits() & !contract.allowed_state != 0 {
+            return Err(SceneError::UnsupportedState(self.id, self.kind));
+        }
+        for key in contract.required_props {
+            if self.props.get(key).is_none() {
+                return Err(SceneError::MissingProperty(self.id, self.kind, key));
+            }
+        }
+        for key in self.props.iter().map(|(key, _)| key.as_str()) {
+            if !contract.allowed_props.contains(&key) {
+                return Err(SceneError::UnknownProperty(
+                    self.id,
+                    self.kind,
+                    key.to_owned(),
+                ));
+            }
+        }
+        let mut total = 1_usize;
+        for child in &self.children {
+            total = total
+                .checked_add(child.validate_at(depth + 1, seen)?)
+                .ok_or(SceneError::TooManyNodes)?;
+            if total > MAX_NODES {
+                return Err(SceneError::TooManyNodes);
+            }
+            if child.id == self.id {
+                return Err(SceneError::SelfParent(self.id));
+            }
+        }
+        Ok(total)
+    }
+
+    /// Walk this node and all descendants in reading order.
+    pub fn walk<'a>(&'a self, output: &mut Vec<&'a Self>) {
+        output.push(self);
+        for child in &self.children {
+            child.walk(output);
+        }
+    }
+}
+
+impl ComponentKind {
+    /// Return the typed semantic contract for this identity.
+    pub fn contract(self) -> ComponentContract {
+        use ComponentKind as K;
+        let (required, state, children) = match self {
+            K::Heading => (&["text"][..], INTERACTION, NO_CHILDREN),
+            K::Text | K::InlineContent => (&["text"][..], INTERACTION, NO_CHILDREN),
+            K::CodeBlock => (&["text", "language"][..], INTERACTION, NO_CHILDREN),
+            K::Button => (&["label", "action"][..], SELECTABLE | STATUS, NO_CHILDREN),
+            K::TextField | K::TextArea | K::NumberField | K::DateTimeField => {
+                (&["value"][..], SELECTABLE | STATUS, NO_CHILDREN)
+            }
+            K::Select | K::MultiSelect => {
+                (&["value", "options"][..], SELECTABLE | STATUS, NO_CHILDREN)
+            }
+            K::Switch | K::Checkbox => (&["value"][..], SELECTABLE | STATUS, NO_CHILDREN),
+            K::Slider => (
+                &["value", "min", "max", "step"][..],
+                SELECTABLE | STATUS,
+                NO_CHILDREN,
+            ),
+            K::Table => (&["columns"][..], SELECTABLE | STATUS, MAX_CHILDREN),
+            K::DatasetChart => (&["source"][..], STATUS, NO_CHILDREN),
+            K::Progress => (&["value", "min", "max"][..], STATUS, NO_CHILDREN),
+            K::Tabs => (&["options"][..], SELECTABLE, MAX_CHILDREN),
+            K::Link => (&["label", "uri"][..], INTERACTION, NO_CHILDREN),
+            K::ImageView => (&["source", "alt"][..], STATUS, NO_CHILDREN),
+            K::AudioPlayer | K::VideoPlayer => (&["source", "duration"][..], STATUS, NO_CHILDREN),
+            K::FileDetails => (&["name", "size"][..], STATUS, NO_CHILDREN),
+            K::NativePortal => (&["status"][..], STATUS | StateSet::EMPTY, NO_CHILDREN),
+            K::Repeater | K::Grid | K::Stack | K::Split => (&[][..], STATUS, MAX_CHILDREN),
+            _ => (&[][..], RUNTIME_ONLY, MAX_CHILDREN),
+        };
+        ComponentContract {
+            family: self.family(),
+            required_props: required,
+            allowed_props: GENERAL_PROPS,
+            allowed_state: state,
+            max_children: children,
+        }
+    }
+}
+
+/// Scene validation failure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SceneError {
+    /// A node exceeded the maximum nesting depth.
+    TooDeep(NodeId),
+    /// A node exceeded the maximum child count.
+    TooManyChildren(NodeId),
+    /// A scene exceeded the maximum total node count.
+    TooManyNodes,
+    /// The same node identity occurred twice.
+    DuplicateNode(NodeId),
+    /// A parent directly contains itself.
+    SelfParent(NodeId),
+    /// Undefined state bits were supplied.
+    InvalidState,
+    /// A state bit is not valid for the component identity.
+    UnsupportedState(NodeId, ComponentKind),
+    /// A required family property is absent.
+    MissingProperty(NodeId, ComponentKind, &'static str),
+    /// A property is not accepted by the component identity.
+    UnknownProperty(NodeId, ComponentKind, String),
+    /// Surface identity was empty or oversized.
+    InvalidSurfaceId,
+}
+
+impl fmt::Display for SceneError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooDeep(id) => write!(f, "scene node {id} is too deep"),
+            Self::TooManyChildren(id) => write!(f, "scene node {id} has too many children"),
+            Self::TooManyNodes => write!(f, "scene has too many nodes"),
+            Self::DuplicateNode(id) => write!(f, "duplicate semantic node identity {id}"),
+            Self::SelfParent(id) => write!(f, "semantic node {id} is its own parent"),
+            Self::InvalidState => write!(f, "undefined semantic state bit"),
+            Self::UnsupportedState(id, kind) => {
+                write!(f, "unsupported state for {kind:?} node {id}")
+            }
+            Self::MissingProperty(id, kind, key) => {
+                write!(f, "{kind:?} node {id} is missing property `{key}`")
+            }
+            Self::UnknownProperty(id, kind, key) => {
+                write!(f, "{kind:?} node {id} does not accept property `{key}`")
+            }
+            Self::InvalidSurfaceId => write!(f, "invalid surface identity"),
+        }
+    }
+}
+
+impl std::error::Error for SceneError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_is_exactly_sixty_two_and_families_are_complete() {
+        assert_eq!(ComponentKind::ALL.len(), 62);
+        let mut names = std::collections::BTreeSet::new();
+        for kind in ComponentKind::ALL {
+            assert!(names.insert(format!("{kind:?}")));
+        }
+        assert_eq!(names.len(), 62);
+        assert_eq!(
+            ComponentKind::ALL
+                .iter()
+                .filter(|kind| kind.family() == "Structure")
+                .count(),
+            12
+        );
+    }
+
+    #[test]
+    fn node_ids_are_stable_and_property_bounds_hold() {
+        assert_eq!(
+            NodeId::from_key("activity/cats"),
+            NodeId::from_key("activity/cats")
+        );
+        let mut values = BTreeMap::new();
+        for i in 0..=MAX_PROPS {
+            values.insert(i.to_string(), PropValue::Bool(true));
+        }
+        assert_eq!(BoundedProps::new(values), Err(PropsError::TooMany));
+    }
+
+    #[test]
+    fn duplicate_ids_are_rejected_before_reconciliation() {
+        let mut root = SemanticNode::new("root", ComponentKind::Region, "Root");
+        root.push(SemanticNode::new("shared", ComponentKind::Group, "One"))
+            .expect("one");
+        root.push(SemanticNode::new("shared", ComponentKind::Group, "Two"))
+            .expect("two");
+        assert!(matches!(root.validate(), Err(SceneError::DuplicateNode(_))));
+    }
+
+    #[test]
+    fn every_identity_rejects_malformed_state() {
+        for kind in ComponentKind::ALL {
+            let mut node = SemanticNode::new("contract", kind, "Contract");
+            let forbidden = (0..12_u32)
+                .map(|bit| 1 << bit)
+                .find(|flag| kind.contract().allowed_state & flag == 0)
+                .expect("every contract excludes at least one state");
+            node.state = StateSet::from_bits(forbidden).expect("valid catalog bit");
+            assert!(matches!(
+                node.validate(),
+                Err(SceneError::UnsupportedState(_, _))
+            ));
+        }
+    }
+
+    #[test]
+    fn serialization_validates_semantic_bounds() {
+        let mut root = SemanticNode::new("root", ComponentKind::Region, "Root");
+        root.push(SemanticNode::new("dupe", ComponentKind::Group, "One"))
+            .expect("child");
+        root.push(SemanticNode::new("dupe", ComponentKind::Group, "Two"))
+            .expect("child");
+        let bytes = serde_json::to_vec(&root).expect("serialize raw semantic shape");
+        assert!(serde_json::from_slice::<SemanticNode>(&bytes).is_err());
+    }
+}

--- a/apps/adaptive-shell/src/fixtures.rs
+++ b/apps/adaptive-shell/src/fixtures.rs
@@ -1,0 +1,1165 @@
+//! Deterministic activity fixtures and headless snapshot generation.
+
+use crate::activity::{
+    Activity, OpaqueOwnerRef, Patch, PatchOutcome, Recipe, RecipeStore, SurfaceId,
+};
+use crate::components::NodeId;
+use crate::components::{ComponentKind, PropValue, SemanticNode, StateSet};
+use crate::input::{Command, ShellState};
+use crate::layout::{LayoutPlan, LayoutPolicy, Rect, SlotKind, Viewport};
+use crate::reconcile::Reconciler;
+use crate::render::{Color, DisplayList, DisplaySummary, DrawCommand};
+use crate::theme::{Density, Theme, ThemeConfig, ThemeName, TokenValue};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Deterministic fixture choices accepted by the binary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FixtureKind {
+    /// Cat-break activity with video, code, and music surfaces.
+    Desktop,
+    /// The same activity under the phone one-surface policy.
+    Phone,
+    /// Complete semantic primitive and state inventory.
+    ThemeLab,
+}
+
+impl FixtureKind {
+    /// Parse a CLI fixture name.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "desktop" => Some(Self::Desktop),
+            "phone" => Some(Self::Phone),
+            "theme-lab" | "theme_lab" => Some(Self::ThemeLab),
+            _ => None,
+        }
+    }
+
+    /// Stable display name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Desktop => "desktop",
+            Self::Phone => "phone",
+            Self::ThemeLab => "theme-lab",
+        }
+    }
+}
+
+impl fmt::Display for FixtureKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Honest state of an external native portal fixture.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NativePortalState {
+    /// No host backend is attached.
+    Unavailable,
+    /// A host backend would be starting.
+    Launching,
+    /// A host backend reports a surface.
+    Ready,
+    /// Surface has input focus.
+    Focused,
+    /// Host backend is stopping.
+    Stopping,
+    /// Host backend failed.
+    Failed,
+}
+
+/// A deterministic monotonic clock used by replayable fixtures.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DeterministicClock {
+    /// Current logical milliseconds.
+    pub now_ms: u64,
+}
+
+impl DeterministicClock {
+    /// Construct a clock at a fixed instant.
+    pub const fn new(now_ms: u64) -> Self {
+        Self { now_ms }
+    }
+
+    /// Read the current instant.
+    pub const fn now(self) -> u64 {
+        self.now_ms
+    }
+
+    /// Advance by a deterministic amount.
+    pub fn advance(&mut self, milliseconds: u64) {
+        self.now_ms = self.now_ms.saturating_add(milliseconds);
+    }
+}
+
+/// A runnable fixture containing the semantic graph and shell state.
+pub struct Fixture {
+    /// Fixture kind.
+    pub kind: FixtureKind,
+    /// Fixed logical viewport.
+    pub viewport: Viewport,
+    /// Current shell state.
+    pub state: ShellState,
+    /// Durable activity identity.
+    pub activity: Activity,
+    /// Durable recipe intent.
+    pub recipe: Recipe,
+    /// Ephemeral materialized surface.
+    pub surface: crate::activity::Surface,
+    /// Resolved Fieldglass theme.
+    pub theme: Theme,
+    /// Deterministic fixture clock.
+    pub clock: DeterministicClock,
+    /// Keyed retained graph.
+    pub reconciler: Reconciler,
+    recipes: RecipeStore,
+}
+
+impl Fixture {
+    /// Build a fixture using the normative default viewport and theme.
+    pub fn new(kind: FixtureKind, config: ThemeConfig) -> Result<Self, FixtureError> {
+        let viewport = match kind {
+            FixtureKind::Desktop | FixtureKind::ThemeLab => Viewport::new(1440, 1000),
+            FixtureKind::Phone => Viewport::new(390, 844),
+        };
+        let root = match kind {
+            FixtureKind::ThemeLab => theme_lab_root(),
+            FixtureKind::Desktop | FixtureKind::Phone => activity_root(),
+        };
+        let recipe = Recipe::new(
+            OpaqueOwnerRef::Principal("fixture-principal".to_owned()),
+            if kind == FixtureKind::ThemeLab {
+                "theme-lab"
+            } else {
+                "cat-break"
+            },
+            "fieldglass",
+            root,
+        )
+        .map_err(FixtureError::Recipe)?;
+        let activity = Activity::new(
+            if kind == FixtureKind::ThemeLab {
+                "theme-lab"
+            } else {
+                "cats"
+            },
+            OpaqueOwnerRef::Principal("fixture-principal".to_owned()),
+            if kind == FixtureKind::ThemeLab {
+                "Theme Lab"
+            } else {
+                "Cat break"
+            },
+            recipe.recipe_id.clone(),
+        );
+        let surface_id = SurfaceId::new("surface-1").map_err(FixtureError::Scene)?;
+        let surface = recipe.surface(surface_id, 1);
+        let theme = Theme::resolve(config);
+        let mut reconciler = Reconciler::new();
+        reconciler
+            .reconcile(&surface.root)
+            .map_err(FixtureError::Scene)?;
+        let mut recipes = RecipeStore::new();
+        recipes
+            .insert(recipe.clone())
+            .map_err(FixtureError::Patch)?;
+        Ok(Self {
+            kind,
+            viewport,
+            state: ShellState {
+                activity_id: activity.activity_id.clone(),
+                theme: config,
+                ..ShellState::default()
+            },
+            activity,
+            recipe,
+            surface,
+            theme,
+            clock: DeterministicClock::new(1_724_847_360_000),
+            reconciler,
+            recipes,
+        })
+    }
+
+    /// Apply a command and rematerialize the surface if its semantic state changed.
+    pub fn apply(&mut self, command: Command) -> Result<bool, FixtureError> {
+        let changed = self.state.apply(command);
+        self.theme = Theme::resolve(self.state.theme);
+        if changed {
+            self.reconciler
+                .reconcile(&self.surface.root)
+                .map_err(FixtureError::Scene)?;
+        }
+        Ok(changed)
+    }
+
+    /// Apply a reviewed recipe patch, then rematerialize the ephemeral surface.
+    pub fn apply_patch(&mut self, patch: &Patch) -> Result<PatchOutcome, FixtureError> {
+        let outcome = self
+            .recipes
+            .apply_patch(patch)
+            .map_err(FixtureError::Patch)?;
+        let (recipe, visual_changed) = match &outcome {
+            PatchOutcome::Applied {
+                recipe,
+                visual_changed,
+            } => (recipe, *visual_changed),
+            PatchOutcome::AlreadyApplied(recipe) => (recipe, false),
+        };
+        self.recipe = recipe.clone();
+        if visual_changed {
+            self.surface = self.recipe.surface(
+                self.surface.surface_id.clone(),
+                self.surface
+                    .incarnation
+                    .checked_add(1)
+                    .ok_or(FixtureError::IncarnationOverflow)?,
+            );
+        }
+        self.activity.current_surface = Some(self.surface.surface_id.clone());
+        self.reconciler
+            .reconcile(&self.surface.root)
+            .map_err(FixtureError::Scene)?;
+        Ok(outcome)
+    }
+
+    /// Resolve the layout plan for the current shell state.
+    pub fn layout(&self) -> LayoutPlan {
+        let surfaces = if self.kind == FixtureKind::ThemeLab {
+            1
+        } else {
+            3
+        };
+        let focused_here = self
+            .state
+            .focus
+            .as_ref()
+            .is_some_and(|focus| focus.surface_id == self.surface.surface_id);
+        LayoutPolicy::resolve(
+            self.viewport,
+            if focused_here {
+                crate::layout::LayoutMode::Focus
+            } else {
+                self.state.layout
+            },
+            self.state.master_percent,
+            surfaces,
+        )
+    }
+
+    /// Produce a backend-neutral display list.
+    pub fn display_list(&self) -> DisplayList {
+        if self.kind == FixtureKind::ThemeLab {
+            theme_lab_display(self.viewport, &self.theme, &self.surface.root)
+        } else {
+            activity_display(
+                self.viewport,
+                &self.theme,
+                &self.state,
+                &self.layout(),
+                &self.surface.root,
+            )
+        }
+    }
+
+    /// Produce deterministic semantic and display summaries.
+    pub fn snapshot(&self) -> Snapshot {
+        let display = self.display_list();
+        let semantic_bytes =
+            serde_json::to_vec(&(&self.activity, &self.recipe, &self.surface, &self.state))
+                .expect("fixture is serializable");
+        let semantic_digest = blake3::hash(&semantic_bytes).to_hex().to_string();
+        Snapshot {
+            fixture: self.kind,
+            viewport: self.viewport,
+            theme: self.theme.config.name,
+            density: self.theme.config.density,
+            scale_percent: self.theme.config.scale.percent(),
+            reduced_motion: self.theme.config.reduced_motion,
+            activity_id: self.activity.activity_id.clone(),
+            recipe_revision: self.recipe.revision,
+            semantic_digest,
+            display: display.summary(),
+            surface_count: if self.kind == FixtureKind::ThemeLab {
+                1
+            } else {
+                3
+            },
+            visible_surface_count: self.layout().slots.len(),
+            native_portal: NativePortalState::Unavailable,
+            clock_ms: self.clock.now(),
+        }
+    }
+
+    /// Return the recipe store used by the fixture.
+    pub fn recipe_store(&self) -> &RecipeStore {
+        &self.recipes
+    }
+}
+
+/// Stable output of one fixture frame.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Snapshot {
+    /// Fixture name.
+    pub fixture: FixtureKind,
+    /// Logical viewport.
+    pub viewport: Viewport,
+    /// Palette.
+    pub theme: ThemeName,
+    /// Density.
+    pub density: Density,
+    /// Text scale percentage.
+    pub scale_percent: u16,
+    /// Reduced-motion setting.
+    pub reduced_motion: bool,
+    /// Activity identity.
+    pub activity_id: String,
+    /// Recipe revision represented.
+    pub recipe_revision: u64,
+    /// Digest of semantic activity/surface state.
+    pub semantic_digest: String,
+    /// Display command summary.
+    pub display: DisplaySummary,
+    /// Number of semantic surfaces in the activity.
+    pub surface_count: usize,
+    /// Number of visible layout slots.
+    pub visible_surface_count: usize,
+    /// Honest native portal state.
+    pub native_portal: NativePortalState,
+    /// Fixed logical timestamp.
+    pub clock_ms: u64,
+}
+
+/// Fixture construction or update failure.
+#[derive(Debug)]
+pub enum FixtureError {
+    /// Semantic scene validation failed.
+    Scene(crate::components::SceneError),
+    /// Recipe operation failed.
+    Patch(crate::activity::PatchError),
+    /// Recipe construction or invariant validation failed.
+    Recipe(crate::activity::RecipeValidationError),
+    /// Surface incarnation exhausted u64.
+    IncarnationOverflow,
+}
+
+impl fmt::Display for FixtureError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Scene(error) => error.fmt(f),
+            Self::Patch(error) => error.fmt(f),
+            Self::Recipe(error) => error.fmt(f),
+            Self::IncarnationOverflow => write!(f, "surface incarnation overflow"),
+        }
+    }
+}
+
+impl std::error::Error for FixtureError {}
+
+fn prop(node: &mut SemanticNode, key: &str, value: PropValue) {
+    node.props = node
+        .props
+        .clone()
+        .with(key.to_owned(), value)
+        .expect("fixture property bounds");
+}
+
+fn child(parent: &mut SemanticNode, node: SemanticNode) {
+    parent.push(node).expect("fixture child bound");
+}
+
+fn activity_root() -> SemanticNode {
+    let mut root = SemanticNode::new(
+        "activity/cat-break/root",
+        ComponentKind::Region,
+        "Cat break",
+    );
+    prop(&mut root, "title", PropValue::Text("Cat break".to_owned()));
+
+    let mut cat_surface = SemanticNode::new(
+        "activity/cat-break/cat-surface",
+        ComponentKind::Card,
+        "Cat video feed",
+    );
+    prop(
+        &mut cat_surface,
+        "subtitle",
+        PropValue::Text("One feed, tuned for you".to_owned()),
+    );
+    let mut video = SemanticNode::new(
+        "activity/cat-break/cat-surface/video",
+        ComponentKind::VideoPlayer,
+        "Miso discovers the warm laundry",
+    );
+    video.state = StateSet::empty().with(StateSet::LOADING, true);
+    prop(
+        &mut video,
+        "title",
+        PropValue::Text("Miso discovers the warm laundry".to_owned()),
+    );
+    prop(&mut video, "duration", PropValue::Text("2:14".to_owned()));
+    prop(
+        &mut video,
+        "source",
+        PropValue::Text("fixture://miso".to_owned()),
+    );
+    child(&mut cat_surface, video);
+    let mut feed = SemanticNode::new(
+        "activity/cat-break/cat-surface/feed",
+        ComponentKind::Repeater,
+        "Cat feed",
+    );
+    for (key, title) in [
+        ("yt", "The box was occupied"),
+        ("peer", "Tiny apartment lion"),
+        ("vid", "Rainy-window cat TV"),
+    ] {
+        let mut item = SemanticNode::new(
+            &format!("activity/cat-break/feed/{key}"),
+            ComponentKind::MediaEmbed,
+            title,
+        );
+        prop(&mut item, "source", PropValue::Text(key.to_owned()));
+        child(&mut feed, item);
+    }
+    child(&mut cat_surface, feed);
+    child(&mut root, cat_surface);
+
+    let mut code = SemanticNode::new(
+        "activity/cat-break/code",
+        ComponentKind::CodeBlock,
+        "surface-model.rs",
+    );
+    prop(&mut code, "language", PropValue::Text("rust".to_owned()));
+    prop(
+        &mut code,
+        "text",
+        PropValue::Text("let activity = open_activity(\"cat-break\");".to_owned()),
+    );
+    child(&mut root, code);
+
+    let mut sound = SemanticNode::new(
+        "activity/cat-break/sound",
+        ComponentKind::AudioPlayer,
+        "Light through the blinds",
+    );
+    sound.state = StateSet::empty().with(StateSet::SUCCESS, true);
+    prop(
+        &mut sound,
+        "source",
+        PropValue::Text("fixture://light".to_owned()),
+    );
+    prop(&mut sound, "duration", PropValue::Text("3:04".to_owned()));
+    child(&mut root, sound);
+
+    let mut portal = SemanticNode::new(
+        "activity/cat-break/native/steam",
+        ComponentKind::NativePortal,
+        "Native application",
+    );
+    portal.state = StateSet::empty().with(StateSet::EMPTY, true);
+    prop(
+        &mut portal,
+        "status",
+        PropValue::Text("Unavailable in fixture".to_owned()),
+    );
+    child(&mut root, portal);
+    root
+}
+
+fn theme_lab_root() -> SemanticNode {
+    let mut root = SemanticNode::new("theme-lab/root", ComponentKind::Region, "Theme Lab");
+    let mut grid = SemanticNode::new("theme-lab/catalog", ComponentKind::Grid, "Semantic catalog");
+    for kind in ComponentKind::ALL {
+        let mut sample =
+            SemanticNode::new(&format!("theme-lab/{kind:?}"), kind, &format!("{kind:?}"));
+        for key in kind.contract().required_props {
+            let value = if matches!(*key, "min" | "max" | "step" | "columns") {
+                PropValue::Number(1.0)
+            } else {
+                PropValue::Text(format!("{key} sample"))
+            };
+            prop(&mut sample, key, value);
+        }
+        sample.state = match kind {
+            ComponentKind::Button | ComponentKind::TextField | ComponentKind::Select => {
+                StateSet::empty().with(StateSet::FOCUS, true)
+            }
+            ComponentKind::NativePortal => StateSet::empty().with(StateSet::EMPTY, true),
+            _ => StateSet::empty(),
+        };
+        child(&mut grid, sample);
+    }
+    child(&mut root, grid);
+    root
+}
+
+fn semantic_display(
+    viewport: Viewport,
+    theme: &Theme,
+    state: &ShellState,
+    root: &SemanticNode,
+    list: &mut DisplayList,
+) {
+    let text = token_color(theme, "aos.color.text", [244, 242, 247, 255]);
+    let focus = token_color(theme, "aos.color.focus", [111, 180, 255, 255]);
+    let rect = Rect {
+        x: 12,
+        y: 54,
+        width: viewport.width.saturating_sub(24),
+        height: viewport.height.saturating_sub(66),
+    };
+    let focus_id = state.focus.as_ref().and_then(|target| target.node_id);
+    render_semantic_node(list, root, theme, rect, focus_id, 0, text, focus);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_semantic_node(
+    list: &mut DisplayList,
+    node: &SemanticNode,
+    theme: &Theme,
+    rect: Rect,
+    focus: Option<NodeId>,
+    depth: usize,
+    text: Color,
+    focus_color: Color,
+) {
+    if Some(node.id) == focus {
+        list.push(DrawCommand::StrokeRoundRect {
+            rect,
+            radius: 3,
+            color: focus_color,
+            width: 3,
+        });
+    }
+    if node.state.bits() != 0 {
+        list.push(DrawCommand::StrokeRoundRect {
+            rect,
+            radius: 4,
+            color: token_color(theme, "aos.color.accent", [157, 122, 255, 255]),
+            width: 2,
+        });
+    }
+    if depth > 0 {
+        list.push(DrawCommand::StrokeRoundRect {
+            rect,
+            radius: 3,
+            color: token_color(theme, "aos.color.line", [61, 62, 71, 255]),
+            width: 1,
+        });
+    }
+    list.push(DrawCommand::Text {
+        rect: Rect {
+            x: rect.x + 8,
+            y: rect.y + 4,
+            width: rect.width.saturating_sub(16),
+            height: 18.min(rect.height),
+        },
+        content: node.accessibility.name.clone(),
+        role: "control".to_owned(),
+        color: text,
+    });
+    if node.children.is_empty() || rect.height < 36 {
+        return;
+    }
+    let gap = u32::from(token_px(theme, "aos.space.2", 7));
+    let available = rect
+        .height
+        .saturating_sub(22 + gap * (node.children.len() as u32 - 1));
+    let child_height = available / node.children.len() as u32;
+    if child_height < 18 {
+        return;
+    }
+    let mut y = rect.y + 22;
+    for child in &node.children {
+        render_semantic_node(
+            list,
+            child,
+            theme,
+            Rect {
+                x: rect.x + 8,
+                y,
+                width: rect.width.saturating_sub(16),
+                height: child_height,
+            },
+            focus,
+            depth + 1,
+            text,
+            focus_color,
+        );
+        y = y.saturating_add(child_height + gap);
+    }
+}
+
+fn token_color(theme: &Theme, role: &str, fallback: Color) -> Color {
+    match theme.tokens.get(role) {
+        Some(TokenValue::Color(color)) => *color,
+        _ => fallback,
+    }
+}
+
+fn token_px(theme: &Theme, role: &str, fallback: u16) -> u16 {
+    match theme.tokens.get(role) {
+        Some(TokenValue::Pixels(px)) => *px,
+        _ => fallback,
+    }
+}
+
+fn activity_display(
+    viewport: Viewport,
+    theme: &Theme,
+    state: &ShellState,
+    plan: &LayoutPlan,
+    root: &SemanticNode,
+) -> DisplayList {
+    let canvas = token_color(theme, "aos.color.canvas", [12, 14, 17, 255]);
+    let raised = token_color(theme, "aos.color.canvas-raised", [23, 25, 30, 255]);
+    let layer = token_color(theme, "aos.color.layer.1", [31, 33, 40, 255]);
+    let text = token_color(theme, "aos.color.text", [244, 242, 247, 255]);
+    let soft = token_color(theme, "aos.color.text-soft", [194, 193, 204, 255]);
+    let dim = token_color(theme, "aos.color.text-dim", [131, 130, 143, 255]);
+    let line = token_color(theme, "aos.color.line", [61, 62, 71, 255]);
+    let accent = token_color(theme, "aos.color.accent", [157, 122, 255, 255]);
+    let focus = token_color(theme, "aos.color.focus", [111, 180, 255, 255]);
+    let radius_window = token_px(theme, "aos.radius.window", 15);
+    let radius_control = token_px(theme, "aos.radius.control", 9);
+    let mut list = DisplayList::new((viewport.width, viewport.height));
+    list.push(DrawCommand::FillRoundRect {
+        rect: Rect {
+            x: 0,
+            y: 0,
+            width: viewport.width,
+            height: viewport.height,
+        },
+        radius: 0,
+        color: canvas,
+    });
+    list.push(DrawCommand::FillRoundRect {
+        rect: Rect {
+            x: 0,
+            y: 0,
+            width: viewport.width,
+            height: if plan.phone { 48 } else { 44 },
+        },
+        radius: 0,
+        color: raised,
+    });
+    list.push(DrawCommand::Icon {
+        rect: Rect {
+            x: 12,
+            y: 12,
+            width: 20,
+            height: 20,
+        },
+        name: "astrid-mark".to_owned(),
+        color: accent,
+    });
+    list.push(DrawCommand::Text {
+        rect: Rect {
+            x: 40,
+            y: 10,
+            width: 130,
+            height: 24,
+        },
+        content: "Astrid".to_owned(),
+        role: "control".to_owned(),
+        color: text,
+    });
+    list.push(DrawCommand::Text {
+        rect: Rect {
+            x: viewport.width / 2 - 110,
+            y: 10,
+            width: 220,
+            height: 24,
+        },
+        content: "Fri, Aug 28 · 09:16 AM".to_owned(),
+        role: "control".to_owned(),
+        color: soft,
+    });
+    for slot in &plan.slots {
+        frame(&mut list, slot.rect, radius_window, layer, line);
+        let title = match slot.kind {
+            SlotKind::Master => "Cat break",
+            SlotKind::Secondary if slot.surface_index == 1 => "Build",
+            SlotKind::Secondary => "Sound",
+            SlotKind::Phone => "Cat break",
+        };
+        list.push(DrawCommand::Text {
+            rect: Rect {
+                x: slot.rect.x + 14,
+                y: slot.rect.y + 12,
+                width: slot.rect.width.saturating_sub(28),
+                height: 22,
+            },
+            content: title.to_owned(),
+            role: "title".to_owned(),
+            color: text,
+        });
+        if slot.kind == SlotKind::Master || slot.kind == SlotKind::Phone {
+            let body = Rect {
+                x: slot.rect.x + 1,
+                y: slot.rect.y + 42,
+                width: slot.rect.width.saturating_sub(2),
+                height: slot.rect.height.saturating_sub(43),
+            };
+            list.push(DrawCommand::FillRoundRect {
+                rect: body,
+                radius: radius_control,
+                color: [53, 54, 78, 255],
+            });
+            list.push(DrawCommand::Icon {
+                rect: Rect {
+                    x: body.x + body.width / 2 - 84,
+                    y: body.y + body.height / 2 - 102,
+                    width: 168,
+                    height: 168,
+                },
+                name: "cat-miso".to_owned(),
+                color: [224, 191, 165, 255],
+            });
+            list.push(DrawCommand::Text {
+                rect: Rect {
+                    x: body.x + 14,
+                    y: body.y + body.height.saturating_sub(74),
+                    width: body.width.saturating_sub(28),
+                    height: 28,
+                },
+                content: "Miso discovers the warm laundry".to_owned(),
+                role: "display".to_owned(),
+                color: text,
+            });
+            list.push(DrawCommand::Line {
+                from: (body.x + 16, body.y + body.height.saturating_sub(32)),
+                to: (
+                    body.x + body.width.saturating_sub(16),
+                    body.y + body.height.saturating_sub(32),
+                ),
+                color: focus,
+                width: 3,
+            });
+        } else if slot.surface_index == 1 {
+            list.push(DrawCommand::Text {
+                rect: Rect {
+                    x: slot.rect.x + 18,
+                    y: slot.rect.y + 62,
+                    width: slot.rect.width.saturating_sub(36),
+                    height: 150,
+                },
+                content: "let activity = open_activity(\"cat-break\");\n\nactivity.propose(Patch::Refresh);".to_owned(),
+                role: "body".to_owned(),
+                color: soft,
+            });
+        } else {
+            list.push(DrawCommand::Text {
+                rect: Rect {
+                    x: slot.rect.x + 20,
+                    y: slot.rect.y + slot.rect.height / 2,
+                    width: slot.rect.width.saturating_sub(40),
+                    height: 30,
+                },
+                content: "Light through the blinds".to_owned(),
+                role: "title".to_owned(),
+                color: text,
+            });
+            list.push(DrawCommand::Line {
+                from: (slot.rect.x + 20, slot.rect.y + slot.rect.height / 2 + 40),
+                to: (
+                    slot.rect.x + slot.rect.width.saturating_sub(20),
+                    slot.rect.y + slot.rect.height / 2 + 40,
+                ),
+                color: accent,
+                width: 3,
+            });
+        }
+    }
+    if plan.phone {
+        list.push(DrawCommand::FillRoundRect {
+            rect: Rect {
+                x: 0,
+                y: viewport.height.saturating_sub(66),
+                width: viewport.width,
+                height: 66,
+            },
+            radius: 0,
+            color: raised,
+        });
+        for (index, label) in ["Pause", "Make", "Build", "Play", "Go"]
+            .into_iter()
+            .enumerate()
+        {
+            let width = viewport.width / 5;
+            list.push(DrawCommand::Text {
+                rect: Rect {
+                    x: index as u32 * width,
+                    y: viewport.height.saturating_sub(48),
+                    width,
+                    height: 28,
+                },
+                content: label.to_owned(),
+                role: "caption".to_owned(),
+                color: if index == 0 { text } else { dim },
+            });
+        }
+    }
+    if state.launcher_open {
+        list.push(DrawCommand::StrokeRoundRect {
+            rect: Rect {
+                x: viewport.width / 2 - 340,
+                y: viewport.height / 2 - 180,
+                width: 680,
+                height: 360,
+            },
+            radius: radius_window,
+            color: focus,
+            width: 2,
+        });
+    }
+    // DisplayList commands are painter-ordered: retain the semantic surface
+    // above every opaque canvas and chrome fill so its root remains visible.
+    semantic_display(viewport, theme, state, root, &mut list);
+    list
+}
+
+fn theme_lab_display(viewport: Viewport, theme: &Theme, root: &SemanticNode) -> DisplayList {
+    let canvas = token_color(theme, "aos.color.canvas", [12, 14, 17, 255]);
+    let raised = token_color(theme, "aos.color.canvas-raised", [23, 25, 30, 255]);
+    let layer = token_color(theme, "aos.color.layer.1", [31, 33, 40, 255]);
+    let text = token_color(theme, "aos.color.text", [244, 242, 247, 255]);
+    let soft = token_color(theme, "aos.color.text-soft", [194, 193, 204, 255]);
+    let line = token_color(theme, "aos.color.line", [61, 62, 71, 255]);
+    let accent = token_color(theme, "aos.color.accent", [157, 122, 255, 255]);
+    let mut list = DisplayList::new((viewport.width, viewport.height));
+    list.push(DrawCommand::FillRoundRect {
+        rect: Rect {
+            x: 0,
+            y: 0,
+            width: viewport.width,
+            height: viewport.height,
+        },
+        radius: 0,
+        color: canvas,
+    });
+    list.push(DrawCommand::FillRoundRect {
+        rect: Rect {
+            x: 0,
+            y: 0,
+            width: viewport.width,
+            height: 54,
+        },
+        radius: 0,
+        color: raised,
+    });
+    list.push(DrawCommand::Text {
+        rect: Rect {
+            x: 54,
+            y: 11,
+            width: 300,
+            height: 30,
+        },
+        content: "Theme Lab".to_owned(),
+        role: "title".to_owned(),
+        color: text,
+    });
+    list.push(DrawCommand::Text {
+        rect: Rect {
+            x: 54,
+            y: 34,
+            width: 520,
+            height: 18,
+        },
+        content: "The complete semantic component contract · fixtures only".to_owned(),
+        role: "caption".to_owned(),
+        color: soft,
+    });
+    let sidebar_width = 220;
+    list.push(DrawCommand::FillRoundRect {
+        rect: Rect {
+            x: 0,
+            y: 54,
+            width: sidebar_width,
+            height: viewport.height.saturating_sub(54),
+        },
+        radius: 0,
+        color: raised,
+    });
+    for (index, family) in [
+        "Structure",
+        "Content",
+        "Input",
+        "Data",
+        "Navigation",
+        "Feedback",
+        "Governed",
+        "Media",
+        "Canvas",
+        "Terminal",
+        "Native",
+        "Tokens",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        list.push(DrawCommand::Text {
+            rect: Rect {
+                x: 20,
+                y: 72 + index as u32 * 38,
+                width: 170,
+                height: 24,
+            },
+            content: family.to_owned(),
+            role: "control".to_owned(),
+            color: if index == 0 { text } else { soft },
+        });
+    }
+    let content_x = sidebar_width + 28;
+    let card_width = (viewport.width - content_x - 28 - 16) / 2;
+    for (index, kind) in ComponentKind::ALL.into_iter().enumerate() {
+        let column = index % 2;
+        let row = index / 2;
+        let x = content_x + column as u32 * (card_width + 16);
+        let y = 76 + row as u32 * 98;
+        let rect = Rect {
+            x,
+            y,
+            width: card_width,
+            height: 84,
+        };
+        frame(&mut list, rect, 9, layer, line);
+        list.push(DrawCommand::Text {
+            rect: Rect {
+                x: x + 12,
+                y: y + 10,
+                width: card_width.saturating_sub(24),
+                height: 22,
+            },
+            content: format!("{kind:?}"),
+            role: "control".to_owned(),
+            color: text,
+        });
+        list.push(DrawCommand::Text {
+            rect: Rect {
+                x: x + 12,
+                y: y + 38,
+                width: card_width.saturating_sub(24),
+                height: 18,
+            },
+            content: format!("{} · default · focus · disabled", kind.family()),
+            role: "caption".to_owned(),
+            color: soft,
+        });
+        list.push(DrawCommand::Line {
+            from: (x + 12, y + 70),
+            to: (x + card_width.saturating_sub(12), y + 70),
+            color: if kind == ComponentKind::NativePortal {
+                token_color(theme, "aos.color.warning", [242, 181, 89, 255])
+            } else {
+                accent
+            },
+            width: 2,
+        });
+    }
+    // Keep the retained semantic layer last in painter order.  The canvas,
+    // sidebar, and card fills must never overdraw it.
+    semantic_display(viewport, theme, &ShellState::default(), root, &mut list);
+    list
+}
+
+fn frame(list: &mut DisplayList, rect: Rect, radius: u16, fill: Color, line: Color) {
+    list.push(DrawCommand::FillRoundRect {
+        rect,
+        radius,
+        color: fill,
+    });
+    list.push(DrawCommand::StrokeRoundRect {
+        rect,
+        radius,
+        color: line,
+        width: 1,
+    });
+}
+
+/// Build a fixture with default settings and return its snapshot.
+pub fn render_fixture(kind: FixtureKind, config: ThemeConfig) -> Result<Snapshot, FixtureError> {
+    Fixture::new(kind, config).map(|fixture| fixture.snapshot())
+}
+
+/// Verify that building the same fixture twice yields the same semantic and display digests.
+pub fn replay_digest(kind: FixtureKind, config: ThemeConfig) -> Result<bool, FixtureError> {
+    let left = Fixture::new(kind, config)?;
+    let right = Fixture::new(kind, config)?;
+    Ok(left.snapshot() == right.snapshot())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme::ThemeConfig;
+
+    fn reviewed_patch(
+        fixture: &Fixture,
+        id: &str,
+        operations: Vec<crate::activity::PatchOp>,
+    ) -> Patch {
+        Patch {
+            schema: "aos.patch@1".to_owned(),
+            owner_ref: fixture.activity.owner_ref.clone(),
+            acting_principal: crate::activity::OpaquePrincipalRef::Agent("agent".to_owned()),
+            proposal_id: "proposal".to_owned(),
+            review: crate::activity::ReviewAcceptance {
+                reviewer: crate::activity::OpaquePrincipalRef::User("reviewer".to_owned()),
+                receipt: "review".to_owned(),
+            },
+            patch_id: id.to_owned(),
+            recipe_id: fixture.recipe.recipe_id.clone(),
+            base_revision: fixture.recipe.revision,
+            base_digest: fixture.recipe.digest.clone(),
+            summary: "reviewed semantic change".to_owned(),
+            operations,
+        }
+    }
+
+    #[test]
+    fn snapshots_are_replayable() {
+        assert!(replay_digest(FixtureKind::Desktop, ThemeConfig::default()).expect("fixture"));
+        assert!(replay_digest(FixtureKind::Phone, ThemeConfig::default()).expect("fixture"));
+        assert!(replay_digest(FixtureKind::ThemeLab, ThemeConfig::default()).expect("fixture"));
+    }
+
+    #[test]
+    fn phone_has_one_visible_surface_and_theme_lab_covers_catalog() {
+        let phone = Fixture::new(FixtureKind::Phone, ThemeConfig::default()).expect("fixture");
+        assert_eq!(phone.snapshot().visible_surface_count, 1);
+        let lab = Fixture::new(FixtureKind::ThemeLab, ThemeConfig::default()).expect("fixture");
+        assert_eq!(lab.surface.root.children[0].children.len(), 62);
+    }
+
+    #[test]
+    fn accepted_patch_rematerializes_surface_and_advances_incarnation() {
+        let mut fixture =
+            Fixture::new(FixtureKind::Desktop, ThemeConfig::default()).expect("fixture");
+        let root_id = fixture.recipe.root.id;
+        let patch = Patch {
+            schema: "aos.patch@1".to_owned(),
+            owner_ref: fixture.activity.owner_ref.clone(),
+            acting_principal: crate::activity::OpaquePrincipalRef::Agent(
+                "fixture-agent".to_owned(),
+            ),
+            proposal_id: "fixture-proposal".to_owned(),
+            review: crate::activity::ReviewAcceptance {
+                reviewer: crate::activity::OpaquePrincipalRef::User("fixture-reviewer".to_owned()),
+                receipt: "fixture-review".to_owned(),
+            },
+            patch_id: "fixture-patch".to_owned(),
+            recipe_id: fixture.recipe.recipe_id.clone(),
+            base_revision: fixture.recipe.revision,
+            base_digest: fixture.recipe.digest.clone(),
+            summary: "focus the activity".to_owned(),
+            operations: vec![crate::activity::PatchOp::SetState {
+                node_id: root_id,
+                state: StateSet::empty().with(StateSet::FOCUS, true),
+            }],
+        };
+        let outcome = fixture.apply_patch(&patch).expect("accepted");
+        assert!(matches!(
+            outcome,
+            PatchOutcome::Applied {
+                visual_changed: true,
+                ..
+            }
+        ));
+        assert_eq!(fixture.recipe.revision, 2);
+        assert_eq!(fixture.surface.incarnation, 2);
+        assert!(fixture.activity.current_surface.is_some());
+    }
+
+    #[test]
+    fn visual_patch_changes_display_and_nonvisual_patch_does_not() {
+        let mut fixture = Fixture::new(FixtureKind::Desktop, ThemeConfig::default()).unwrap();
+        let before = fixture.snapshot().display.digest;
+        let visual = reviewed_patch(
+            &fixture,
+            "visual",
+            vec![crate::activity::PatchOp::SetState {
+                node_id: fixture.recipe.root.id,
+                state: StateSet::empty().with(StateSet::FOCUS, true),
+            }],
+        );
+        assert!(matches!(
+            fixture.apply_patch(&visual).unwrap(),
+            PatchOutcome::Applied {
+                visual_changed: true,
+                ..
+            }
+        ));
+        assert_ne!(before, fixture.snapshot().display.digest);
+        assert_eq!(fixture.surface.incarnation, 2);
+
+        let mut fixture = Fixture::new(FixtureKind::Desktop, ThemeConfig::default()).unwrap();
+        let before = fixture.snapshot().display.digest;
+        let nonvisual = reviewed_patch(
+            &fixture,
+            "nonvisual",
+            vec![crate::activity::PatchOp::SetRecipeMetadata {
+                key: "restore_hint".to_owned(),
+                value: PropValue::Text("anchor".to_owned()),
+            }],
+        );
+        assert!(matches!(
+            fixture.apply_patch(&nonvisual).unwrap(),
+            PatchOutcome::Applied {
+                visual_changed: false,
+                ..
+            }
+        ));
+        assert_eq!(before, fixture.snapshot().display.digest);
+        assert_eq!(fixture.recipe.revision, 2);
+        assert_eq!(fixture.surface.incarnation, 1);
+    }
+
+    #[test]
+    fn opaque_fill_cannot_cover_semantic_sample_pixel() {
+        for kind in [FixtureKind::Desktop, FixtureKind::ThemeLab] {
+            let fixture = Fixture::new(kind, ThemeConfig::default()).expect("fixture");
+            let root_name = fixture.surface.root.accessibility.name.as_str();
+            let list = fixture.display_list();
+            let (semantic_index, semantic_rect) = list
+                .commands
+                .iter()
+                .enumerate()
+                .find_map(|(index, command)| match command {
+                    DrawCommand::Text {
+                        rect,
+                        content,
+                        role,
+                        ..
+                    } if role == "control" && content == root_name => Some((index, *rect)),
+                    _ => None,
+                })
+                .expect("root semantic text command");
+            let sample = (
+                semantic_rect.x + semantic_rect.width / 2,
+                semantic_rect.y + semantic_rect.height / 2,
+            );
+            let later_opaque_fill = list.commands.iter().enumerate().any(|(index, command)| {
+                if index <= semantic_index {
+                    return false;
+                }
+                match command {
+                    DrawCommand::FillRoundRect { rect, color, .. } => {
+                        color[3] == u8::MAX
+                            && sample.0 >= rect.x
+                            && sample.1 >= rect.y
+                            && sample.0 < rect.x.saturating_add(rect.width)
+                            && sample.1 < rect.y.saturating_add(rect.height)
+                    }
+                    _ => false,
+                }
+            });
+            assert!(
+                !later_opaque_fill,
+                "{kind} has an opaque fill after the semantic root sample pixel"
+            );
+        }
+    }
+}

--- a/apps/adaptive-shell/src/input.rs
+++ b/apps/adaptive-shell/src/input.rs
@@ -1,0 +1,173 @@
+//! Shell commands, transient state, and keyboard/pointer parity.
+
+use crate::activity::SurfaceId;
+use crate::components::NodeId;
+use crate::layout::LayoutMode;
+use crate::theme::{Density, TextScale, ThemeConfig, ThemeName};
+use serde::{Deserialize, Serialize};
+
+/// Commands available from a pointer, keyboard, or launcher result.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Command {
+    /// Open/close the launcher (Command/Super-Space or click).
+    ToggleLauncher,
+    /// Cycle master, grid, and single layouts.
+    CycleLayout,
+    /// Enter focus mode for a surface.
+    FocusSurface(SurfaceId),
+    /// Focus a stable semantic node inside a surface.
+    FocusNode {
+        /// Stable surface target.
+        surface_id: SurfaceId,
+        /// Stable semantic node target.
+        node_id: NodeId,
+    },
+    /// Restore the layout before focus mode.
+    RestoreLayout,
+    /// Open/close notifications.
+    ToggleNotifications,
+    /// Open/close the Theme Lab.
+    ToggleThemeLab,
+    /// Switch the current activity.
+    SelectActivity(String),
+    /// Set the palette.
+    SetTheme(ThemeName),
+    /// Set spacing/control density.
+    SetDensity(Density),
+    /// Set text scale.
+    SetScale(TextScale),
+    /// Toggle reduced motion.
+    SetReducedMotion(bool),
+    /// Move the desktop splitter by a percentage-point delta.
+    ResizeMaster(i8),
+}
+
+/// User-visible state for the shell fixture.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ShellState {
+    /// Selected activity id.
+    pub activity_id: String,
+    /// Current layout mode.
+    pub layout: LayoutMode,
+    /// Layout mode to restore after focus.
+    pub previous_layout: Option<LayoutMode>,
+    /// Stable surface/node focus target.
+    pub focus: Option<FocusTarget>,
+    /// Launcher visibility.
+    pub launcher_open: bool,
+    /// Notification panel visibility.
+    pub notifications_open: bool,
+    /// Theme Lab visibility.
+    pub theme_lab_open: bool,
+    /// Desktop master-column percentage.
+    pub master_percent: u8,
+    /// Theme and accessibility settings.
+    pub theme: ThemeConfig,
+}
+
+/// Typed focus target used by layout, reconciliation, and display.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct FocusTarget {
+    /// Stable surface target.
+    pub surface_id: SurfaceId,
+    /// Optional stable semantic node target.
+    pub node_id: Option<NodeId>,
+}
+
+impl Default for ShellState {
+    fn default() -> Self {
+        Self {
+            activity_id: "cats".to_owned(),
+            layout: LayoutMode::Master,
+            previous_layout: None,
+            focus: None,
+            launcher_open: false,
+            notifications_open: false,
+            theme_lab_open: false,
+            master_percent: crate::layout::MASTER_DEFAULT_PERCENT,
+            theme: ThemeConfig::default(),
+        }
+    }
+}
+
+impl ShellState {
+    /// Apply a command and return whether visible state changed.
+    pub fn apply(&mut self, command: Command) -> bool {
+        let before = self.clone();
+        match command {
+            Command::ToggleLauncher => self.launcher_open = !self.launcher_open,
+            Command::CycleLayout => {
+                self.layout = match self.layout {
+                    LayoutMode::Master => LayoutMode::Grid,
+                    LayoutMode::Grid => LayoutMode::Single,
+                    LayoutMode::Single | LayoutMode::Focus => LayoutMode::Master,
+                };
+                if self.layout != LayoutMode::Focus {
+                    self.previous_layout = None;
+                }
+            }
+            Command::FocusSurface(surface_id) => {
+                self.previous_layout = Some(self.layout);
+                self.layout = LayoutMode::Focus;
+                self.focus = Some(FocusTarget {
+                    surface_id,
+                    node_id: None,
+                });
+            }
+            Command::FocusNode {
+                surface_id,
+                node_id,
+            } => {
+                self.previous_layout = Some(self.layout);
+                self.layout = LayoutMode::Focus;
+                self.focus = Some(FocusTarget {
+                    surface_id,
+                    node_id: Some(node_id),
+                });
+            }
+            Command::RestoreLayout => {
+                if let Some(previous) = self.previous_layout.take() {
+                    self.layout = previous;
+                } else {
+                    self.layout = LayoutMode::Master;
+                }
+            }
+            Command::ToggleNotifications => self.notifications_open = !self.notifications_open,
+            Command::ToggleThemeLab => self.theme_lab_open = !self.theme_lab_open,
+            Command::SelectActivity(activity) => self.activity_id = activity,
+            Command::SetTheme(name) => self.theme.name = name,
+            Command::SetDensity(density) => self.theme.density = density,
+            Command::SetScale(scale) => self.theme.scale = scale,
+            Command::SetReducedMotion(value) => self.theme.reduced_motion = value,
+            Command::ResizeMaster(delta) => {
+                let current = i16::from(self.master_percent);
+                self.master_percent = (current + i16::from(delta)).clamp(
+                    i16::from(crate::layout::MASTER_MIN_PERCENT),
+                    i16::from(crate::layout::MASTER_MAX_PERCENT),
+                ) as u8;
+            }
+        }
+        *self != before
+    }
+
+    /// Resolve the current theme.
+    pub fn resolved_theme(&self) -> crate::theme::Theme {
+        crate::theme::Theme::resolve(self.theme)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn focus_restores_layout_and_resize_clamps() {
+        let mut state = ShellState::default();
+        assert!(state.apply(Command::FocusSurface(SurfaceId::new("surface-1").unwrap())));
+        assert_eq!(state.layout, LayoutMode::Focus);
+        assert!(state.apply(Command::RestoreLayout));
+        assert_eq!(state.layout, LayoutMode::Master);
+        assert!(state.apply(Command::ResizeMaster(100)));
+        assert_eq!(state.master_percent, crate::layout::MASTER_MAX_PERCENT);
+    }
+}

--- a/apps/adaptive-shell/src/layout.rs
+++ b/apps/adaptive-shell/src/layout.rs
@@ -1,0 +1,283 @@
+//! Responsive desktop and phone layout policy.
+
+use serde::{Deserialize, Serialize};
+
+/// Width at which the desktop shell becomes a phone shell.
+pub const PHONE_BREAKPOINT: u32 = 760;
+/// Desktop top-bar height.
+pub const DESKTOP_TOP_BAR: u32 = 44;
+/// Phone activity strip height.
+pub const PHONE_ACTIVITY_STRIP: u32 = 66;
+/// Minimum and maximum master-column percentages.
+pub const MASTER_MIN_PERCENT: u8 = 38;
+/// Maximum master-column percentage.
+pub const MASTER_MAX_PERCENT: u8 = 76;
+/// Default master-column percentage.
+pub const MASTER_DEFAULT_PERCENT: u8 = 62;
+
+/// Workspace layout modes.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LayoutMode {
+    /// One master plus up to two stacked secondary surfaces.
+    #[default]
+    Master,
+    /// Two equal surfaces.
+    Grid,
+    /// One surface fills the workspace.
+    Single,
+    /// One selected surface fills the workspace temporarily.
+    Focus,
+}
+
+/// Logical viewport dimensions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Viewport {
+    /// Width in logical pixels.
+    pub width: u32,
+    /// Height in logical pixels.
+    pub height: u32,
+}
+
+impl Viewport {
+    /// Construct a viewport.
+    pub const fn new(width: u32, height: u32) -> Self {
+        Self { width, height }
+    }
+
+    /// Whether phone mode applies.
+    pub const fn is_phone(self) -> bool {
+        self.width < PHONE_BREAKPOINT
+    }
+}
+
+/// Integer rectangle used by the backend-neutral display list.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Rect {
+    /// Left coordinate.
+    pub x: u32,
+    /// Top coordinate.
+    pub y: u32,
+    /// Width.
+    pub width: u32,
+    /// Height.
+    pub height: u32,
+}
+
+/// Semantic role of a laid-out slot.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SlotKind {
+    /// Primary activity surface.
+    Master,
+    /// Secondary activity surface.
+    Secondary,
+    /// The sole phone surface.
+    Phone,
+}
+
+/// One visible surface slot.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SurfaceSlot {
+    /// Surface index in activity order.
+    pub surface_index: usize,
+    /// Slot role.
+    pub kind: SlotKind,
+    /// Pixel rectangle.
+    pub rect: Rect,
+}
+
+/// Result of applying responsive layout policy.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LayoutPlan {
+    /// Input viewport.
+    pub viewport: Viewport,
+    /// Resolved mode (phone always reports single visible surface).
+    pub mode: LayoutMode,
+    /// Whether phone-specific rules apply.
+    pub phone: bool,
+    /// Clamped master-column percentage.
+    pub master_percent: u8,
+    /// Number of secondary surfaces visible in the stack.
+    pub stack_count: usize,
+    /// Bottom strip height in this plan.
+    pub activity_strip_height: u32,
+    /// Visible surface slots in reading order.
+    pub slots: Vec<SurfaceSlot>,
+}
+
+/// Stateless responsive layout resolver.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LayoutPolicy;
+
+impl LayoutPolicy {
+    /// Resolve a layout with at most two secondary surfaces visible.
+    pub fn resolve(
+        viewport: Viewport,
+        mode: LayoutMode,
+        requested_master_percent: u8,
+        surface_count: usize,
+    ) -> LayoutPlan {
+        let phone = viewport.is_phone();
+        if phone {
+            let inset = 8;
+            let top = 48;
+            let bottom = PHONE_ACTIVITY_STRIP;
+            let width = viewport.width.saturating_sub(inset * 2);
+            let height = viewport.height.saturating_sub(top + bottom + inset);
+            let slots = if surface_count == 0 {
+                Vec::new()
+            } else {
+                vec![SurfaceSlot {
+                    surface_index: 0,
+                    kind: SlotKind::Phone,
+                    rect: Rect {
+                        x: inset,
+                        y: top,
+                        width,
+                        height,
+                    },
+                }]
+            };
+            return LayoutPlan {
+                viewport,
+                mode: LayoutMode::Single,
+                phone: true,
+                master_percent: requested_master_percent
+                    .clamp(MASTER_MIN_PERCENT, MASTER_MAX_PERCENT),
+                stack_count: 0,
+                activity_strip_height: PHONE_ACTIVITY_STRIP,
+                slots,
+            };
+        }
+
+        let master_percent = requested_master_percent.clamp(MASTER_MIN_PERCENT, MASTER_MAX_PERCENT);
+        let inset = 10;
+        let gap = 10;
+        let top = DESKTOP_TOP_BAR + inset;
+        let width = viewport.width.saturating_sub(inset * 2);
+        let height = viewport.height.saturating_sub(top + inset);
+        let visible = surface_count.min(3);
+        let mut slots = Vec::new();
+        let resolved_mode = if surface_count == 0 {
+            LayoutMode::Single
+        } else {
+            mode
+        };
+        match resolved_mode {
+            LayoutMode::Master => {
+                if visible > 0 {
+                    let master_width = width
+                        .saturating_sub(gap)
+                        .saturating_mul(u32::from(master_percent))
+                        / 100;
+                    slots.push(SurfaceSlot {
+                        surface_index: 0,
+                        kind: SlotKind::Master,
+                        rect: Rect {
+                            x: inset,
+                            y: top,
+                            width: master_width,
+                            height,
+                        },
+                    });
+                    let stack_x = inset + master_width + gap;
+                    let stack_width = width.saturating_sub(master_width + gap);
+                    let stack_count = visible.saturating_sub(1).min(2);
+                    let stack_gap = if stack_count > 1 { gap } else { 0 };
+                    let each_height = if stack_count == 0 {
+                        0
+                    } else {
+                        height.saturating_sub(stack_gap) / stack_count as u32
+                    };
+                    for index in 0..stack_count {
+                        slots.push(SurfaceSlot {
+                            surface_index: index + 1,
+                            kind: SlotKind::Secondary,
+                            rect: Rect {
+                                x: stack_x,
+                                y: top + index as u32 * (each_height + stack_gap),
+                                width: stack_width,
+                                height: each_height,
+                            },
+                        });
+                    }
+                }
+            }
+            LayoutMode::Grid => {
+                let count = visible.min(2);
+                let each_width = if count == 0 {
+                    0
+                } else {
+                    width.saturating_sub(gap) / count as u32
+                };
+                for index in 0..count {
+                    slots.push(SurfaceSlot {
+                        surface_index: index,
+                        kind: if index == 0 {
+                            SlotKind::Master
+                        } else {
+                            SlotKind::Secondary
+                        },
+                        rect: Rect {
+                            x: inset + index as u32 * (each_width + gap),
+                            y: top,
+                            width: each_width,
+                            height,
+                        },
+                    });
+                }
+            }
+            LayoutMode::Single | LayoutMode::Focus => {
+                if visible > 0 {
+                    slots.push(SurfaceSlot {
+                        surface_index: 0,
+                        kind: SlotKind::Master,
+                        rect: Rect {
+                            x: inset,
+                            y: top,
+                            width,
+                            height,
+                        },
+                    });
+                }
+            }
+        }
+        let stack_count = slots
+            .iter()
+            .filter(|slot| slot.kind == SlotKind::Secondary)
+            .count();
+        LayoutPlan {
+            viewport,
+            mode: resolved_mode,
+            phone: false,
+            master_percent,
+            stack_count,
+            activity_strip_height: 0,
+            slots,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desktop_master_clamps_and_caps_stack() {
+        let plan = LayoutPolicy::resolve(Viewport::new(1440, 1000), LayoutMode::Master, 100, 5);
+        assert!(!plan.phone);
+        assert_eq!(plan.master_percent, MASTER_MAX_PERCENT);
+        assert_eq!(plan.stack_count, 2);
+        assert_eq!(plan.slots.len(), 3);
+    }
+
+    #[test]
+    fn phone_is_one_surface_plus_strip() {
+        let plan = LayoutPolicy::resolve(Viewport::new(390, 844), LayoutMode::Grid, 62, 4);
+        assert!(plan.phone);
+        assert_eq!(plan.mode, LayoutMode::Single);
+        assert_eq!(plan.slots.len(), 1);
+        assert_eq!(plan.activity_strip_height, PHONE_ACTIVITY_STRIP);
+    }
+}

--- a/apps/adaptive-shell/src/lib.rs
+++ b/apps/adaptive-shell/src/lib.rs
@@ -1,0 +1,30 @@
+//! A native, renderer-neutral reference shell for the AOS Adaptive Workspace.
+//!
+//! This crate deliberately stops at the user-space semantic and headless
+//! rendering boundary.  It does not start a daemon, spawn a process, talk to
+//! Astrid, or pretend that a native portal is available.  A future windowing
+//! backend can consume [`render::DisplayList`] without changing the semantic
+//! model in this crate.
+
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+#![warn(missing_docs)]
+
+pub mod activity;
+pub mod components;
+pub mod fixtures;
+pub mod input;
+pub mod layout;
+pub mod reconcile;
+pub mod render;
+pub mod theme;
+
+pub use activity::{
+    Activity, ActivityRegistry, OpaqueOwnerRef, Patch, PatchError, PatchOp, PatchOutcome, Recipe,
+    RecipeStore, Surface, SurfaceId,
+};
+pub use components::{ComponentKind, NodeId, SemanticNode, StateSet};
+pub use fixtures::{Fixture, FixtureKind, Snapshot};
+pub use input::{Command, ShellState};
+pub use layout::{LayoutMode, LayoutPlan, LayoutPolicy, Viewport};
+pub use theme::{Density, Theme, ThemeConfig, ThemeName};

--- a/apps/adaptive-shell/src/main.rs
+++ b/apps/adaptive-shell/src/main.rs
@@ -1,0 +1,146 @@
+//! Command-line entry point for the deterministic native shell runner.
+
+use adaptive_shell::fixtures::{FixtureKind, render_fixture};
+use adaptive_shell::theme::{Density, TextScale, ThemeConfig, ThemeName};
+use std::env;
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let options = Options::parse(env::args().skip(1))?;
+    if options.help {
+        print_help();
+        return Ok(());
+    }
+    if !options.headless {
+        eprintln!(
+            "native window backend is intentionally deferred; run with --headless for the runnable Rust shell"
+        );
+        return Ok(());
+    }
+    let snapshot = render_fixture(options.fixture, options.theme)?;
+    if options.json {
+        println!("{}", serde_json::to_string_pretty(&snapshot)?);
+    } else {
+        println!("AOS Adaptive Workspace · native Rust headless runner");
+        println!(
+            "fixture={} viewport={}x{}",
+            snapshot.fixture, snapshot.viewport.width, snapshot.viewport.height
+        );
+        println!(
+            "theme={} density={} scale={} reduced_motion={}",
+            snapshot.theme, snapshot.density, snapshot.scale_percent, snapshot.reduced_motion
+        );
+        println!(
+            "activity={} recipe_revision={} surfaces={}/{}",
+            snapshot.activity_id,
+            snapshot.recipe_revision,
+            snapshot.visible_surface_count,
+            snapshot.surface_count
+        );
+        println!(
+            "display_commands={} semantic_digest={} display_digest={}",
+            snapshot.display.commands, snapshot.semantic_digest, snapshot.display.digest
+        );
+        println!(
+            "native_portal={:?} clock_ms={}",
+            snapshot.native_portal, snapshot.clock_ms
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Options {
+    fixture: FixtureKind,
+    headless: bool,
+    json: bool,
+    help: bool,
+    theme: ThemeConfig,
+}
+
+impl Options {
+    fn parse<I>(args: I) -> Result<Self, String>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let mut fixture = FixtureKind::Desktop;
+        let mut headless = false;
+        let mut json = false;
+        let mut help = false;
+        let mut theme = ThemeConfig::default();
+        let mut args = args.into_iter();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--fixture" => {
+                    let value = args
+                        .next()
+                        .ok_or("--fixture needs desktop, phone, or theme-lab")?;
+                    fixture = FixtureKind::parse(&value).ok_or_else(|| {
+                        format!("unknown fixture `{value}` (expected desktop|phone|theme-lab)")
+                    })?;
+                }
+                "--headless" => headless = true,
+                "--json" => json = true,
+                "--help" | "-h" => help = true,
+                "--theme" => {
+                    let value = args
+                        .next()
+                        .ok_or("--theme needs dark, light, or contrast")?;
+                    theme.name = match value.as_str() {
+                        "dark" => ThemeName::Dark,
+                        "light" => ThemeName::Light,
+                        "contrast" | "high-contrast" => ThemeName::Contrast,
+                        _ => {
+                            return Err(format!(
+                                "unknown theme `{value}` (expected dark|light|contrast)"
+                            ));
+                        }
+                    };
+                }
+                "--density" => {
+                    let value = args.next().ok_or("--density needs tight, cozy, or open")?;
+                    theme.density = match value.as_str() {
+                        "tight" => Density::Tight,
+                        "cozy" => Density::Cozy,
+                        "open" => Density::Open,
+                        _ => {
+                            return Err(format!(
+                                "unknown density `{value}` (expected tight|cozy|open)"
+                            ));
+                        }
+                    };
+                }
+                "--scale" => {
+                    let value = args.next().ok_or("--scale needs 90, 100, 118, or 200")?;
+                    theme.scale = match value.as_str() {
+                        "90" | "90%" => TextScale::P90,
+                        "100" | "100%" => TextScale::P100,
+                        "118" | "118%" => TextScale::P118,
+                        "200" | "200%" => TextScale::P200,
+                        _ => {
+                            return Err(format!(
+                                "unknown scale `{value}` (expected 90|100|118|200)"
+                            ));
+                        }
+                    };
+                }
+                "--reduced-motion" => theme.reduced_motion = true,
+                value if value.starts_with('-') => return Err(format!("unknown option `{value}`")),
+                value => return Err(format!("unexpected argument `{value}`")),
+            }
+        }
+        Ok(Self {
+            fixture,
+            headless,
+            json,
+            help,
+            theme,
+        })
+    }
+}
+
+fn print_help() {
+    println!(
+        "AOS Adaptive Workspace native Rust runner\n\nUsage: adaptive-shell --headless [options]\n\nOptions:\n  --fixture desktop|phone|theme-lab\n  --theme dark|light|contrast\n  --density tight|cozy|open\n  --scale 90|100|118|200\n  --reduced-motion\n  --json\n  --help\n\nThe current tranche is headless by design; no browser, daemon, network, or native portal is assumed."
+    );
+}

--- a/apps/adaptive-shell/src/reconcile.rs
+++ b/apps/adaptive-shell/src/reconcile.rs
@@ -1,0 +1,177 @@
+//! Keyed reconciliation over the semantic scene graph.
+
+use crate::components::{NodeId, SceneError, SemanticNode};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A retained node record.  Renderer handles intentionally do not live here.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RetainedNode {
+    /// Stable semantic identity.
+    pub id: NodeId,
+    /// Semantic kind at the last reconciliation.
+    pub kind: crate::components::ComponentKind,
+    /// Parent identity, if any.
+    pub parent: Option<NodeId>,
+    /// Number of times this identity has been reconciled.
+    pub generation: u64,
+}
+
+/// Keyed reconciliation outcome.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ReconcileReport {
+    /// Nodes whose identity and kind were reused.
+    pub reused: Vec<NodeId>,
+    /// Newly materialized semantic nodes.
+    pub created: Vec<NodeId>,
+    /// Identities removed from the retained tree.
+    pub removed: Vec<NodeId>,
+    /// Focus survived the update.
+    pub focus_preserved: bool,
+}
+
+/// Retained semantic tree with stable focus.
+#[derive(Clone, Debug, Default)]
+pub struct Reconciler {
+    nodes: BTreeMap<NodeId, RetainedNode>,
+    focus: Option<NodeId>,
+}
+
+impl Reconciler {
+    /// Create an empty reconciler.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reconcile a new semantic root using stable keyed identities.
+    pub fn reconcile(&mut self, root: &SemanticNode) -> Result<ReconcileReport, SceneError> {
+        root.validate()?;
+        let mut next = BTreeMap::new();
+        collect(root, None, &self.nodes, &mut next);
+        let mut reused = Vec::new();
+        let mut created = Vec::new();
+        for (id, node) in &next {
+            if self
+                .nodes
+                .get(id)
+                .is_some_and(|previous| previous.kind == node.kind)
+            {
+                reused.push(*id);
+            } else {
+                created.push(*id);
+            }
+        }
+        let mut removed = self
+            .nodes
+            .keys()
+            .filter(|id| !next.contains_key(id))
+            .copied()
+            .collect::<Vec<_>>();
+        reused.sort_unstable();
+        created.sort_unstable();
+        removed.sort_unstable();
+        let focus_preserved = self.focus.is_some_and(|focus| next.contains_key(&focus));
+        if !focus_preserved {
+            self.focus = next.keys().next().copied();
+        }
+        self.nodes = next;
+        Ok(ReconcileReport {
+            reused,
+            created,
+            removed,
+            focus_preserved,
+        })
+    }
+
+    /// Set focus if the identity is currently present.
+    pub fn focus(&mut self, id: NodeId) -> bool {
+        if self.nodes.contains_key(&id) {
+            self.focus = Some(id);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Return the currently focused identity.
+    pub const fn focused(&self) -> Option<NodeId> {
+        self.focus
+    }
+
+    /// Clear focus (for a transient modal or launcher).
+    pub const fn clear_focus(&mut self) {
+        self.focus = None;
+    }
+
+    /// Return a retained node by identity.
+    pub fn get(&self, id: NodeId) -> Option<&RetainedNode> {
+        self.nodes.get(&id)
+    }
+
+    /// Return identities in deterministic order.
+    pub fn ids(&self) -> impl Iterator<Item = NodeId> + '_ {
+        self.nodes.keys().copied()
+    }
+}
+
+fn collect(
+    node: &SemanticNode,
+    parent: Option<NodeId>,
+    previous: &BTreeMap<NodeId, RetainedNode>,
+    output: &mut BTreeMap<NodeId, RetainedNode>,
+) {
+    let generation = previous
+        .get(&node.id)
+        .map_or(1, |retained| retained.generation.saturating_add(1));
+    output.insert(
+        node.id,
+        RetainedNode {
+            id: node.id,
+            kind: node.kind,
+            parent,
+            generation,
+        },
+    );
+    for child in &node.children {
+        collect(child, Some(node.id), previous, output);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::{ComponentKind, SemanticNode};
+
+    #[test]
+    fn keyed_reconcile_reuses_identity_and_focus() {
+        let mut root = SemanticNode::new("root", ComponentKind::Region, "Root");
+        let mut button = SemanticNode::new("stable", ComponentKind::Button, "Stable");
+        button.props = button
+            .props
+            .clone()
+            .with(
+                "label",
+                crate::components::PropValue::Text("Stable".to_owned()),
+            )
+            .expect("property");
+        button.props = button
+            .props
+            .clone()
+            .with(
+                "action",
+                crate::components::PropValue::Text("noop".to_owned()),
+            )
+            .expect("property");
+        root.push(button).expect("child");
+        let stable = root.children[0].id;
+        let mut reconciler = Reconciler::new();
+        let first = reconciler.reconcile(&root).expect("valid");
+        assert_eq!(first.created.len(), 2);
+        assert!(reconciler.focus(stable));
+        root.children[0].accessibility.name = "Still stable".to_owned();
+        let second = reconciler.reconcile(&root).expect("valid");
+        assert!(second.focus_preserved);
+        assert!(second.reused.contains(&stable));
+        assert_eq!(reconciler.focused(), Some(stable));
+    }
+}

--- a/apps/adaptive-shell/src/render.rs
+++ b/apps/adaptive-shell/src/render.rs
@@ -1,0 +1,242 @@
+//! Backend-neutral display-list and renderer boundary.
+
+use crate::layout::Rect;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// A backend-neutral color.
+pub type Color = [u8; 4];
+
+/// Primitive display commands consumed by a native renderer adapter.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum DrawCommand {
+    /// Fill a rounded rectangle.
+    FillRoundRect {
+        /// Target rectangle.
+        rect: Rect,
+        /// Corner radius in logical pixels.
+        radius: u16,
+        /// Fill color.
+        color: Color,
+    },
+    /// Stroke a rounded rectangle.
+    StrokeRoundRect {
+        /// Target rectangle.
+        rect: Rect,
+        /// Corner radius in logical pixels.
+        radius: u16,
+        /// Stroke color.
+        color: Color,
+        /// Stroke width.
+        width: u16,
+    },
+    /// Draw a horizontal or vertical line.
+    Line {
+        /// Start point.
+        from: (u32, u32),
+        /// End point.
+        to: (u32, u32),
+        /// Line color.
+        color: Color,
+        /// Width.
+        width: u16,
+    },
+    /// Draw semantic text.  A text backend can choose shaping and fallback.
+    Text {
+        /// Text bounds.
+        rect: Rect,
+        /// UTF-8 content.
+        content: String,
+        /// Semantic typography role.
+        role: String,
+        /// Text color.
+        color: Color,
+    },
+    /// Draw an icon by semantic name.
+    Icon {
+        /// Icon bounds.
+        rect: Rect,
+        /// Registered icon name.
+        name: String,
+        /// Icon color.
+        color: Color,
+    },
+    /// A bounded media or portal placeholder.
+    Placeholder {
+        /// Placeholder bounds.
+        rect: Rect,
+        /// Human-readable state.
+        label: String,
+        /// Accent color.
+        color: Color,
+    },
+}
+
+/// Ordered display commands for one deterministic frame.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct DisplayList {
+    /// Logical frame size.
+    pub viewport: (u32, u32),
+    /// Commands in painter order.
+    pub commands: Vec<DrawCommand>,
+}
+
+impl DisplayList {
+    /// Construct an empty list.
+    pub const fn new(viewport: (u32, u32)) -> Self {
+        Self {
+            viewport,
+            commands: Vec::new(),
+        }
+    }
+
+    /// Append a command.
+    pub fn push(&mut self, command: DrawCommand) {
+        self.commands.push(command);
+    }
+
+    /// Stable digest suitable for snapshot assertions.
+    pub fn digest(&self) -> String {
+        let bytes = serde_json::to_vec(self).expect("display list is serializable");
+        blake3::hash(&bytes).to_hex().to_string()
+    }
+
+    /// Return a compact summary for a human smoke run.
+    pub fn summary(&self) -> DisplaySummary {
+        let mut fills = 0;
+        let mut strokes = 0;
+        let mut text = 0;
+        let mut icons = 0;
+        let mut placeholders = 0;
+        for command in &self.commands {
+            match command {
+                DrawCommand::FillRoundRect { .. } => fills += 1,
+                DrawCommand::StrokeRoundRect { .. } | DrawCommand::Line { .. } => strokes += 1,
+                DrawCommand::Text { .. } => text += 1,
+                DrawCommand::Icon { .. } => icons += 1,
+                DrawCommand::Placeholder { .. } => placeholders += 1,
+            }
+        }
+        DisplaySummary {
+            viewport: self.viewport,
+            commands: self.commands.len(),
+            fills,
+            strokes,
+            text,
+            icons,
+            placeholders,
+            digest: self.digest(),
+        }
+    }
+}
+
+/// Compact command counts and digest.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DisplaySummary {
+    /// Logical frame size.
+    pub viewport: (u32, u32),
+    /// Total command count.
+    pub commands: usize,
+    /// Rounded fills.
+    pub fills: usize,
+    /// Strokes and lines.
+    pub strokes: usize,
+    /// Text commands.
+    pub text: usize,
+    /// Icon commands.
+    pub icons: usize,
+    /// Placeholder commands.
+    pub placeholders: usize,
+    /// Stable frame digest.
+    pub digest: String,
+}
+
+/// Render result from a backend adapter.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RenderReceipt {
+    /// Digest of the accepted display list.
+    pub digest: String,
+    /// Number of accepted commands.
+    pub command_count: usize,
+}
+
+/// Renderer backend boundary.  Concrete GPU/window handles stay below this trait.
+pub trait Renderer {
+    /// Consume a display list.
+    fn render(&mut self, display_list: &DisplayList) -> Result<RenderReceipt, RenderError>;
+}
+
+/// Deterministic headless renderer used by tests and the CLI smoke path.
+#[derive(Clone, Debug, Default)]
+pub struct HeadlessRenderer {
+    last: Option<DisplayList>,
+}
+
+impl HeadlessRenderer {
+    /// Construct an empty headless renderer.
+    pub const fn new() -> Self {
+        Self { last: None }
+    }
+
+    /// Return the last accepted list.
+    pub fn last(&self) -> Option<&DisplayList> {
+        self.last.as_ref()
+    }
+}
+
+impl Renderer for HeadlessRenderer {
+    fn render(&mut self, display_list: &DisplayList) -> Result<RenderReceipt, RenderError> {
+        if display_list.viewport.0 == 0 || display_list.viewport.1 == 0 {
+            return Err(RenderError::InvalidViewport);
+        }
+        let receipt = RenderReceipt {
+            digest: display_list.digest(),
+            command_count: display_list.commands.len(),
+        };
+        self.last = Some(display_list.clone());
+        Ok(receipt)
+    }
+}
+
+/// Renderer boundary failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RenderError {
+    /// A zero-sized frame cannot be rendered.
+    InvalidViewport,
+}
+
+impl fmt::Display for RenderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidViewport => f.write_str("renderer viewport cannot be zero-sized"),
+        }
+    }
+}
+
+impl std::error::Error for RenderError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn headless_render_is_deterministic() {
+        let mut list = DisplayList::new((320, 240));
+        list.push(DrawCommand::Text {
+            rect: Rect {
+                x: 1,
+                y: 1,
+                width: 100,
+                height: 20,
+            },
+            content: "hello".to_owned(),
+            role: "body".to_owned(),
+            color: [255, 255, 255, 255],
+        });
+        let digest = list.digest();
+        let mut renderer = HeadlessRenderer::new();
+        let receipt = renderer.render(&list).expect("valid viewport");
+        assert_eq!(receipt.digest, digest);
+        assert_eq!(renderer.last(), Some(&list));
+    }
+}

--- a/apps/adaptive-shell/src/theme.rs
+++ b/apps/adaptive-shell/src/theme.rs
@@ -1,0 +1,465 @@
+//! Fieldglass semantic theme roles and accessibility settings.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// Supported semantic palettes.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ThemeName {
+    /// Warm dark-neutral default.
+    #[default]
+    Dark,
+    /// Light-neutral palette.
+    Light,
+    /// Explicit borders and high contrast, with no transparency dependency.
+    Contrast,
+}
+
+impl fmt::Display for ThemeName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Dark => "dark",
+            Self::Light => "light",
+            Self::Contrast => "contrast",
+        })
+    }
+}
+
+/// Spacing/control density.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Density {
+    /// 4/7/10 spacing and 31 px compact controls.
+    Tight,
+    /// 4/7/10/14 spacing and 36 px controls.
+    #[default]
+    Cozy,
+    /// 7/10/14/20 spacing and 42 px controls.
+    Open,
+}
+
+impl fmt::Display for Density {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Tight => "tight",
+            Self::Cozy => "cozy",
+            Self::Open => "open",
+        })
+    }
+}
+
+/// Text scale values supported by the shell.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub enum TextScale {
+    /// 90% scale.
+    P90,
+    /// 100% scale.
+    #[default]
+    P100,
+    /// 118% scale.
+    P118,
+    /// 200% accessibility scale.
+    P200,
+}
+
+impl TextScale {
+    /// Return the scale as a percentage.
+    pub const fn percent(self) -> u16 {
+        match self {
+            Self::P90 => 90,
+            Self::P100 => 100,
+            Self::P118 => 118,
+            Self::P200 => 200,
+        }
+    }
+}
+
+/// A typed role value.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum TokenValue {
+    /// RGBA color.
+    Color([u8; 4]),
+    /// Logical pixels.
+    Pixels(u16),
+    /// Text size in logical pixels.
+    TypeScale(u16),
+    /// Motion duration in milliseconds.
+    Millis(u16),
+}
+
+/// Complete role-resolved Fieldglass token map.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ThemeTokens {
+    /// Stable semantic token role map.
+    pub roles: BTreeMap<String, TokenValue>,
+}
+
+impl ThemeTokens {
+    /// Every role required by `aos.theme/1` in this tranche.
+    pub const REQUIRED_ROLES: [&'static str; 39] = [
+        "aos.color.canvas",
+        "aos.color.canvas-raised",
+        "aos.color.fieldglass",
+        "aos.color.layer.1",
+        "aos.color.layer.2",
+        "aos.color.layer.3",
+        "aos.color.text",
+        "aos.color.text-soft",
+        "aos.color.text-dim",
+        "aos.color.line",
+        "aos.color.line-strong",
+        "aos.color.accent",
+        "aos.color.accent-strong",
+        "aos.color.accent-wash",
+        "aos.color.success",
+        "aos.color.warning",
+        "aos.color.danger",
+        "aos.color.info",
+        "aos.color.focus",
+        "aos.radius.detail",
+        "aos.radius.control",
+        "aos.radius.window",
+        "aos.space.1",
+        "aos.space.2",
+        "aos.space.3",
+        "aos.space.4",
+        "aos.space.5",
+        "aos.space.6",
+        "aos.control.height.compact",
+        "aos.control.height.cozy",
+        "aos.control.height.spacious",
+        "aos.type.caption",
+        "aos.type.body",
+        "aos.type.control",
+        "aos.type.title",
+        "aos.type.display",
+        "aos.motion.fast",
+        "aos.motion.normal",
+        "aos.motion.layout",
+    ];
+
+    /// Resolve the requested palette and accessibility settings.
+    pub fn resolve(
+        name: ThemeName,
+        density: Density,
+        scale: TextScale,
+        reduced_motion: bool,
+    ) -> Self {
+        let (canvas, raised, fieldglass, text, text_soft, text_dim, line, line_strong) = match name
+        {
+            ThemeName::Dark => (
+                [12, 14, 17, 255],
+                [23, 25, 30, 255],
+                [27, 29, 35, 246],
+                [244, 242, 247, 255],
+                [194, 193, 204, 255],
+                [156, 155, 166, 255],
+                [61, 62, 71, 255],
+                [85, 86, 99, 255],
+            ),
+            ThemeName::Light => (
+                [245, 245, 247, 255],
+                [255, 255, 255, 255],
+                [247, 247, 250, 248],
+                [28, 29, 34, 255],
+                [77, 78, 88, 255],
+                [95, 96, 105, 255],
+                [205, 206, 214, 255],
+                [170, 171, 183, 255],
+            ),
+            ThemeName::Contrast => (
+                [0, 0, 0, 255],
+                [0, 0, 0, 255],
+                [0, 0, 0, 255],
+                [255, 255, 255, 255],
+                [245, 245, 245, 255],
+                [220, 220, 220, 255],
+                [255, 255, 255, 255],
+                [255, 255, 0, 255],
+            ),
+        };
+        let accent = match name {
+            ThemeName::Contrast => [255, 210, 0, 255],
+            ThemeName::Light => [95, 47, 213, 255],
+            ThemeName::Dark => [157, 122, 255, 255],
+        };
+        let (success, warning, danger, info, focus) = match name {
+            ThemeName::Light => (
+                [17, 124, 88, 255],
+                [154, 94, 7, 255],
+                [169, 39, 55, 255],
+                [12, 91, 165, 255],
+                [9, 75, 145, 255],
+            ),
+            ThemeName::Contrast => (
+                [76, 208, 149, 255],
+                [242, 181, 89, 255],
+                [235, 105, 121, 255],
+                [92, 170, 245, 255],
+                [111, 180, 255, 255],
+            ),
+            ThemeName::Dark => (
+                [76, 208, 149, 255],
+                [242, 181, 89, 255],
+                [235, 105, 121, 255],
+                [92, 170, 245, 255],
+                [111, 180, 255, 255],
+            ),
+        };
+        let mut roles = BTreeMap::new();
+        for (key, value) in [
+            ("aos.color.canvas", TokenValue::Color(canvas)),
+            ("aos.color.canvas-raised", TokenValue::Color(raised)),
+            ("aos.color.fieldglass", TokenValue::Color(fieldglass)),
+            ("aos.color.layer.1", TokenValue::Color(raised)),
+            ("aos.color.layer.2", TokenValue::Color([31, 33, 40, 255])),
+            ("aos.color.layer.3", TokenValue::Color([43, 44, 52, 255])),
+            ("aos.color.text", TokenValue::Color(text)),
+            ("aos.color.text-soft", TokenValue::Color(text_soft)),
+            ("aos.color.text-dim", TokenValue::Color(text_dim)),
+            ("aos.color.line", TokenValue::Color(line)),
+            ("aos.color.line-strong", TokenValue::Color(line_strong)),
+            ("aos.color.accent", TokenValue::Color(accent)),
+            (
+                "aos.color.accent-strong",
+                TokenValue::Color([187, 159, 255, 255]),
+            ),
+            (
+                "aos.color.accent-wash",
+                TokenValue::Color([132, 96, 225, 90]),
+            ),
+            ("aos.color.success", TokenValue::Color(success)),
+            ("aos.color.warning", TokenValue::Color(warning)),
+            ("aos.color.danger", TokenValue::Color(danger)),
+            ("aos.color.info", TokenValue::Color(info)),
+            ("aos.color.focus", TokenValue::Color(focus)),
+        ] {
+            roles.insert(key.to_owned(), value);
+        }
+        for (key, value) in [
+            ("aos.radius.detail", 6),
+            ("aos.radius.control", 9),
+            ("aos.radius.window", 15),
+        ] {
+            roles.insert(key.to_owned(), TokenValue::Pixels(value));
+        }
+        let spaces = match density {
+            Density::Tight => [4, 6, 9, 12, 16, 22],
+            Density::Cozy => [4, 7, 10, 14, 20, 28],
+            Density::Open => [5, 9, 13, 18, 26, 34],
+        };
+        for (index, value) in spaces.into_iter().enumerate() {
+            roles.insert(
+                format!("aos.space.{}", index + 1),
+                TokenValue::Pixels(value),
+            );
+        }
+        let heights = match density {
+            Density::Tight => [31, 34, 38],
+            Density::Cozy => [31, 36, 42],
+            Density::Open => [36, 42, 48],
+        };
+        for (key, value) in [
+            "aos.control.height.compact",
+            "aos.control.height.cozy",
+            "aos.control.height.spacious",
+        ]
+        .into_iter()
+        .zip(heights)
+        {
+            roles.insert(key.to_owned(), TokenValue::Pixels(value));
+        }
+        let base = u16::try_from(u32::from(scale.percent()) * 16 / 100).unwrap_or(16);
+        for (key, multiplier) in [
+            ("aos.type.caption", 0.75_f32),
+            ("aos.type.body", 0.875),
+            ("aos.type.control", 0.875),
+            ("aos.type.title", 1.375),
+            ("aos.type.display", 2.25),
+        ] {
+            roles.insert(
+                key.to_owned(),
+                TokenValue::TypeScale((f32::from(base) * multiplier).round() as u16),
+            );
+        }
+        let motions = if reduced_motion {
+            [0, 0, 0]
+        } else {
+            [90, 150, 240]
+        };
+        for (key, value) in ["aos.motion.fast", "aos.motion.normal", "aos.motion.layout"]
+            .into_iter()
+            .zip(motions)
+        {
+            roles.insert(key.to_owned(), TokenValue::Millis(value));
+        }
+        Self { roles }
+    }
+
+    /// Check that all required roles are present.
+    pub fn is_complete(&self) -> bool {
+        Self::REQUIRED_ROLES
+            .iter()
+            .all(|key| self.roles.contains_key(*key))
+    }
+
+    /// Resolve one role.
+    pub fn get(&self, role: &str) -> Option<&TokenValue> {
+        self.roles.get(role)
+    }
+
+    /// WCAG relative luminance for an opaque sRGB token.
+    pub fn relative_luminance(color: [u8; 4]) -> f32 {
+        let channel = |value: u8| {
+            let value = f32::from(value) / 255.0;
+            if value <= 0.039_28 {
+                value / 12.92
+            } else {
+                ((value + 0.055) / 1.055).powf(2.4)
+            }
+        };
+        0.2126 * channel(color[0]) + 0.7152 * channel(color[1]) + 0.0722 * channel(color[2])
+    }
+
+    /// WCAG contrast ratio, independent of foreground/background order.
+    pub fn contrast_ratio(left: [u8; 4], right: [u8; 4]) -> f32 {
+        let a = Self::relative_luminance(left);
+        let b = Self::relative_luminance(right);
+        let lighter = a.max(b);
+        let darker = a.min(b);
+        (lighter + 0.05) / (darker + 0.05)
+    }
+
+    /// Fail closed if required colors are absent, transparent, or too low contrast.
+    pub fn validate_accessibility(&self) -> Result<(), &'static str> {
+        let color = |role: &str| match self.roles.get(role) {
+            Some(TokenValue::Color(color)) if color[3] == 255 => Ok(*color),
+            Some(TokenValue::Color(_)) => Err("required accessibility token is transparent"),
+            _ => Err("required accessibility token is absent"),
+        };
+        let canvas = color("aos.color.canvas")?;
+        let raised = color("aos.color.canvas-raised")?;
+        for background in [canvas, raised] {
+            for role in [
+                "aos.color.text",
+                "aos.color.text-soft",
+                "aos.color.text-dim",
+            ] {
+                let foreground = color(role)?;
+                let ratio = Self::contrast_ratio(foreground, background);
+                if ratio < 4.5 {
+                    return Err("required token fails WCAG AA contrast");
+                }
+            }
+            for role in [
+                "aos.color.accent",
+                "aos.color.success",
+                "aos.color.warning",
+                "aos.color.danger",
+                "aos.color.info",
+                "aos.color.focus",
+            ] {
+                let foreground = color(role)?;
+                if Self::contrast_ratio(foreground, background) < 3.0 {
+                    return Err(Box::leak(role.to_owned().into_boxed_str()));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Theme selection plus accessibility settings.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ThemeConfig {
+    /// Palette.
+    pub name: ThemeName,
+    /// Density.
+    pub density: Density,
+    /// Text scale.
+    pub scale: TextScale,
+    /// Whether movement is removed.
+    pub reduced_motion: bool,
+}
+
+impl Default for ThemeConfig {
+    fn default() -> Self {
+        Self {
+            name: ThemeName::Dark,
+            density: Density::Cozy,
+            scale: TextScale::P100,
+            reduced_motion: false,
+        }
+    }
+}
+
+/// Resolve tokens from a named config.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Theme {
+    /// Selected configuration.
+    pub config: ThemeConfig,
+    /// Resolved semantic roles.
+    pub tokens: ThemeTokens,
+}
+
+impl Theme {
+    /// Resolve a complete theme.
+    pub fn resolve(config: ThemeConfig) -> Self {
+        let tokens = ThemeTokens::resolve(
+            config.name,
+            config.density,
+            config.scale,
+            config.reduced_motion,
+        );
+        Self { config, tokens }
+    }
+
+    /// Stable digest used by deterministic display snapshots.
+    pub fn digest(&self) -> String {
+        let bytes = serde_json::to_vec(self).expect("theme is serializable");
+        blake3::hash(&bytes).to_hex().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_theme_resolves_every_role() {
+        for name in [ThemeName::Dark, ThemeName::Light, ThemeName::Contrast] {
+            for density in [Density::Tight, Density::Cozy, Density::Open] {
+                let theme = Theme::resolve(ThemeConfig {
+                    name,
+                    density,
+                    ..ThemeConfig::default()
+                });
+                assert!(theme.tokens.is_complete());
+                assert_eq!(theme.tokens.roles.len(), ThemeTokens::REQUIRED_ROLES.len());
+            }
+        }
+    }
+
+    #[test]
+    fn all_theme_combinations_meet_wcag_and_opaque_fallback() {
+        for name in [ThemeName::Dark, ThemeName::Light, ThemeName::Contrast] {
+            for density in [Density::Tight, Density::Cozy, Density::Open] {
+                for scale in [
+                    TextScale::P90,
+                    TextScale::P100,
+                    TextScale::P118,
+                    TextScale::P200,
+                ] {
+                    let tokens = ThemeTokens::resolve(name, density, scale, true);
+                    assert!(
+                        tokens.validate_accessibility().is_ok(),
+                        "{name:?} failed: {:?}",
+                        tokens.validate_accessibility()
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #92

## Summary

Add the detached Adaptive Workspace runner as `apps/adaptive-shell`. It
opens on an activity, materializes `aos.recipe@1` into an ephemeral
`aos.surface@1`, applies reviewed `aos.patch@1` compare-and-swap, and
emits a backend-neutral display list. HTML/CSS/JS design artifacts are
not part of this tree and are not the product shell.

## Claim boundary

This PR lands the headless semantic core only:

- 62 catalog identities and Fieldglass theme/density/scale/reduced-motion tokens
- typed opaque owner versus acting principal, with required non-self review
- desktop master-plus-stack and phone one-visible-surface layout
- keyed reconciliation, focus commands, and deterministic snapshots
- honest `NativePortal` unavailable fixture state

It does **not** prove Activity Atlas/spatial placement integration, GPU or
window presentation, live native-application control, recipe persistence,
live `~/.aos` operation, release publication, or Astrid public contracts.
Those remain later issues (#94, #97, and the Atlas/display successor).

## Verification

Local, locked crate checks:

- `cargo fmt --all -- --check`
- `cargo test --locked -p adaptive-shell` — 25 passed
- `cargo clippy --locked -p adaptive-shell --all-targets -- -D warnings`

Headless JSON fixtures (`native_portal=unavailable` in all three):

| Fixture | Flags | Viewport | Commands | Visible surfaces | Display digest |
| --- | --- | --- | --- | --- | --- |
| desktop | default dark/cozy | 1440x1000 | 43 | 3/3 | `08e3c974e2a6725b59c19262423eb3954ae3d5a71cf018a067541699f166df78` |
| phone | **`--theme light`** | 390x844 | 34 | 1/3 | `b42ef26453f594b72130cf5e6fe07fc0de22d8dd1e7d605bc891e7fe85d6d223` |
| theme-lab | `--density open` | 1440x1000 | 330 | 1/1 | `0a3937a7e165e5f7cc6128e4045824de7d7232f07cb9fcd60a0d9d59acf54402` |

The phone digest above is valid **only** with `--theme light`. Default
dark phone is a different digest (`d1565241cf90d346a2ba202bd58cd04f8990d828884441767cf1b740a92f879f`)
with the same 34 commands and one visible surface. Keep the light-theme
flag explicit in later replay evidence.

## Residuals

- `activity.rs` (1137) and `fixtures.rs` (1165) exceed the 1000-line split
  signal; they are accepted as-is in this freeze.
- Public `Surface` fields still rely on construction/insert validation.
- Theme contrast-failure currently leaks a boxed role string.
- Text-scale tokens resolve but do not change the headless display digest.
- Layout gaps/insets remain fixed constants.
- Malformed-state coverage is the first forbidden bit per identity, not the
  exhaustive 12-bit × 62 product.
- No GPU/window backend, recipe persistence, or live runtime is present.

## Test plan

- CI on this draft.
- Do not merge until independent review of the signed SHA and CI are
  accepted on the intended delivery surface.
