### PR TITLE
feat(capsules): add semantic surface catalog, theme packs, and Theme Lab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- An unpublished native Rust semantic catalog capsule that owns the finite v1
+  component inventory, complete primitive records, two complete theme packs,
+  hostile-value validation, fail-closed token fallback, safe unknown-component
+  fallback, A2UI declared-loss fixtures, and a catalog-owned Theme Lab matrix.
 - A bounded `aos-rhai` capsule with profile-scoped Rhai evaluation, strict
   resource ceilings, cooperative cancellation, and no script-visible host
   effects.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "capsule-surface-catalog"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "capsule-surface-model"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 name = "capsule-surface-catalog"
 version = "0.1.0"
 dependencies = [
+ "capsule-surface-model",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "capsules/capsule-session",
     "capsules/capsule-shell",
     "capsules/capsule-skills",
+    "capsules/capsule-surface-catalog",
     "capsules/capsule-surface-model",
     "capsules/capsule-workspace-recipes",
     "capsules/capsule-system",

--- a/capsules/capsule-surface-catalog/Capsule.toml
+++ b/capsules/capsule-surface-catalog/Capsule.toml
@@ -1,0 +1,15 @@
+[package]
+name = "capsule-surface-catalog"
+version = "0.1.0"
+description = "Finite AOS semantic component catalog, theme packs, and validators"
+authors = ["Joshua J. Bouw <jjb@unicity-labs.com>"]
+astrid-version = ">=0.7.0"
+license = "MIT OR Apache-2.0"
+publish = false
+
+# This unpublished library contract is not installed, activated, granted,
+# packaged as WASM, or exposed through adaptive-shell in this tranche.
+[[component]]
+id = "surface-catalog"
+file = "capsule_surface_catalog.wasm"
+type = "library"

--- a/capsules/capsule-surface-catalog/Cargo.toml
+++ b/capsules/capsule-surface-catalog/Cargo.toml
@@ -11,5 +11,6 @@ name = "capsule_surface_catalog"
 path = "src/lib.rs"
 
 [dependencies]
+capsule-surface-model = { path = "../capsule-surface-model" }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.150"

--- a/capsules/capsule-surface-catalog/Cargo.toml
+++ b/capsules/capsule-surface-catalog/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "capsule-surface-catalog"
+version = "0.1.0"
+edition = "2024"
+description = "Finite AOS semantic component catalog, theme packs, and validators"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+name = "capsule_surface_catalog"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "=1.0.228", features = ["derive"] }
+serde_json = "=1.0.150"

--- a/capsules/capsule-surface-catalog/src/a2ui.rs
+++ b/capsules/capsule-surface-catalog/src/a2ui.rs
@@ -1,0 +1,111 @@
+//! Declared-loss A2UI input mapping evidence owned by the catalog.
+
+use crate::catalog::Primitive;
+use std::fmt;
+
+/// One declared-loss source-to-catalog mapping.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DeclaredLossMapping {
+    /// A2UI source identity.
+    pub source: &'static str,
+    /// Permitted catalog targets, in preference order.
+    pub targets: &'static [Primitive],
+}
+
+/// A2UI mapping failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum A2uiImportError {
+    /// Source had no declared-loss catalog mapping.
+    UnmappedSource,
+}
+
+impl fmt::Display for A2uiImportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("A2UI component has no declared-loss catalog mapping")
+    }
+}
+
+impl std::error::Error for A2uiImportError {}
+
+/// Normative mapping consumed by the #91 adapter.
+pub const A2UI_DECLARED_LOSS: &[DeclaredLossMapping] = &[
+    DeclaredLossMapping {
+        source: "Row",
+        targets: &[Primitive::Stack],
+    },
+    DeclaredLossMapping {
+        source: "Column",
+        targets: &[Primitive::Stack],
+    },
+    DeclaredLossMapping {
+        source: "List",
+        targets: &[Primitive::Repeater, Primitive::Stack],
+    },
+    DeclaredLossMapping {
+        source: "ChoicePicker",
+        targets: &[Primitive::Select, Primitive::MultiSelect],
+    },
+    DeclaredLossMapping {
+        source: "Modal",
+        targets: &[Primitive::Dialog],
+    },
+    DeclaredLossMapping {
+        source: "Image",
+        targets: &[Primitive::ImageView],
+    },
+    DeclaredLossMapping {
+        source: "TextHeadingHint",
+        targets: &[Primitive::Heading, Primitive::Text],
+    },
+    DeclaredLossMapping {
+        source: "TextBodyHint",
+        targets: &[Primitive::Text, Primitive::Heading],
+    },
+];
+
+/// Return all declared catalog targets, preserving preference order.
+pub fn map_a2ui_component(source: &str) -> Result<&'static [Primitive], A2uiImportError> {
+    A2UI_DECLARED_LOSS
+        .iter()
+        .find(|mapping| mapping.source == source)
+        .map(|mapping| mapping.targets)
+        .ok_or(A2uiImportError::UnmappedSource)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_every_required_a2ui_boundary() {
+        assert_eq!(map_a2ui_component("Row").unwrap(), &[Primitive::Stack][..]);
+        assert_eq!(
+            map_a2ui_component("Column").unwrap(),
+            &[Primitive::Stack][..]
+        );
+        assert_eq!(
+            map_a2ui_component("List").unwrap(),
+            &[Primitive::Repeater, Primitive::Stack][..]
+        );
+        assert_eq!(
+            map_a2ui_component("ChoicePicker").unwrap(),
+            &[Primitive::Select, Primitive::MultiSelect][..]
+        );
+        assert_eq!(
+            map_a2ui_component("Modal").unwrap(),
+            &[Primitive::Dialog][..]
+        );
+        assert_eq!(
+            map_a2ui_component("Image").unwrap(),
+            &[Primitive::ImageView][..]
+        );
+        assert_eq!(
+            map_a2ui_component("TextHeadingHint").unwrap(),
+            &[Primitive::Heading, Primitive::Text][..]
+        );
+        assert_eq!(
+            map_a2ui_component("NotInA2ui"),
+            Err(A2uiImportError::UnmappedSource)
+        );
+    }
+}

--- a/capsules/capsule-surface-catalog/src/catalog.rs
+++ b/capsules/capsule-surface-catalog/src/catalog.rs
@@ -1,5 +1,6 @@
 //! The finite `aos.catalog/1` primitive inventory and record validator.
 
+use capsule_surface_model::ComponentKind;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fmt;
@@ -10,281 +11,133 @@ pub const CATALOG_SCHEMA: &str = "aos.catalog/1";
 const MAX_TEXT_BYTES: usize = 320;
 const MAX_SLOTS: usize = 8;
 
-/// Every v1 primitive in the exact stable order owned by this capsule.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
-#[serde(rename_all = "PascalCase")]
-pub enum Primitive {
-    /// A named semantic region.
-    Region,
-    /// An ordered vertical or horizontal stack.
-    Stack,
-    /// A grid of semantic children.
-    Grid,
-    /// A resizable split.
-    Split,
-    /// Navigation sidebar.
-    Sidebar,
-    /// A row of semantic actions.
-    ActionBar,
-    /// Framed content card.
-    Card,
-    /// Preference or content group.
-    Group,
-    /// Collapsible content.
-    Collapse,
-    /// Repeated bounded children.
-    Repeater,
-    /// Scrollable semantic region.
-    ScrollRegion,
-    /// A semantic divider.
-    Divider,
-    /// A heading.
-    Heading,
-    /// Body or inline text.
-    Text,
-    /// Inline rich content.
-    InlineContent,
-    /// Source or code text.
-    CodeBlock,
-    /// Compact label.
-    Badge,
-    /// Prominent numeric fact.
-    KeyFigure,
-    /// Empty-result explanation.
-    EmptyState,
-    /// A named icon.
-    Icon,
-    /// An action control; icon-only controls use the icon slot.
-    Button,
-    /// Single-line text entry.
-    TextField,
-    /// Multi-line text entry.
-    TextArea,
-    /// Numeric entry.
-    NumberField,
-    /// Single selection.
-    Select,
-    /// Multiple selection.
-    MultiSelect,
-    /// Boolean switch.
-    Switch,
-    /// Boolean checkbox.
-    Checkbox,
-    /// Bounded range input.
-    Slider,
-    /// Date or time entry.
-    DateTimeField,
-    /// Tabular data.
-    Table,
-    /// Concise record summary.
-    RecordSummary,
-    /// Data chart with a textual equivalent.
-    DatasetChart,
-    /// Ordered events.
-    Timeline,
-    /// Before-and-after difference.
-    Difference,
-    /// Progress indicator.
-    Progress,
-    /// Tab navigation.
-    Tabs,
-    /// Hierarchical navigation.
-    Breadcrumb,
-    /// Context menu.
-    Menu,
-    /// Page navigation.
-    Pager,
-    /// A semantic link.
-    Link,
-    /// Important non-blocking alert.
-    Alert,
-    /// Temporary notification.
-    Toast,
-    /// Inline feedback.
-    InlineMessage,
-    /// Loading placeholder.
-    Skeleton,
-    /// Busy indicator.
-    Spinner,
-    /// Small status indicator.
-    StatusDot,
-    /// Modal dialog.
-    Dialog,
-    /// Capability description, never a grant.
-    CapabilityCard,
-    /// Consent request, never consent itself.
-    ConsentForm,
-    /// Deliberate secure-input prompt.
-    SecurePrompt,
-    /// Governed file-selection request.
-    FilePicker,
-    /// Image media.
-    ImageView,
-    /// Audio media.
-    AudioPlayer,
-    /// Video media.
-    VideoPlayer,
-    /// File metadata.
-    FileDetails,
-    /// Typed principal-scoped media reference.
-    MediaEmbed,
-    /// Free-form drawing stage.
-    CanvasStage,
-    /// Diagram surface.
-    DiagramView,
-    /// Annotation layer.
-    AnnotationLayer,
-    /// Presentation of a bound terminal session.
-    TerminalView,
-    /// Presentation of external portal state.
-    NativePortal,
-}
+/// The canonical v1 primitive identity is owned by `capsule-surface-model`.
+pub use capsule_surface_model::ComponentKind as Primitive;
 
-impl Primitive {
-    /// Every primitive in stable contract order.
-    pub const ALL: [Self; 62] = [
-        Self::Region,
-        Self::Stack,
-        Self::Grid,
-        Self::Split,
-        Self::Sidebar,
-        Self::ActionBar,
-        Self::Card,
-        Self::Group,
-        Self::Collapse,
-        Self::Repeater,
-        Self::ScrollRegion,
-        Self::Divider,
-        Self::Heading,
-        Self::Text,
-        Self::InlineContent,
-        Self::CodeBlock,
-        Self::Badge,
-        Self::KeyFigure,
-        Self::EmptyState,
-        Self::Icon,
-        Self::Button,
-        Self::TextField,
-        Self::TextArea,
-        Self::NumberField,
-        Self::Select,
-        Self::MultiSelect,
-        Self::Switch,
-        Self::Checkbox,
-        Self::Slider,
-        Self::DateTimeField,
-        Self::Table,
-        Self::RecordSummary,
-        Self::DatasetChart,
-        Self::Timeline,
-        Self::Difference,
-        Self::Progress,
-        Self::Tabs,
-        Self::Breadcrumb,
-        Self::Menu,
-        Self::Pager,
-        Self::Link,
-        Self::Alert,
-        Self::Toast,
-        Self::InlineMessage,
-        Self::Skeleton,
-        Self::Spinner,
-        Self::StatusDot,
-        Self::Dialog,
-        Self::CapabilityCard,
-        Self::ConsentForm,
-        Self::SecurePrompt,
-        Self::FilePicker,
-        Self::ImageView,
-        Self::AudioPlayer,
-        Self::VideoPlayer,
-        Self::FileDetails,
-        Self::MediaEmbed,
-        Self::CanvasStage,
-        Self::DiagramView,
-        Self::AnnotationLayer,
-        Self::TerminalView,
-        Self::NativePortal,
-    ];
-
-    /// Stable string identity.
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Region => "Region",
-            Self::Stack => "Stack",
-            Self::Grid => "Grid",
-            Self::Split => "Split",
-            Self::Sidebar => "Sidebar",
-            Self::ActionBar => "ActionBar",
-            Self::Card => "Card",
-            Self::Group => "Group",
-            Self::Collapse => "Collapse",
-            Self::Repeater => "Repeater",
-            Self::ScrollRegion => "ScrollRegion",
-            Self::Divider => "Divider",
-            Self::Heading => "Heading",
-            Self::Text => "Text",
-            Self::InlineContent => "InlineContent",
-            Self::CodeBlock => "CodeBlock",
-            Self::Badge => "Badge",
-            Self::KeyFigure => "KeyFigure",
-            Self::EmptyState => "EmptyState",
-            Self::Icon => "Icon",
-            Self::Button => "Button",
-            Self::TextField => "TextField",
-            Self::TextArea => "TextArea",
-            Self::NumberField => "NumberField",
-            Self::Select => "Select",
-            Self::MultiSelect => "MultiSelect",
-            Self::Switch => "Switch",
-            Self::Checkbox => "Checkbox",
-            Self::Slider => "Slider",
-            Self::DateTimeField => "DateTimeField",
-            Self::Table => "Table",
-            Self::RecordSummary => "RecordSummary",
-            Self::DatasetChart => "DatasetChart",
-            Self::Timeline => "Timeline",
-            Self::Difference => "Difference",
-            Self::Progress => "Progress",
-            Self::Tabs => "Tabs",
-            Self::Breadcrumb => "Breadcrumb",
-            Self::Menu => "Menu",
-            Self::Pager => "Pager",
-            Self::Link => "Link",
-            Self::Alert => "Alert",
-            Self::Toast => "Toast",
-            Self::InlineMessage => "InlineMessage",
-            Self::Skeleton => "Skeleton",
-            Self::Spinner => "Spinner",
-            Self::StatusDot => "StatusDot",
-            Self::Dialog => "Dialog",
-            Self::CapabilityCard => "CapabilityCard",
-            Self::ConsentForm => "ConsentForm",
-            Self::SecurePrompt => "SecurePrompt",
-            Self::FilePicker => "FilePicker",
-            Self::ImageView => "ImageView",
-            Self::AudioPlayer => "AudioPlayer",
-            Self::VideoPlayer => "VideoPlayer",
-            Self::FileDetails => "FileDetails",
-            Self::MediaEmbed => "MediaEmbed",
-            Self::CanvasStage => "CanvasStage",
-            Self::DiagramView => "DiagramView",
-            Self::AnnotationLayer => "AnnotationLayer",
-            Self::TerminalView => "TerminalView",
-            Self::NativePortal => "NativePortal",
-        }
-    }
-
-    /// Parse the stable string identity without accepting extensions.
-    pub fn from_id(value: &str) -> Option<Self> {
-        Self::ALL
+/// Catalog-owned behavior layered on the canonical component identity.
+pub trait CatalogPrimitive: Copy + Eq + Into<ComponentKind> + From<ComponentKind> {
+    /// Parse an unnamespaced canonical identity; extensions are rejected.
+    fn from_id(value: &str) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        ComponentKind::ALL
             .iter()
             .copied()
-            .find(|kind| kind.as_str() == value)
+            .find(|kind| {
+                serde_json::to_string(kind)
+                    .is_ok_and(|serialized| serialized.trim_matches('"') == value)
+            })
+            .map(Self::from)
     }
 
-    /// Coarse semantic family.
-    pub const fn family(self) -> PrimitiveFamily {
+    /// Public issue-family name mapped by this catalog.
+    fn catalog_family(self) -> PrimitiveFamily;
+
+    /// Whether presentation can create authority.
+    fn mints_capability(self) -> bool {
+        false
+    }
+
+    /// States that a complete record and Lab corpus must document.
+    fn required_states(self) -> Vec<State> {
+        let interaction = vec![
+            State::Default,
+            State::Hover,
+            State::Pressed,
+            State::FocusVisible,
+            State::Disabled,
+        ];
+        let kind: ComponentKind = self.into();
+        match kind.catalog_family() {
+            PrimitiveFamily::Layout => {
+                if kind == ComponentKind::Repeater {
+                    vec![
+                        State::Default,
+                        State::FocusVisible,
+                        State::Disabled,
+                        State::Loading,
+                        State::Empty,
+                    ]
+                } else if matches!(kind, ComponentKind::ActionBar | ComponentKind::Collapse) {
+                    vec![State::Default, State::FocusVisible, State::Disabled]
+                } else {
+                    vec![State::Default]
+                }
+            }
+            PrimitiveFamily::Content => {
+                if matches!(
+                    kind,
+                    ComponentKind::Badge | ComponentKind::KeyFigure | ComponentKind::EmptyState
+                ) {
+                    vec![State::Default, State::FocusVisible, State::Disabled]
+                } else {
+                    vec![State::Default]
+                }
+            }
+            PrimitiveFamily::Input => interaction,
+            PrimitiveFamily::Data => {
+                let mut states = vec![State::Default, State::FocusVisible, State::Disabled];
+                if matches!(
+                    kind,
+                    ComponentKind::EmptyState
+                        | ComponentKind::Table
+                        | ComponentKind::DatasetChart
+                        | ComponentKind::Progress
+                ) {
+                    states.extend([State::Loading, State::Empty]);
+                }
+                states
+            }
+            PrimitiveFamily::Navigation => {
+                vec![State::Default, State::FocusVisible, State::Disabled]
+            }
+            PrimitiveFamily::Feedback => {
+                if matches!(
+                    kind,
+                    ComponentKind::Skeleton | ComponentKind::Spinner | ComponentKind::StatusDot
+                ) {
+                    vec![State::Default, State::Loading]
+                } else {
+                    vec![
+                        State::Default,
+                        State::FocusVisible,
+                        State::Disabled,
+                        State::Success,
+                        State::Warning,
+                        State::Danger,
+                    ]
+                }
+            }
+            PrimitiveFamily::Permission => vec![
+                State::Default,
+                State::FocusVisible,
+                State::Disabled,
+                State::Loading,
+                State::Error,
+            ],
+            PrimitiveFamily::Media | PrimitiveFamily::Canvas => vec![
+                State::Default,
+                State::FocusVisible,
+                State::Loading,
+                State::Empty,
+                State::Error,
+            ],
+            PrimitiveFamily::Terminal => vec![
+                State::Default,
+                State::FocusVisible,
+                State::Loading,
+                State::Error,
+            ],
+            PrimitiveFamily::NativePortal => {
+                vec![State::Default, State::Loading, State::Empty, State::Error]
+            }
+        }
+    }
+}
+
+impl CatalogPrimitive for ComponentKind {
+    fn catalog_family(self) -> PrimitiveFamily {
         match self {
             Self::Region
             | Self::Stack
@@ -346,124 +199,6 @@ impl Primitive {
             Self::TerminalView => PrimitiveFamily::Terminal,
             Self::NativePortal => PrimitiveFamily::NativePortal,
         }
-    }
-
-    /// Whether presentation of this primitive can create authority.
-    pub const fn mints_capability(self) -> bool {
-        false
-    }
-
-    /// States that a complete record and Lab corpus must document.
-    pub fn required_states(self) -> Vec<State> {
-        let interaction = [
-            State::Default,
-            State::Hover,
-            State::Pressed,
-            State::FocusVisible,
-            State::Disabled,
-        ];
-        let status = [State::Default, State::Loading, State::Empty, State::Error];
-        match self {
-            Self::Region
-            | Self::Stack
-            | Self::Grid
-            | Self::Split
-            | Self::Sidebar
-            | Self::Card
-            | Self::Group
-            | Self::ScrollRegion
-            | Self::Heading
-            | Self::Text
-            | Self::InlineContent
-            | Self::CodeBlock
-            | Self::Icon => vec![State::Default],
-            Self::ActionBar
-            | Self::Collapse
-            | Self::Repeater
-            | Self::Divider
-            | Self::Badge
-            | Self::KeyFigure
-            | Self::EmptyState
-            | Self::Table
-            | Self::RecordSummary
-            | Self::DatasetChart
-            | Self::Timeline
-            | Self::Difference
-            | Self::Progress
-            | Self::Tabs
-            | Self::Breadcrumb
-            | Self::Menu
-            | Self::Pager
-            | Self::Link => {
-                let mut states = vec![State::Default, State::FocusVisible, State::Disabled];
-                if matches!(
-                    self,
-                    Self::Repeater
-                        | Self::EmptyState
-                        | Self::Table
-                        | Self::DatasetChart
-                        | Self::Progress
-                ) {
-                    states.extend([State::Loading, State::Empty]);
-                }
-                states
-            }
-            Self::Button
-            | Self::TextField
-            | Self::TextArea
-            | Self::NumberField
-            | Self::Select
-            | Self::MultiSelect
-            | Self::Switch
-            | Self::Checkbox
-            | Self::Slider
-            | Self::DateTimeField => interaction.to_vec(),
-            Self::Alert | Self::Toast | Self::InlineMessage | Self::Dialog => vec![
-                State::Default,
-                State::FocusVisible,
-                State::Disabled,
-                State::Success,
-                State::Warning,
-                State::Danger,
-            ],
-            Self::Skeleton | Self::Spinner | Self::StatusDot => {
-                vec![State::Default, State::Loading]
-            }
-            Self::CapabilityCard | Self::ConsentForm | Self::SecurePrompt | Self::FilePicker => {
-                vec![
-                    State::Default,
-                    State::FocusVisible,
-                    State::Disabled,
-                    State::Loading,
-                    State::Error,
-                ]
-            }
-            Self::ImageView
-            | Self::AudioPlayer
-            | Self::VideoPlayer
-            | Self::FileDetails
-            | Self::MediaEmbed
-            | Self::CanvasStage
-            | Self::DiagramView
-            | Self::AnnotationLayer => {
-                let mut states = vec![State::Default, State::FocusVisible];
-                states.extend(status[1..].iter().copied());
-                states
-            }
-            Self::TerminalView => vec![
-                State::Default,
-                State::FocusVisible,
-                State::Loading,
-                State::Error,
-            ],
-            Self::NativePortal => vec![State::Default, State::Loading, State::Empty, State::Error],
-        }
-    }
-}
-
-impl fmt::Display for Primitive {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(self.as_str())
     }
 }
 
@@ -622,7 +357,7 @@ impl Catalog {
     pub fn v1() -> Self {
         Self {
             schema: CATALOG_SCHEMA.to_owned(),
-            records: Primitive::ALL
+            records: ComponentKind::ALL
                 .into_iter()
                 .map(PrimitiveRecord::for_primitive)
                 .collect(),
@@ -637,7 +372,7 @@ impl Catalog {
         if self.records.len() != 62 {
             return Err(CatalogError::PrimitiveCount);
         }
-        let expected: Vec<_> = Primitive::ALL.into_iter().collect();
+        let expected: Vec<_> = ComponentKind::ALL.into_iter().collect();
         let actual: Vec<_> = self.records.iter().map(|record| record.id).collect();
         if actual != expected {
             return Err(CatalogError::PrimitiveOrder);
@@ -657,7 +392,7 @@ impl Catalog {
 impl PrimitiveRecord {
     /// Build the normative record for a v1 primitive.
     pub fn for_primitive(id: Primitive) -> Self {
-        let family = id.family();
+        let family = id.catalog_family();
         let (semantic_role, accessibility, focus, native, motion, fallback) = match family {
             PrimitiveFamily::Layout => (
                 "layout container",
@@ -926,79 +661,15 @@ fn bounded_text(value: &str) -> bool {
 mod tests {
     use super::*;
 
-    const EXPECTED: [Primitive; 62] = Primitive::ALL;
-
     #[test]
-    fn owns_the_exact_v1_inventory() {
-        let expected_names = [
-            "Region",
-            "Stack",
-            "Grid",
-            "Split",
-            "Sidebar",
-            "ActionBar",
-            "Card",
-            "Group",
-            "Collapse",
-            "Repeater",
-            "ScrollRegion",
-            "Divider",
-            "Heading",
-            "Text",
-            "InlineContent",
-            "CodeBlock",
-            "Badge",
-            "KeyFigure",
-            "EmptyState",
-            "Icon",
-            "Button",
-            "TextField",
-            "TextArea",
-            "NumberField",
-            "Select",
-            "MultiSelect",
-            "Switch",
-            "Checkbox",
-            "Slider",
-            "DateTimeField",
-            "Table",
-            "RecordSummary",
-            "DatasetChart",
-            "Timeline",
-            "Difference",
-            "Progress",
-            "Tabs",
-            "Breadcrumb",
-            "Menu",
-            "Pager",
-            "Link",
-            "Alert",
-            "Toast",
-            "InlineMessage",
-            "Skeleton",
-            "Spinner",
-            "StatusDot",
-            "Dialog",
-            "CapabilityCard",
-            "ConsentForm",
-            "SecurePrompt",
-            "FilePicker",
-            "ImageView",
-            "AudioPlayer",
-            "VideoPlayer",
-            "FileDetails",
-            "MediaEmbed",
-            "CanvasStage",
-            "DiagramView",
-            "AnnotationLayer",
-            "TerminalView",
-            "NativePortal",
-        ];
-        assert_eq!(EXPECTED.len(), 62);
-        assert_eq!(expected_names.len(), 62);
-        for (primitive, name) in Primitive::ALL.into_iter().zip(expected_names) {
-            assert_eq!(primitive.as_str(), name);
-        }
+    fn consumes_component_kind_all_exactly_once() {
+        let catalog = Catalog::v1();
+        let actual: Vec<ComponentKind> = catalog.records.iter().map(|record| record.id).collect();
+        assert_eq!(actual, ComponentKind::ALL.to_vec());
+        assert_eq!(
+            actual.iter().collect::<BTreeSet<_>>().len(),
+            ComponentKind::ALL.len()
+        );
     }
 
     #[test]

--- a/capsules/capsule-surface-catalog/src/catalog.rs
+++ b/capsules/capsule-surface-catalog/src/catalog.rs
@@ -1,0 +1,1028 @@
+//! The finite `aos.catalog/1` primitive inventory and record validator.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fmt;
+
+/// Stable catalog contract identity.
+pub const CATALOG_SCHEMA: &str = "aos.catalog/1";
+
+const MAX_TEXT_BYTES: usize = 320;
+const MAX_SLOTS: usize = 8;
+
+/// Every v1 primitive in the exact stable order owned by this capsule.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum Primitive {
+    /// A named semantic region.
+    Region,
+    /// An ordered vertical or horizontal stack.
+    Stack,
+    /// A grid of semantic children.
+    Grid,
+    /// A resizable split.
+    Split,
+    /// Navigation sidebar.
+    Sidebar,
+    /// A row of semantic actions.
+    ActionBar,
+    /// Framed content card.
+    Card,
+    /// Preference or content group.
+    Group,
+    /// Collapsible content.
+    Collapse,
+    /// Repeated bounded children.
+    Repeater,
+    /// Scrollable semantic region.
+    ScrollRegion,
+    /// A semantic divider.
+    Divider,
+    /// A heading.
+    Heading,
+    /// Body or inline text.
+    Text,
+    /// Inline rich content.
+    InlineContent,
+    /// Source or code text.
+    CodeBlock,
+    /// Compact label.
+    Badge,
+    /// Prominent numeric fact.
+    KeyFigure,
+    /// Empty-result explanation.
+    EmptyState,
+    /// A named icon.
+    Icon,
+    /// An action control; icon-only controls use the icon slot.
+    Button,
+    /// Single-line text entry.
+    TextField,
+    /// Multi-line text entry.
+    TextArea,
+    /// Numeric entry.
+    NumberField,
+    /// Single selection.
+    Select,
+    /// Multiple selection.
+    MultiSelect,
+    /// Boolean switch.
+    Switch,
+    /// Boolean checkbox.
+    Checkbox,
+    /// Bounded range input.
+    Slider,
+    /// Date or time entry.
+    DateTimeField,
+    /// Tabular data.
+    Table,
+    /// Concise record summary.
+    RecordSummary,
+    /// Data chart with a textual equivalent.
+    DatasetChart,
+    /// Ordered events.
+    Timeline,
+    /// Before-and-after difference.
+    Difference,
+    /// Progress indicator.
+    Progress,
+    /// Tab navigation.
+    Tabs,
+    /// Hierarchical navigation.
+    Breadcrumb,
+    /// Context menu.
+    Menu,
+    /// Page navigation.
+    Pager,
+    /// A semantic link.
+    Link,
+    /// Important non-blocking alert.
+    Alert,
+    /// Temporary notification.
+    Toast,
+    /// Inline feedback.
+    InlineMessage,
+    /// Loading placeholder.
+    Skeleton,
+    /// Busy indicator.
+    Spinner,
+    /// Small status indicator.
+    StatusDot,
+    /// Modal dialog.
+    Dialog,
+    /// Capability description, never a grant.
+    CapabilityCard,
+    /// Consent request, never consent itself.
+    ConsentForm,
+    /// Deliberate secure-input prompt.
+    SecurePrompt,
+    /// Governed file-selection request.
+    FilePicker,
+    /// Image media.
+    ImageView,
+    /// Audio media.
+    AudioPlayer,
+    /// Video media.
+    VideoPlayer,
+    /// File metadata.
+    FileDetails,
+    /// Typed principal-scoped media reference.
+    MediaEmbed,
+    /// Free-form drawing stage.
+    CanvasStage,
+    /// Diagram surface.
+    DiagramView,
+    /// Annotation layer.
+    AnnotationLayer,
+    /// Presentation of a bound terminal session.
+    TerminalView,
+    /// Presentation of external portal state.
+    NativePortal,
+}
+
+impl Primitive {
+    /// Every primitive in stable contract order.
+    pub const ALL: [Self; 62] = [
+        Self::Region,
+        Self::Stack,
+        Self::Grid,
+        Self::Split,
+        Self::Sidebar,
+        Self::ActionBar,
+        Self::Card,
+        Self::Group,
+        Self::Collapse,
+        Self::Repeater,
+        Self::ScrollRegion,
+        Self::Divider,
+        Self::Heading,
+        Self::Text,
+        Self::InlineContent,
+        Self::CodeBlock,
+        Self::Badge,
+        Self::KeyFigure,
+        Self::EmptyState,
+        Self::Icon,
+        Self::Button,
+        Self::TextField,
+        Self::TextArea,
+        Self::NumberField,
+        Self::Select,
+        Self::MultiSelect,
+        Self::Switch,
+        Self::Checkbox,
+        Self::Slider,
+        Self::DateTimeField,
+        Self::Table,
+        Self::RecordSummary,
+        Self::DatasetChart,
+        Self::Timeline,
+        Self::Difference,
+        Self::Progress,
+        Self::Tabs,
+        Self::Breadcrumb,
+        Self::Menu,
+        Self::Pager,
+        Self::Link,
+        Self::Alert,
+        Self::Toast,
+        Self::InlineMessage,
+        Self::Skeleton,
+        Self::Spinner,
+        Self::StatusDot,
+        Self::Dialog,
+        Self::CapabilityCard,
+        Self::ConsentForm,
+        Self::SecurePrompt,
+        Self::FilePicker,
+        Self::ImageView,
+        Self::AudioPlayer,
+        Self::VideoPlayer,
+        Self::FileDetails,
+        Self::MediaEmbed,
+        Self::CanvasStage,
+        Self::DiagramView,
+        Self::AnnotationLayer,
+        Self::TerminalView,
+        Self::NativePortal,
+    ];
+
+    /// Stable string identity.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Region => "Region",
+            Self::Stack => "Stack",
+            Self::Grid => "Grid",
+            Self::Split => "Split",
+            Self::Sidebar => "Sidebar",
+            Self::ActionBar => "ActionBar",
+            Self::Card => "Card",
+            Self::Group => "Group",
+            Self::Collapse => "Collapse",
+            Self::Repeater => "Repeater",
+            Self::ScrollRegion => "ScrollRegion",
+            Self::Divider => "Divider",
+            Self::Heading => "Heading",
+            Self::Text => "Text",
+            Self::InlineContent => "InlineContent",
+            Self::CodeBlock => "CodeBlock",
+            Self::Badge => "Badge",
+            Self::KeyFigure => "KeyFigure",
+            Self::EmptyState => "EmptyState",
+            Self::Icon => "Icon",
+            Self::Button => "Button",
+            Self::TextField => "TextField",
+            Self::TextArea => "TextArea",
+            Self::NumberField => "NumberField",
+            Self::Select => "Select",
+            Self::MultiSelect => "MultiSelect",
+            Self::Switch => "Switch",
+            Self::Checkbox => "Checkbox",
+            Self::Slider => "Slider",
+            Self::DateTimeField => "DateTimeField",
+            Self::Table => "Table",
+            Self::RecordSummary => "RecordSummary",
+            Self::DatasetChart => "DatasetChart",
+            Self::Timeline => "Timeline",
+            Self::Difference => "Difference",
+            Self::Progress => "Progress",
+            Self::Tabs => "Tabs",
+            Self::Breadcrumb => "Breadcrumb",
+            Self::Menu => "Menu",
+            Self::Pager => "Pager",
+            Self::Link => "Link",
+            Self::Alert => "Alert",
+            Self::Toast => "Toast",
+            Self::InlineMessage => "InlineMessage",
+            Self::Skeleton => "Skeleton",
+            Self::Spinner => "Spinner",
+            Self::StatusDot => "StatusDot",
+            Self::Dialog => "Dialog",
+            Self::CapabilityCard => "CapabilityCard",
+            Self::ConsentForm => "ConsentForm",
+            Self::SecurePrompt => "SecurePrompt",
+            Self::FilePicker => "FilePicker",
+            Self::ImageView => "ImageView",
+            Self::AudioPlayer => "AudioPlayer",
+            Self::VideoPlayer => "VideoPlayer",
+            Self::FileDetails => "FileDetails",
+            Self::MediaEmbed => "MediaEmbed",
+            Self::CanvasStage => "CanvasStage",
+            Self::DiagramView => "DiagramView",
+            Self::AnnotationLayer => "AnnotationLayer",
+            Self::TerminalView => "TerminalView",
+            Self::NativePortal => "NativePortal",
+        }
+    }
+
+    /// Parse the stable string identity without accepting extensions.
+    pub fn from_id(value: &str) -> Option<Self> {
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|kind| kind.as_str() == value)
+    }
+
+    /// Coarse semantic family.
+    pub const fn family(self) -> PrimitiveFamily {
+        match self {
+            Self::Region
+            | Self::Stack
+            | Self::Grid
+            | Self::Split
+            | Self::Sidebar
+            | Self::ActionBar
+            | Self::Card
+            | Self::Group
+            | Self::Collapse
+            | Self::Repeater
+            | Self::ScrollRegion
+            | Self::Divider => PrimitiveFamily::Layout,
+            Self::Heading
+            | Self::Text
+            | Self::InlineContent
+            | Self::CodeBlock
+            | Self::Badge
+            | Self::KeyFigure
+            | Self::EmptyState
+            | Self::Icon => PrimitiveFamily::Content,
+            Self::Button
+            | Self::TextField
+            | Self::TextArea
+            | Self::NumberField
+            | Self::Select
+            | Self::MultiSelect
+            | Self::Switch
+            | Self::Checkbox
+            | Self::Slider
+            | Self::DateTimeField => PrimitiveFamily::Input,
+            Self::Table
+            | Self::RecordSummary
+            | Self::DatasetChart
+            | Self::Timeline
+            | Self::Difference
+            | Self::Progress => PrimitiveFamily::Data,
+            Self::Tabs | Self::Breadcrumb | Self::Menu | Self::Pager | Self::Link => {
+                PrimitiveFamily::Navigation
+            }
+            Self::Alert
+            | Self::Toast
+            | Self::InlineMessage
+            | Self::Skeleton
+            | Self::Spinner
+            | Self::StatusDot
+            | Self::Dialog => PrimitiveFamily::Feedback,
+            Self::CapabilityCard | Self::ConsentForm | Self::SecurePrompt | Self::FilePicker => {
+                PrimitiveFamily::Permission
+            }
+            Self::ImageView
+            | Self::AudioPlayer
+            | Self::VideoPlayer
+            | Self::FileDetails
+            | Self::MediaEmbed => PrimitiveFamily::Media,
+            Self::CanvasStage | Self::DiagramView | Self::AnnotationLayer => {
+                PrimitiveFamily::Canvas
+            }
+            Self::TerminalView => PrimitiveFamily::Terminal,
+            Self::NativePortal => PrimitiveFamily::NativePortal,
+        }
+    }
+
+    /// Whether presentation of this primitive can create authority.
+    pub const fn mints_capability(self) -> bool {
+        false
+    }
+
+    /// States that a complete record and Lab corpus must document.
+    pub fn required_states(self) -> Vec<State> {
+        let interaction = [
+            State::Default,
+            State::Hover,
+            State::Pressed,
+            State::FocusVisible,
+            State::Disabled,
+        ];
+        let status = [State::Default, State::Loading, State::Empty, State::Error];
+        match self {
+            Self::Region
+            | Self::Stack
+            | Self::Grid
+            | Self::Split
+            | Self::Sidebar
+            | Self::Card
+            | Self::Group
+            | Self::ScrollRegion
+            | Self::Heading
+            | Self::Text
+            | Self::InlineContent
+            | Self::CodeBlock
+            | Self::Icon => vec![State::Default],
+            Self::ActionBar
+            | Self::Collapse
+            | Self::Repeater
+            | Self::Divider
+            | Self::Badge
+            | Self::KeyFigure
+            | Self::EmptyState
+            | Self::Table
+            | Self::RecordSummary
+            | Self::DatasetChart
+            | Self::Timeline
+            | Self::Difference
+            | Self::Progress
+            | Self::Tabs
+            | Self::Breadcrumb
+            | Self::Menu
+            | Self::Pager
+            | Self::Link => {
+                let mut states = vec![State::Default, State::FocusVisible, State::Disabled];
+                if matches!(
+                    self,
+                    Self::Repeater
+                        | Self::EmptyState
+                        | Self::Table
+                        | Self::DatasetChart
+                        | Self::Progress
+                ) {
+                    states.extend([State::Loading, State::Empty]);
+                }
+                states
+            }
+            Self::Button
+            | Self::TextField
+            | Self::TextArea
+            | Self::NumberField
+            | Self::Select
+            | Self::MultiSelect
+            | Self::Switch
+            | Self::Checkbox
+            | Self::Slider
+            | Self::DateTimeField => interaction.to_vec(),
+            Self::Alert | Self::Toast | Self::InlineMessage | Self::Dialog => vec![
+                State::Default,
+                State::FocusVisible,
+                State::Disabled,
+                State::Success,
+                State::Warning,
+                State::Danger,
+            ],
+            Self::Skeleton | Self::Spinner | Self::StatusDot => {
+                vec![State::Default, State::Loading]
+            }
+            Self::CapabilityCard | Self::ConsentForm | Self::SecurePrompt | Self::FilePicker => {
+                vec![
+                    State::Default,
+                    State::FocusVisible,
+                    State::Disabled,
+                    State::Loading,
+                    State::Error,
+                ]
+            }
+            Self::ImageView
+            | Self::AudioPlayer
+            | Self::VideoPlayer
+            | Self::FileDetails
+            | Self::MediaEmbed
+            | Self::CanvasStage
+            | Self::DiagramView
+            | Self::AnnotationLayer => {
+                let mut states = vec![State::Default, State::FocusVisible];
+                states.extend(status[1..].iter().copied());
+                states
+            }
+            Self::TerminalView => vec![
+                State::Default,
+                State::FocusVisible,
+                State::Loading,
+                State::Error,
+            ],
+            Self::NativePortal => vec![State::Default, State::Loading, State::Empty, State::Error],
+        }
+    }
+}
+
+impl fmt::Display for Primitive {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Coarse owned family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PrimitiveFamily {
+    /// Layout primitives.
+    Layout,
+    /// Content primitives.
+    Content,
+    /// Input controls.
+    Input,
+    /// Data presentation.
+    Data,
+    /// Navigation controls.
+    Navigation,
+    /// Feedback surfaces.
+    Feedback,
+    /// Authority-request visualizations.
+    Permission,
+    /// Media references.
+    Media,
+    /// Canvas surfaces.
+    Canvas,
+    /// Bound terminal presentation.
+    Terminal,
+    /// External portal presentation.
+    NativePortal,
+}
+
+/// Declared child and slot policy.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum ChildrenPolicy {
+    /// The primitive owns no children or slots.
+    None,
+    /// A finite set of named slots.
+    ClosedSlots {
+        /// Allowed slot identifiers.
+        slots: Vec<String>,
+    },
+    /// A bounded sequence of ordinary catalog children.
+    BoundedChildren {
+        /// Human-readable child role.
+        child_role: String,
+        /// Inclusive minimum.
+        minimum: u8,
+        /// Inclusive maximum.
+        maximum: u8,
+    },
+}
+
+/// Semantic interaction state.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum State {
+    /// Resting presentation.
+    Default,
+    /// Pointer hover.
+    Hover,
+    /// Active press.
+    Pressed,
+    /// Keyboard-originated focus indicator.
+    FocusVisible,
+    /// Noninteractive or unavailable.
+    Disabled,
+    /// Work is pending.
+    Loading,
+    /// No content is available.
+    Empty,
+    /// A recoverable failure.
+    Error,
+    /// Positive completion.
+    Success,
+    /// Cautionary status.
+    Warning,
+    /// Severe status.
+    Danger,
+    /// Chosen item.
+    Selected,
+}
+
+/// One complete v1 primitive record.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PrimitiveRecord {
+    /// Stable primitive identity.
+    pub id: Primitive,
+    /// Stable semantic role.
+    pub semantic_role: String,
+    /// Allowed children or slots.
+    pub children: ChildrenPolicy,
+    /// Required accessibility naming strategy.
+    pub accessibility_label_strategy: String,
+    /// Required state set.
+    pub states: BTreeSet<State>,
+    /// Density behavior expressed on the semantic scale.
+    pub density_behavior: String,
+    /// Compact phone adaptation.
+    pub phone_adaptation: String,
+    /// Desktop adaptation.
+    pub desktop_adaptation: String,
+    /// Native semantic mapping.
+    pub native_mapping: String,
+    /// Focus and keyboard contract.
+    pub focus_keyboard_contract: String,
+    /// Motion contract.
+    pub motion_contract: String,
+    /// Safe presentation fallback.
+    pub fallback_rendering: String,
+}
+
+/// Catalog validation failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CatalogError {
+    /// Contract identity was not exactly `aos.catalog/1`.
+    Schema,
+    /// The v1 inventory count was not exactly 62.
+    PrimitiveCount,
+    /// The records were absent, reordered, or duplicated.
+    PrimitiveOrder,
+    /// A required semantic field was empty or oversized.
+    RecordField,
+    /// A closed child contract had no slot or exceeded the slot bound.
+    ChildrenPolicy,
+}
+
+impl fmt::Display for CatalogError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::Schema => "catalog schema must be aos.catalog/1",
+            Self::PrimitiveCount => "catalog must own exactly 62 v1 primitives",
+            Self::PrimitiveOrder => "catalog records must equal the stable v1 inventory",
+            Self::RecordField => "catalog record has an invalid semantic field",
+            Self::ChildrenPolicy => "catalog record has an invalid child policy",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for CatalogError {}
+
+/// Canonical v1 catalog.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Catalog {
+    /// Stable contract identity.
+    pub schema: String,
+    /// One record per v1 primitive.
+    pub records: Vec<PrimitiveRecord>,
+}
+
+impl Catalog {
+    /// Construct the canonical catalog.
+    pub fn v1() -> Self {
+        Self {
+            schema: CATALOG_SCHEMA.to_owned(),
+            records: Primitive::ALL
+                .into_iter()
+                .map(PrimitiveRecord::for_primitive)
+                .collect(),
+        }
+    }
+
+    /// Validate exact v1 identity, inventory, order, and record completeness.
+    pub fn validate(&self) -> Result<(), CatalogError> {
+        if self.schema != CATALOG_SCHEMA {
+            return Err(CatalogError::Schema);
+        }
+        if self.records.len() != 62 {
+            return Err(CatalogError::PrimitiveCount);
+        }
+        let expected: Vec<_> = Primitive::ALL.into_iter().collect();
+        let actual: Vec<_> = self.records.iter().map(|record| record.id).collect();
+        if actual != expected {
+            return Err(CatalogError::PrimitiveOrder);
+        }
+        self.records
+            .iter()
+            .try_for_each(PrimitiveRecord::validate)?;
+        Ok(())
+    }
+
+    /// Look up a record by primitive identity.
+    pub fn record(&self, id: Primitive) -> Option<&PrimitiveRecord> {
+        self.records.iter().find(|record| record.id == id)
+    }
+}
+
+impl PrimitiveRecord {
+    /// Build the normative record for a v1 primitive.
+    pub fn for_primitive(id: Primitive) -> Self {
+        let family = id.family();
+        let (semantic_role, accessibility, focus, native, motion, fallback) = match family {
+            PrimitiveFamily::Layout => (
+                "layout container",
+                "name a region that changes reading order; otherwise inherit the nearest named ancestor",
+                "children manage focus; the container is not a tab stop unless explicitly scrollable",
+                "map to the host composition container",
+                "inherit reduced-motion policy; never animate layout autonomously",
+                "render children in source order with default block layout",
+            ),
+            PrimitiveFamily::Content => (
+                "content presentation",
+                "use authored text as the accessible name; icons require an explicit text alternative",
+                "selectable or link-like content may receive keyboard focus; ordinary text does not",
+                "map to platform text or static-image semantics",
+                "use opacity transitions only and suppress them when reduced motion is requested",
+                "render plain text or descriptive metadata without replacing semantic content",
+            ),
+            PrimitiveFamily::Input => (
+                "input control",
+                "require an explicit programmatic label even when a visible label is absent",
+                "make the control focusable and document Enter, Space, arrows, or Escape behavior",
+                "map to the platform semantic control",
+                "suppress value-change motion and use instant feedback when reduced motion is requested",
+                "render the current value and label as read-only text with actions unavailable",
+            ),
+            PrimitiveFamily::Data => (
+                "data presentation",
+                "supply a concise programmatic name and text equivalent for the represented facts",
+                "make row, tab, or summary interaction reachable in reading order",
+                "map to platform list, table, image, or progress semantics with text alternatives",
+                "respect reduced motion for transitions and provide a static final state",
+                "render a bounded textual summary or empty-state explanation",
+            ),
+            PrimitiveFamily::Navigation => (
+                "navigation control",
+                "require a destination or section name distinct from surrounding text",
+                "use roving or sequential keyboard traversal appropriate to the control and Enter activation",
+                "map to platform navigation or link semantics",
+                "use short transition only and set it to zero when reduced motion is requested",
+                "render readable links or a flat list without performing navigation",
+            ),
+            PrimitiveFamily::Feedback => (
+                "feedback presentation",
+                "announce meaningful state with a programmatic name and concise live message",
+                "make dismiss or acknowledgment controls reachable and Escape-close modal feedback",
+                "map to platform alert, progress, dialog, or static-indicator semantics",
+                "respect reduced motion; essential state changes remain visible without movement",
+                "render static state text and keep dismissal unavailable rather than losing the message",
+            ),
+            PrimitiveFamily::Permission => (
+                "authority request visualization",
+                "name the requested scope and state that presentation is not approval",
+                "make every affordance keyboard reachable; record explicit activation as a request",
+                "map to static semantic content and route the request through policy, never presentation",
+                "suppress attention motion under reduced motion and preserve the full request text",
+                "render a read-only explanation and mark request actions unavailable",
+            ),
+            PrimitiveFamily::Media => (
+                "media reference",
+                "require alt text, transcript, title, or typed metadata before presentation",
+                "make transport controls keyboard operable; metadata-only media need not be focusable",
+                "map to platform media or static metadata semantics without arbitrary execution",
+                "respect reduced motion and never autoplay moving or sounding media",
+                "render typed metadata, alt text, or transcript without invoking the media reference",
+            ),
+            PrimitiveFamily::Canvas => (
+                "authorable visual surface",
+                "supply a programmatic name and nonvisual equivalent or annotation",
+                "make tools and annotations keyboard reachable and trap pointer drawing only to the stage",
+                "map to an opaque drawing or diagram view with an accessibility layer",
+                "scale redraw motion to density and honor reduced motion with final-frame rendering",
+                "render title, annotations, or textual equivalent without arbitrary stage execution",
+            ),
+            PrimitiveFamily::Terminal => (
+                "bound terminal session presentation",
+                "name the bound session and summarize its state; presentation is not a shell",
+                "support focus, arrow scrolling, copy shortcuts, and no command entry from this view",
+                "map to a read-only or bound-session native view supplied by policy",
+                "avoid scroll animation and respect reduced motion",
+                "render bounded session metadata and status without starting or sending a command",
+            ),
+            PrimitiveFamily::NativePortal => (
+                "native portal presentation",
+                "name the portal contract and display explicit unavailable or loaded state",
+                "treat embedded controls as unavailable until a policy-approved native adapter owns them",
+                "present portal state only; live native control remains outside this catalog",
+                "show deterministic state changes without autonomous motion",
+                "render a neutral unavailable state and preserve the declared portal identity",
+            ),
+        };
+        let density = match family {
+            PrimitiveFamily::Layout => {
+                "compress spacing ratios on compact density and expand ratios on spacious density"
+            }
+            PrimitiveFamily::Content => {
+                "scale typography by bounded ratios while preserving reading measure"
+            }
+            PrimitiveFamily::Input => {
+                "preserve bounded minimum target height and adjust padding only"
+            }
+            PrimitiveFamily::Data => {
+                "reduce row and column padding before truncating semantic text"
+            }
+            PrimitiveFamily::Navigation => {
+                "keep reachable target height and collapse secondary labels on phone"
+            }
+            PrimitiveFamily::Feedback => "adjust padding and text scale without hiding the message",
+            PrimitiveFamily::Permission => "preserve complete request text at every density",
+            PrimitiveFamily::Media => "preserve aspect ratio and controls while reducing padding",
+            PrimitiveFamily::Canvas => {
+                "preserve semantic tool target size while scaling canvas bounds"
+            }
+            PrimitiveFamily::Terminal => "preserve legible monospace scale while reducing padding",
+            PrimitiveFamily::NativePortal => {
+                "preserve the declared portal bounds and padding ratios"
+            }
+        };
+        let phone = match family {
+            PrimitiveFamily::Layout => "stack children in one column with safe-area-aware spacing",
+            PrimitiveFamily::Content => "wrap naturally and allow bounded vertical growth",
+            PrimitiveFamily::Input => "use full-width controls with platform-native input surfaces",
+            PrimitiveFamily::Data => {
+                "summarize or progressively disclose columns while keeping text equivalents"
+            }
+            PrimitiveFamily::Navigation => "collapse to bottom, overflow, or compact controls",
+            PrimitiveFamily::Feedback => {
+                "present inline or full-width feedback with dismissal reachable"
+            }
+            PrimitiveFamily::Permission => "present one complete request in reading order",
+            PrimitiveFamily::Media => "present controls below media and respect safe areas",
+            PrimitiveFamily::Canvas => "use one full-width stage with reachable tools",
+            PrimitiveFamily::Terminal => "use full width, bounded height, and scrollable output",
+            PrimitiveFamily::NativePortal => "use a full-width unavailable or presentation frame",
+        };
+        let desktop = match family {
+            PrimitiveFamily::Layout => "use ordered columns, grids, or splits at bounded ratios",
+            PrimitiveFamily::Content => "use a bounded measure and desktop typography hierarchy",
+            PrimitiveFamily::Input => {
+                "use aligned controls and adjacent labels with pointer precision"
+            }
+            PrimitiveFamily::Data => {
+                "use comparable columns or expanded visual form with text equivalents"
+            }
+            PrimitiveFamily::Navigation => {
+                "use horizontal or persistent navigation with keyboard paths"
+            }
+            PrimitiveFamily::Feedback => {
+                "use positioned, inline, or modal feedback with stable targets"
+            }
+            PrimitiveFamily::Permission => {
+                "use a focused request layout while keeping policy text complete"
+            }
+            PrimitiveFamily::Media => {
+                "use bounded media proportions with adjacent transport controls"
+            }
+            PrimitiveFamily::Canvas => "use a bounded stage with persistent tool palettes",
+            PrimitiveFamily::Terminal => {
+                "use a resizable bounded pane with persistent scrollbar semantics"
+            }
+            PrimitiveFamily::NativePortal => {
+                "use declared desktop bounds and explicit state presentation"
+            }
+        };
+        Self {
+            id,
+            semantic_role: semantic_role.to_owned(),
+            children: Self::children(id),
+            accessibility_label_strategy: accessibility.to_owned(),
+            states: id.required_states().into_iter().collect(),
+            density_behavior: density.to_owned(),
+            phone_adaptation: phone.to_owned(),
+            desktop_adaptation: desktop.to_owned(),
+            native_mapping: native.to_owned(),
+            focus_keyboard_contract: focus.to_owned(),
+            motion_contract: motion.to_owned(),
+            fallback_rendering: fallback.to_owned(),
+        }
+    }
+
+    fn children(id: Primitive) -> ChildrenPolicy {
+        let slots = |values: &[&str]| ChildrenPolicy::ClosedSlots {
+            slots: values.iter().map(|value| (*value).to_owned()).collect(),
+        };
+        let children = |role: &str, minimum: u8, maximum: u8| ChildrenPolicy::BoundedChildren {
+            child_role: role.to_owned(),
+            minimum,
+            maximum,
+        };
+        match id {
+            Primitive::Split => slots(&["start", "end"]),
+            Primitive::Card => slots(&["header", "content", "footer"]),
+            Primitive::Collapse => slots(&["summary", "content"]),
+            Primitive::Repeater => slots(&["template"]),
+            Primitive::Button => slots(&["icon", "label"]),
+            Primitive::Dialog => slots(&["header", "content", "footer"]),
+            Primitive::Tabs => slots(&["tab", "panel"]),
+            Primitive::Breadcrumb => children("crumb", 1, 16),
+            Primitive::Menu => children("item", 0, 64),
+            Primitive::Pager => slots(&["previous", "status", "next"]),
+            Primitive::CapabilityCard => slots(&["scope-summary", "policy-links"]),
+            Primitive::ConsentForm => slots(&["statement", "choices", "actions"]),
+            Primitive::SecurePrompt => slots(&["prompt", "secure-input"]),
+            Primitive::FilePicker => slots(&["filter-summary", "selection-preview"]),
+            Primitive::DiagramView => slots(&["stage", "legend"]),
+            Primitive::AnnotationLayer => children("annotation", 0, 64),
+            id if Self::is_repeat_layout(id) => children("catalog primitive", 0, 64),
+            _ => ChildrenPolicy::None,
+        }
+    }
+
+    const fn is_repeat_layout(id: Primitive) -> bool {
+        matches!(
+            id,
+            Primitive::Region
+                | Primitive::Stack
+                | Primitive::Grid
+                | Primitive::Sidebar
+                | Primitive::ActionBar
+                | Primitive::Group
+                | Primitive::ScrollRegion
+        )
+    }
+
+    /// Validate completeness and bounded semantic text.
+    pub fn validate(&self) -> Result<(), CatalogError> {
+        let valid_children = match &self.children {
+            ChildrenPolicy::None => true,
+            ChildrenPolicy::ClosedSlots { slots } => {
+                !slots.is_empty()
+                    && slots.len() <= MAX_SLOTS
+                    && slots.iter().all(|slot| bounded_text(slot))
+            }
+            ChildrenPolicy::BoundedChildren {
+                child_role,
+                minimum,
+                maximum,
+            } => bounded_text(child_role) && minimum <= maximum,
+        };
+        if !valid_children {
+            return Err(CatalogError::ChildrenPolicy);
+        }
+        let fields = [
+            &self.semantic_role,
+            &self.accessibility_label_strategy,
+            &self.density_behavior,
+            &self.phone_adaptation,
+            &self.desktop_adaptation,
+            &self.native_mapping,
+            &self.focus_keyboard_contract,
+            &self.motion_contract,
+            &self.fallback_rendering,
+        ];
+        if fields.iter().all(|field| bounded_text(field)) {
+            Ok(())
+        } else {
+            Err(CatalogError::RecordField)
+        }
+    }
+}
+
+fn bounded_text(value: &str) -> bool {
+    !value.trim().is_empty() && value.len() <= MAX_TEXT_BYTES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EXPECTED: [Primitive; 62] = Primitive::ALL;
+
+    #[test]
+    fn owns_the_exact_v1_inventory() {
+        let expected_names = [
+            "Region",
+            "Stack",
+            "Grid",
+            "Split",
+            "Sidebar",
+            "ActionBar",
+            "Card",
+            "Group",
+            "Collapse",
+            "Repeater",
+            "ScrollRegion",
+            "Divider",
+            "Heading",
+            "Text",
+            "InlineContent",
+            "CodeBlock",
+            "Badge",
+            "KeyFigure",
+            "EmptyState",
+            "Icon",
+            "Button",
+            "TextField",
+            "TextArea",
+            "NumberField",
+            "Select",
+            "MultiSelect",
+            "Switch",
+            "Checkbox",
+            "Slider",
+            "DateTimeField",
+            "Table",
+            "RecordSummary",
+            "DatasetChart",
+            "Timeline",
+            "Difference",
+            "Progress",
+            "Tabs",
+            "Breadcrumb",
+            "Menu",
+            "Pager",
+            "Link",
+            "Alert",
+            "Toast",
+            "InlineMessage",
+            "Skeleton",
+            "Spinner",
+            "StatusDot",
+            "Dialog",
+            "CapabilityCard",
+            "ConsentForm",
+            "SecurePrompt",
+            "FilePicker",
+            "ImageView",
+            "AudioPlayer",
+            "VideoPlayer",
+            "FileDetails",
+            "MediaEmbed",
+            "CanvasStage",
+            "DiagramView",
+            "AnnotationLayer",
+            "TerminalView",
+            "NativePortal",
+        ];
+        assert_eq!(EXPECTED.len(), 62);
+        assert_eq!(expected_names.len(), 62);
+        for (primitive, name) in Primitive::ALL.into_iter().zip(expected_names) {
+            assert_eq!(primitive.as_str(), name);
+        }
+    }
+
+    #[test]
+    fn every_record_is_complete_and_request_only() {
+        let catalog = Catalog::v1();
+        catalog.validate().expect("catalog is valid");
+        for record in &catalog.records {
+            assert!(!record.id.mints_capability());
+            assert!(matches!(
+                record.accessibility_label_strategy.to_lowercase(),
+                value if value.contains("require") || value.contains("name")
+            ));
+            assert!(!record.states.is_empty());
+        }
+    }
+
+    #[test]
+    fn rejects_reordered_or_incomplete_catalogs() {
+        let mut catalog = Catalog::v1();
+        assert!(catalog.validate().is_ok());
+        catalog.records.swap(0, 1);
+        assert_eq!(catalog.validate(), Err(CatalogError::PrimitiveOrder));
+        catalog = Catalog::v1();
+        catalog.records.pop();
+        assert_eq!(catalog.validate(), Err(CatalogError::PrimitiveCount));
+    }
+}

--- a/capsules/capsule-surface-catalog/src/catalog.rs
+++ b/capsules/capsule-surface-catalog/src/catalog.rs
@@ -851,7 +851,7 @@ impl PrimitiveRecord {
             Primitive::Card => slots(&["header", "content", "footer"]),
             Primitive::Collapse => slots(&["summary", "content"]),
             Primitive::Repeater => slots(&["template"]),
-            Primitive::Button => slots(&["icon", "label"]),
+            Primitive::Button => slots(&["leading-icon", "label", "trailing-icon"]),
             Primitive::Dialog => slots(&["header", "content", "footer"]),
             Primitive::Tabs => slots(&["tab", "panel"]),
             Primitive::Breadcrumb => children("crumb", 1, 16),
@@ -1013,6 +1013,54 @@ mod tests {
             ));
             assert!(!record.states.is_empty());
         }
+        let families = [
+            (PrimitiveFamily::Layout, "layout"),
+            (PrimitiveFamily::Content, "content"),
+            (PrimitiveFamily::Input, "input"),
+            (PrimitiveFamily::Data, "data"),
+            (PrimitiveFamily::Navigation, "navigation"),
+            (PrimitiveFamily::Feedback, "feedback"),
+            (PrimitiveFamily::Permission, "permission"),
+            (PrimitiveFamily::Media, "media"),
+            (PrimitiveFamily::Canvas, "canvas"),
+            (PrimitiveFamily::Terminal, "terminal"),
+            (PrimitiveFamily::NativePortal, "native-portal"),
+        ];
+        for (family, expected_name) in families {
+            assert_eq!(
+                serde_json::to_value(family).unwrap(),
+                serde_json::json!(expected_name)
+            );
+        }
+        let button = catalog.record(Primitive::Button).unwrap();
+        assert_eq!(
+            button.children,
+            ChildrenPolicy::ClosedSlots {
+                slots: ["leading-icon", "label", "trailing-icon",]
+                    .iter()
+                    .map(|slot| (*slot).to_owned())
+                    .collect()
+            }
+        );
+        for kind in [
+            Primitive::CapabilityCard,
+            Primitive::ConsentForm,
+            Primitive::SecurePrompt,
+            Primitive::FilePicker,
+        ] {
+            let record = catalog.record(kind).unwrap();
+            assert!(record.native_mapping.contains("policy"));
+            assert!(!record.native_mapping.contains("grant"));
+        }
+        let terminal = catalog.record(Primitive::TerminalView).unwrap();
+        assert!(
+            terminal
+                .focus_keyboard_contract
+                .contains("no command entry")
+        );
+        let native_portal = catalog.record(Primitive::NativePortal).unwrap();
+        assert!(native_portal.native_mapping.contains("portal state only"));
+        assert!(native_portal.fallback_rendering.contains("unavailable"));
     }
 
     #[test]

--- a/capsules/capsule-surface-catalog/src/lab.rs
+++ b/capsules/capsule-surface-catalog/src/lab.rs
@@ -5,14 +5,34 @@ use crate::theme::{ColorEnvironment, Density, ThemePack};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Exclusive upper bound of the phone breakpoint, in rem.
+pub const COMPACT_BREAKPOINT_REM: f64 = 45.0;
+/// Exclusive lower bound of the desktop breakpoint, in rem.
+pub const DESKTOP_BREAKPOINT_REM: f64 = 72.0;
+
 /// Lab breakpoint.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Breakpoint {
     /// Compact phone viewport.
     Phone,
+    /// Intermediate compact breakpoint.
+    Compact,
     /// Desktop viewport.
     Desktop,
+}
+
+impl Breakpoint {
+    /// Resolve the contract breakpoint from a viewport width in rem.
+    pub const fn from_viewport_rem(width_rem: f64) -> Self {
+        if width_rem < COMPACT_BREAKPOINT_REM {
+            Self::Phone
+        } else if width_rem < DESKTOP_BREAKPOINT_REM {
+            Self::Compact
+        } else {
+            Self::Desktop
+        }
+    }
 }
 
 /// Lab input modality.
@@ -148,7 +168,7 @@ impl ThemeLab {
             },
             LabDimension {
                 name: "breakpoint".to_owned(),
-                values: ["phone", "desktop"]
+                values: ["phone", "compact", "desktop"]
                     .iter()
                     .map(|value| (*value).to_owned())
                     .collect(),
@@ -205,13 +225,13 @@ pub fn canonical_recipe_fixture() -> RecipeFixture {
         recipe_id: "fixture/workspace-recipe".to_owned(),
         revision: 1,
         semantic_digest: "fixture-semantic-content".to_owned(),
-        theme_id: "aurora@1.0.0".to_owned(),
+        theme_id: "aos.builtin.fieldglass@1.0.0".to_owned(),
     }
 }
 
 /// Number of complete documented scenarios.
 pub const fn scenario_count() -> usize {
-    4 * 3 * 2 * 2 * 4 * 2
+    4 * 3 * 3 * 2 * 4 * 2
 }
 
 /// Enumerate every documented scenario.
@@ -233,7 +253,7 @@ pub fn scenario(index: usize) -> Option<Scenario> {
         ColorEnvironment::HighContrastDark,
     ];
     let densities = [Density::Compact, Density::Cozy, Density::Spacious];
-    let breakpoints = [Breakpoint::Phone, Breakpoint::Desktop];
+    let breakpoints = [Breakpoint::Phone, Breakpoint::Compact, Breakpoint::Desktop];
     let modalities = [InputModality::Pointer, InputModality::Keyboard];
     let scales = [90, 100, 118, 200];
     let mut remaining = index;
@@ -296,12 +316,13 @@ fn scenario_supported(scenario: &Scenario) -> bool {
     ) && matches!(
         scenario.density,
         Density::Compact | Density::Cozy | Density::Spacious
-    ) && matches!(scenario.breakpoint, Breakpoint::Phone | Breakpoint::Desktop)
-        && matches!(
-            scenario.modality,
-            InputModality::Pointer | InputModality::Keyboard
-        )
-        && matches!(scenario.text_scale_percent, 90 | 100 | 118 | 200)
+    ) && matches!(
+        scenario.breakpoint,
+        Breakpoint::Phone | Breakpoint::Compact | Breakpoint::Desktop
+    ) && matches!(
+        scenario.modality,
+        InputModality::Pointer | InputModality::Keyboard
+    ) && matches!(scenario.text_scale_percent, 90 | 100 | 118 | 200)
 }
 
 fn token_role(id: Primitive, state: State) -> &'static str {
@@ -342,17 +363,27 @@ mod tests {
         let lab = ThemeLab::new();
         assert_eq!(lab.catalog.records.len(), 62);
         assert_eq!(lab.themes.len(), BUILT_IN_THEME_COUNT);
-        assert_eq!(scenario_count(), 384);
-        assert_eq!(scenarios().len(), 384);
+        assert_eq!(scenario_count(), 576);
+        assert_eq!(scenarios().len(), 576);
         assert_eq!(
             lab.dimensions()
                 .into_iter()
                 .map(|dimension| dimension.values.len())
                 .product::<usize>(),
-            384
+            576
         );
-        assert!(scenario(383).is_some());
+        assert!(scenario(575).is_some());
         assert!(scenario(768).is_none());
+        assert_eq!(
+            Breakpoint::from_viewport_rem(44.999_999_999_999),
+            Breakpoint::Phone
+        );
+        assert_eq!(Breakpoint::from_viewport_rem(45.0), Breakpoint::Compact);
+        assert_eq!(
+            Breakpoint::from_viewport_rem(71.999_999_999_999),
+            Breakpoint::Compact
+        );
+        assert_eq!(Breakpoint::from_viewport_rem(72.0), Breakpoint::Desktop);
     }
 
     #[test]

--- a/capsules/capsule-surface-catalog/src/lab.rs
+++ b/capsules/capsule-surface-catalog/src/lab.rs
@@ -1,6 +1,6 @@
 //! Catalog-owned Theme Lab verification corpus.
 
-use crate::catalog::{Catalog, Primitive, PrimitiveRecord, State};
+use crate::catalog::{Catalog, CatalogPrimitive, Primitive, PrimitiveRecord, State};
 use crate::theme::{ColorEnvironment, Density, ThemePack};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -336,7 +336,7 @@ fn token_role(id: Primitive, state: State) -> &'static str {
         State::FocusVisible => "aos.color.focus",
         State::Selected => "aos.color.selected",
         State::Loading | State::Empty => "aos.color.text-muted",
-        _ => match id.family() {
+        _ => match id.catalog_family() {
             crate::catalog::PrimitiveFamily::Layout => "aos.color.surface",
             crate::catalog::PrimitiveFamily::Content => "aos.color.text",
             crate::catalog::PrimitiveFamily::Input => "aos.color.accent",

--- a/capsules/capsule-surface-catalog/src/lab.rs
+++ b/capsules/capsule-surface-catalog/src/lab.rs
@@ -1,0 +1,394 @@
+//! Catalog-owned Theme Lab verification corpus.
+
+use crate::catalog::{Catalog, Primitive, PrimitiveRecord, State};
+use crate::theme::{ColorEnvironment, Density, ThemePack};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Lab breakpoint.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Breakpoint {
+    /// Compact phone viewport.
+    Phone,
+    /// Desktop viewport.
+    Desktop,
+}
+
+/// Lab input modality.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InputModality {
+    /// Pointer presentation.
+    Pointer,
+    /// Keyboard-originated presentation.
+    Keyboard,
+}
+
+/// One complete documented Lab scenario.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Scenario {
+    /// Color and contrast environment.
+    pub environment: ColorEnvironment,
+    /// Density.
+    pub density: Density,
+    /// Viewport breakpoint.
+    pub breakpoint: Breakpoint,
+    /// Input modality.
+    pub modality: InputModality,
+    /// Text scale.
+    pub text_scale_percent: u8,
+    /// Reduced-motion preference.
+    pub reduced_motion: bool,
+}
+
+/// Lab dimension documentation.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LabDimension {
+    /// Stable dimension name.
+    pub name: String,
+    /// Documented values.
+    pub values: Vec<String>,
+}
+
+/// Catalog-owned verification surface.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ThemeLab {
+    /// Exact catalog.
+    pub catalog: Catalog,
+    /// Two complete themes.
+    pub themes: [ThemePack; 2],
+}
+
+/// One semantic Lab instance.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LabInstance {
+    /// Primitive under test.
+    pub component_id: Primitive,
+    /// State under test.
+    pub state: State,
+    /// Scenario under test.
+    pub scenario: Scenario,
+    /// Theme used.
+    pub theme_id: String,
+    /// Theme version used.
+    pub theme_version: String,
+    /// Primary semantic token used for state presentation.
+    pub semantic_token_role: &'static str,
+}
+
+/// Fixture recipe identity remains unchanged when presentation changes.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecipeFixture {
+    /// Stable recipe id.
+    pub recipe_id: String,
+    /// Stable recipe revision.
+    pub revision: u64,
+    /// Stable semantic content digest.
+    pub semantic_digest: String,
+    /// Theme reference attached to the recipe.
+    pub theme_id: String,
+}
+
+/// Lab construction or instantiation failure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LabError {
+    /// State was not documented for the primitive.
+    StateUnsupported,
+    /// Scenario value was outside the documented dimension.
+    ScenarioUnsupported,
+    /// Theme lacked coverage for the scenario.
+    ThemeIncomplete,
+}
+
+impl fmt::Display for LabError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::StateUnsupported => "state is not documented for this primitive",
+            Self::ScenarioUnsupported => "scenario is outside the documented Lab matrix",
+            Self::ThemeIncomplete => "theme does not cover this scenario",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for LabError {}
+
+impl ThemeLab {
+    /// Construct the verification corpus.
+    pub fn new() -> Self {
+        let registry = crate::theme::ThemeRegistry::new();
+        let themes = registry.packs();
+        Self {
+            catalog: Catalog::v1(),
+            themes: [themes[0].clone(), themes[1].clone()],
+        }
+    }
+
+    /// Documented dimensions.
+    pub fn dimensions(&self) -> Vec<LabDimension> {
+        vec![
+            LabDimension {
+                name: "environment".to_owned(),
+                values: ["light", "dark", "high-contrast-light", "high-contrast-dark"]
+                    .iter()
+                    .map(|value| (*value).to_owned())
+                    .collect(),
+            },
+            LabDimension {
+                name: "density".to_owned(),
+                values: ["compact", "cozy", "spacious"]
+                    .iter()
+                    .map(|value| (*value).to_owned())
+                    .collect(),
+            },
+            LabDimension {
+                name: "breakpoint".to_owned(),
+                values: ["phone", "desktop"]
+                    .iter()
+                    .map(|value| (*value).to_owned())
+                    .collect(),
+            },
+            LabDimension {
+                name: "modality".to_owned(),
+                values: ["pointer", "keyboard"]
+                    .iter()
+                    .map(|value| (*value).to_owned())
+                    .collect(),
+            },
+            LabDimension {
+                name: "text-scale".to_owned(),
+                values: ["90", "100", "118", "200"]
+                    .iter()
+                    .map(|value| (*value).to_owned())
+                    .collect(),
+            },
+            LabDimension {
+                name: "reduced-motion".to_owned(),
+                values: ["false", "true"]
+                    .iter()
+                    .map(|value| (*value).to_owned())
+                    .collect(),
+            },
+        ]
+    }
+
+    /// Switch only the theme reference on a fixture recipe.
+    pub fn switch_theme(&self, recipe: &RecipeFixture, theme: &ThemePack) -> RecipeFixture {
+        RecipeFixture {
+            recipe_id: recipe.recipe_id.clone(),
+            revision: recipe.revision,
+            semantic_digest: recipe.semantic_digest.clone(),
+            theme_id: format!("{}@{}", theme.id, theme.version),
+        }
+    }
+}
+
+impl Default for ThemeLab {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Construct the canonical verification surface.
+pub fn verification_lab() -> ThemeLab {
+    ThemeLab::new()
+}
+
+/// Canonical fixture recipe used by the independence proof.
+pub fn canonical_recipe_fixture() -> RecipeFixture {
+    RecipeFixture {
+        recipe_id: "fixture/workspace-recipe".to_owned(),
+        revision: 1,
+        semantic_digest: "fixture-semantic-content".to_owned(),
+        theme_id: "aurora@1.0.0".to_owned(),
+    }
+}
+
+/// Number of complete documented scenarios.
+pub const fn scenario_count() -> usize {
+    4 * 3 * 2 * 2 * 4 * 2
+}
+
+/// Enumerate every documented scenario.
+pub fn scenarios() -> Vec<Scenario> {
+    (0..scenario_count())
+        .map(|index| scenario(index).expect("index is bounded"))
+        .collect()
+}
+
+/// Return a scenario by canonical cross-product index.
+pub fn scenario(index: usize) -> Option<Scenario> {
+    if index >= scenario_count() {
+        return None;
+    }
+    let environments = [
+        ColorEnvironment::Light,
+        ColorEnvironment::Dark,
+        ColorEnvironment::HighContrastLight,
+        ColorEnvironment::HighContrastDark,
+    ];
+    let densities = [Density::Compact, Density::Cozy, Density::Spacious];
+    let breakpoints = [Breakpoint::Phone, Breakpoint::Desktop];
+    let modalities = [InputModality::Pointer, InputModality::Keyboard];
+    let scales = [90, 100, 118, 200];
+    let mut remaining = index;
+    let mut next = |bound: usize| {
+        let value = remaining % bound;
+        remaining /= bound;
+        value
+    };
+    Some(Scenario {
+        environment: environments[next(environments.len())],
+        density: densities[next(densities.len())],
+        breakpoint: breakpoints[next(breakpoints.len())],
+        modality: modalities[next(modalities.len())],
+        text_scale_percent: scales[next(scales.len())],
+        reduced_motion: next(2) == 1,
+    })
+}
+
+/// Instantiate one semantic primitive in one state, scenario, and theme.
+pub fn instantiate(
+    record: &PrimitiveRecord,
+    state: State,
+    scenario: Scenario,
+    theme: &ThemePack,
+) -> Result<LabInstance, LabError> {
+    if !record.states.contains(&state) {
+        return Err(LabError::StateUnsupported);
+    }
+    if !scenario_supported(&scenario) {
+        return Err(LabError::ScenarioUnsupported);
+    }
+    let resolved = theme
+        .resolved_tokens(
+            scenario.environment,
+            scenario.density,
+            scenario.reduced_motion,
+        )
+        .ok_or(LabError::ThemeIncomplete)?;
+    let role = token_role(record.id, state);
+    if !resolved.contains_key(role) {
+        return Err(LabError::ThemeIncomplete);
+    }
+    Ok(LabInstance {
+        component_id: record.id,
+        state,
+        scenario,
+        theme_id: theme.id.clone(),
+        theme_version: theme.version.clone(),
+        semantic_token_role: role,
+    })
+}
+
+fn scenario_supported(scenario: &Scenario) -> bool {
+    matches!(
+        scenario.environment,
+        ColorEnvironment::Light
+            | ColorEnvironment::Dark
+            | ColorEnvironment::HighContrastLight
+            | ColorEnvironment::HighContrastDark
+    ) && matches!(
+        scenario.density,
+        Density::Compact | Density::Cozy | Density::Spacious
+    ) && matches!(scenario.breakpoint, Breakpoint::Phone | Breakpoint::Desktop)
+        && matches!(
+            scenario.modality,
+            InputModality::Pointer | InputModality::Keyboard
+        )
+        && matches!(scenario.text_scale_percent, 90 | 100 | 118 | 200)
+}
+
+fn token_role(id: Primitive, state: State) -> &'static str {
+    if state == State::Disabled {
+        return "aos.color.disabled";
+    }
+    match state {
+        State::Error => "aos.color.danger",
+        State::Success => "aos.color.success",
+        State::Warning => "aos.color.warning",
+        State::FocusVisible => "aos.color.focus",
+        State::Selected => "aos.color.selected",
+        State::Loading | State::Empty => "aos.color.text-muted",
+        _ => match id.family() {
+            crate::catalog::PrimitiveFamily::Layout => "aos.color.surface",
+            crate::catalog::PrimitiveFamily::Content => "aos.color.text",
+            crate::catalog::PrimitiveFamily::Input => "aos.color.accent",
+            crate::catalog::PrimitiveFamily::Data => "aos.color.text",
+            crate::catalog::PrimitiveFamily::Navigation => "aos.color.accent",
+            crate::catalog::PrimitiveFamily::Feedback => "aos.color.information",
+            crate::catalog::PrimitiveFamily::Permission => "aos.color.focus",
+            crate::catalog::PrimitiveFamily::Media => "aos.color.surface",
+            crate::catalog::PrimitiveFamily::Canvas => "aos.color.surface",
+            crate::catalog::PrimitiveFamily::Terminal => "aos.color.surface",
+            crate::catalog::PrimitiveFamily::NativePortal => "aos.color.border",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme::{BUILT_IN_THEME_COUNT, required_theme_roles};
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn documents_the_complete_matrix() {
+        let lab = ThemeLab::new();
+        assert_eq!(lab.catalog.records.len(), 62);
+        assert_eq!(lab.themes.len(), BUILT_IN_THEME_COUNT);
+        assert_eq!(scenario_count(), 384);
+        assert_eq!(scenarios().len(), 384);
+        assert_eq!(
+            lab.dimensions()
+                .into_iter()
+                .map(|dimension| dimension.values.len())
+                .product::<usize>(),
+            384
+        );
+        assert!(scenario(383).is_some());
+        assert!(scenario(768).is_none());
+    }
+
+    #[test]
+    fn instantiates_every_record_state_scenario_and_theme() {
+        let lab = ThemeLab::new();
+        let scenarios = scenarios();
+        let mut observed_records = BTreeSet::new();
+        let mut observed_states = BTreeSet::new();
+        for theme in &lab.themes {
+            for record in &lab.catalog.records {
+                for state in record.states.iter().copied() {
+                    for scenario in scenarios.iter().copied() {
+                        let instance = instantiate(record, state, scenario, theme)
+                            .expect("Lab instance is complete");
+                        assert_eq!(instance.component_id, record.id);
+                        assert_eq!(instance.state, state);
+                        assert!(required_theme_roles().contains(&instance.semantic_token_role));
+                        observed_records.insert(record.id);
+                        observed_states.insert(state);
+                    }
+                }
+            }
+        }
+        assert_eq!(observed_records.len(), 62);
+        assert!(observed_states.contains(&State::FocusVisible));
+        assert!(observed_states.contains(&State::Disabled));
+    }
+
+    #[test]
+    fn theme_change_does_not_change_recipe_identity() {
+        let lab = ThemeLab::new();
+        let recipe = canonical_recipe_fixture();
+        let changed = lab.switch_theme(&recipe, &lab.themes[1]);
+        assert_eq!(recipe.recipe_id, changed.recipe_id);
+        assert_eq!(recipe.revision, changed.revision);
+        assert_eq!(recipe.semantic_digest, changed.semantic_digest);
+        assert_ne!(recipe.theme_id, changed.theme_id);
+    }
+}

--- a/capsules/capsule-surface-catalog/src/lib.rs
+++ b/capsules/capsule-surface-catalog/src/lib.rs
@@ -14,8 +14,8 @@ pub mod unknown;
 
 pub use a2ui::{A2uiImportError, DeclaredLossMapping, map_a2ui_component};
 pub use catalog::{
-    CATALOG_SCHEMA, Catalog, CatalogError, ChildrenPolicy, Primitive, PrimitiveFamily,
-    PrimitiveRecord, State,
+    CATALOG_SCHEMA, Catalog, CatalogError, CatalogPrimitive, ChildrenPolicy, Primitive,
+    PrimitiveFamily, PrimitiveRecord, State,
 };
 pub use lab::{
     Breakpoint, COMPACT_BREAKPOINT_REM, DESKTOP_BREAKPOINT_REM, InputModality, LabDimension,

--- a/capsules/capsule-surface-catalog/src/lib.rs
+++ b/capsules/capsule-surface-catalog/src/lib.rs
@@ -1,0 +1,32 @@
+//! Host-independent semantic component catalog and theme-pack contracts.
+//!
+//! The catalog describes presentation only. It deliberately has no host
+//! imports, file access, process access, network access, or capability API.
+
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+
+pub mod a2ui;
+pub mod catalog;
+pub mod lab;
+pub mod theme;
+pub mod unknown;
+
+pub use a2ui::{A2uiImportError, DeclaredLossMapping, map_a2ui_component};
+pub use catalog::{
+    CATALOG_SCHEMA, Catalog, CatalogError, ChildrenPolicy, Primitive, PrimitiveFamily,
+    PrimitiveRecord, State,
+};
+pub use lab::{
+    Breakpoint, InputModality, LabDimension, LabError, LabInstance, RecipeFixture, Scenario,
+    ThemeLab, instantiate, scenario_count, scenarios, verification_lab,
+};
+pub use theme::{
+    BUILT_IN_THEME_COUNT, ColorEnvironment, Density, EnvironmentSpec, FallbackStage, Material,
+    NeutralFallback, Preferences, ResolvedToken, SafeArea, ThemeError, ThemePack, ThemeRegistry,
+    TokenValue, required_theme_roles,
+};
+pub use unknown::{
+    UnknownComponent, UnknownComponentDocument, UnknownComponentError, UnknownFallback,
+    validate_unknown_component,
+};

--- a/capsules/capsule-surface-catalog/src/lib.rs
+++ b/capsules/capsule-surface-catalog/src/lib.rs
@@ -18,13 +18,14 @@ pub use catalog::{
     PrimitiveRecord, State,
 };
 pub use lab::{
-    Breakpoint, InputModality, LabDimension, LabError, LabInstance, RecipeFixture, Scenario,
-    ThemeLab, instantiate, scenario_count, scenarios, verification_lab,
+    Breakpoint, COMPACT_BREAKPOINT_REM, DESKTOP_BREAKPOINT_REM, InputModality, LabDimension,
+    LabError, LabInstance, RecipeFixture, Scenario, ThemeLab, instantiate, scenario_count,
+    scenarios, verification_lab,
 };
 pub use theme::{
-    BUILT_IN_THEME_COUNT, ColorEnvironment, Density, EnvironmentSpec, FallbackStage, Material,
-    NeutralFallback, Preferences, ResolvedToken, SafeArea, ThemeError, ThemePack, ThemeRegistry,
-    TokenValue, required_theme_roles,
+    BUILT_IN_THEME_COUNT, ColorEnvironment, Density, EnvironmentSpec, FIELDGLASS_THEME_ID,
+    FallbackStage, Material, NeutralFallback, PAPER_SIGNAL_THEME_ID, Preferences, ResolvedToken,
+    SafeArea, ThemeError, ThemePack, ThemeRegistry, TokenValue, required_theme_roles,
 };
 pub use unknown::{
     UnknownComponent, UnknownComponentDocument, UnknownComponentError, UnknownFallback,

--- a/capsules/capsule-surface-catalog/src/theme.rs
+++ b/capsules/capsule-surface-catalog/src/theme.rs
@@ -8,6 +8,10 @@ use std::fmt;
 pub const THEME_SCHEMA: &str = "aos.theme/1";
 /// Number of complete themes shipped by this tranche.
 pub const BUILT_IN_THEME_COUNT: usize = 2;
+/// Canonical dark-first built-in theme identity.
+pub const FIELDGLASS_THEME_ID: &str = "aos.builtin.fieldglass";
+/// Canonical light-first built-in theme identity.
+pub const PAPER_SIGNAL_THEME_ID: &str = "aos.builtin.paper-signal";
 
 const SUPPORTED_TEXT_SCALES: [u8; 4] = [90, 100, 118, 200];
 const APPROVED_LENGTHS: [u16; 14] = [0, 2, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128, 192];
@@ -302,7 +306,7 @@ impl Default for ThemeRegistry {
 impl ThemeRegistry {
     /// Construct and validate the two built-in packs.
     pub fn new() -> Self {
-        let packs = [ThemePack::aurora(), ThemePack::daylight()];
+        let packs = [ThemePack::fieldglass(), ThemePack::paper_signal()];
         for pack in &packs {
             pack.validate()
                 .expect("built-in theme packs are valid by construction");
@@ -371,10 +375,7 @@ impl ThemeRegistry {
         density: Density,
         role: &str,
     ) -> Option<ResolvedToken> {
-        let id = match environment {
-            ColorEnvironment::Light | ColorEnvironment::HighContrastLight => "daylight",
-            ColorEnvironment::Dark | ColorEnvironment::HighContrastDark => "aurora",
-        };
+        let id = FIELDGLASS_THEME_ID;
         let pack = self.packs().iter().find(|pack| pack.id == id)?;
         pack.resolved_token(environment, density, role)
             .map(|value| ResolvedToken {
@@ -570,13 +571,13 @@ struct Palette {
 
 impl ThemePack {
     /// Complete dark-first built-in theme.
-    pub fn aurora() -> Self {
-        Self::pack("aurora", false)
+    pub fn fieldglass() -> Self {
+        Self::pack(FIELDGLASS_THEME_ID, false)
     }
 
     /// Complete light-first built-in theme.
-    pub fn daylight() -> Self {
-        Self::pack("daylight", true)
+    pub fn paper_signal() -> Self {
+        Self::pack(PAPER_SIGNAL_THEME_ID, true)
     }
 
     fn pack(id: &str, light: bool) -> Self {
@@ -894,7 +895,7 @@ fn semantic_tokens(id: &str, environment: ColorEnvironment) -> BTreeMap<String, 
 
 fn palette(id: &str, dark: bool, high_contrast: bool) -> Palette {
     let transparent_black = [0, 0, 0, 64];
-    if id == "aurora" {
+    if id == FIELDGLASS_THEME_ID {
         if dark && high_contrast {
             return Palette {
                 background: [0, 0, 0, 255],
@@ -1140,18 +1141,25 @@ fn validate_token(role: &str, value: TokenValue) -> Result<(), ThemeError> {
 }
 
 fn valid_theme_id(value: &str) -> bool {
-    let mut characters = value.chars();
-    if !characters
-        .next()
-        .is_some_and(|character| character.is_ascii_lowercase())
+    if value.is_empty()
         || value.len() > 64
+        || value.starts_with('.')
+        || value.ends_with('.')
+        || value.contains("..")
         || !value.chars().all(|character| {
-            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+            character.is_ascii_lowercase()
+                || character.is_ascii_digit()
+                || matches!(character, '-' | '.')
         })
     {
         return false;
     }
-    !value.ends_with('-') && !value.contains("--")
+    value.split('.').all(|segment| {
+        !segment.is_empty()
+            && !segment.starts_with('-')
+            && !segment.ends_with('-')
+            && !segment.contains("--")
+    })
 }
 
 fn valid_role(role: &str) -> bool {
@@ -1220,7 +1228,11 @@ mod tests {
 
     #[test]
     fn ships_two_complete_themes() {
-        for pack in [ThemePack::aurora(), ThemePack::daylight()] {
+        assert_eq!(
+            [FIELDGLASS_THEME_ID, PAPER_SIGNAL_THEME_ID],
+            ["aos.builtin.fieldglass", "aos.builtin.paper-signal"]
+        );
+        for pack in [ThemePack::fieldglass(), ThemePack::paper_signal()] {
             pack.validate().expect("theme is complete");
             for environment in [
                 ColorEnvironment::Light,
@@ -1242,12 +1254,12 @@ mod tests {
 
     #[test]
     fn hostile_tokens_fail_closed() {
-        let mut pack = ThemePack::daylight();
+        let mut pack = ThemePack::paper_signal();
         pack.aliases
             .insert("aos.color.accent".to_owned(), "aos.color.text".to_owned());
         assert!(pack.validate().is_ok());
 
-        let mut transparent_required_color = ThemePack::daylight();
+        let mut transparent_required_color = ThemePack::paper_signal();
         transparent_required_color
             .semantic_tokens
             .get_mut(&ColorEnvironment::Light)
@@ -1261,7 +1273,7 @@ mod tests {
             Err(ThemeError::TokenValue)
         ));
 
-        let mut infinite = ThemePack::daylight();
+        let mut infinite = ThemePack::paper_signal();
         infinite
             .density_tokens
             .get_mut(&Density::Cozy)
@@ -1286,9 +1298,27 @@ mod tests {
     #[test]
     fn missing_token_falls_back_through_stages() {
         let registry = ThemeRegistry::new();
+        for environment in [
+            ColorEnvironment::Light,
+            ColorEnvironment::Dark,
+            ColorEnvironment::HighContrastLight,
+            ColorEnvironment::HighContrastDark,
+        ] {
+            let fallback = registry
+                .resolve(
+                    "absent",
+                    "1.0.0",
+                    environment,
+                    Density::Cozy,
+                    "aos.color.text",
+                )
+                .expect("built-in contrast fallback");
+            assert_eq!(fallback.stage, FallbackStage::BuiltInContrast);
+            assert_eq!(fallback.theme_id, FIELDGLASS_THEME_ID);
+        }
         let exact = registry
             .resolve(
-                "daylight",
+                FIELDGLASS_THEME_ID,
                 "1.0.0",
                 ColorEnvironment::Light,
                 Density::Cozy,
@@ -1298,7 +1328,7 @@ mod tests {
         assert_eq!(exact.stage, FallbackStage::ExactTheme);
         let compatible = registry
             .resolve(
-                "daylight",
+                FIELDGLASS_THEME_ID,
                 "1.4.0",
                 ColorEnvironment::Light,
                 Density::Cozy,

--- a/capsules/capsule-surface-catalog/src/theme.rs
+++ b/capsules/capsule-surface-catalog/src/theme.rs
@@ -1,0 +1,1320 @@
+//! `aos.theme/1` packs, bounded values, and fail-closed token fallback.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+/// Stable theme contract identity.
+pub const THEME_SCHEMA: &str = "aos.theme/1";
+/// Number of complete themes shipped by this tranche.
+pub const BUILT_IN_THEME_COUNT: usize = 2;
+
+const SUPPORTED_TEXT_SCALES: [u8; 4] = [90, 100, 118, 200];
+const APPROVED_LENGTHS: [u16; 14] = [0, 2, 4, 6, 8, 12, 16, 24, 32, 48, 64, 96, 128, 192];
+const APPROVED_SPACE: [u16; 15] = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 24, 32, 40, 48];
+const APPROVED_RADIUS: [u16; 7] = [0, 2, 4, 6, 8, 12, 16];
+const APPROVED_DURATION: [u16; 8] = [0, 60, 90, 120, 150, 180, 240, 400];
+const APPROVED_RATIO: [u16; 11] = [0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000];
+
+/// Color environment represented by a theme environment.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ColorEnvironment {
+    /// Ordinary light environment.
+    Light,
+    /// Ordinary dark environment.
+    Dark,
+    /// High-contrast light environment.
+    HighContrastLight,
+    /// High-contrast dark environment.
+    HighContrastDark,
+}
+
+/// Platform material family.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Material {
+    /// Opaque platform surface.
+    Opaque,
+    /// Translucent platform surface with a catalog-provided opaque fallback.
+    Translucent,
+    /// Explicit high-contrast surface.
+    HighContrast,
+}
+
+/// Named spacing and control density.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Density {
+    /// Compact spacing.
+    Compact,
+    /// Default spacing.
+    Cozy,
+    /// Spacious spacing.
+    Spacious,
+}
+
+/// Bounded platform-material descriptor.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnvironmentSpec {
+    /// Platform material family.
+    pub material: Material,
+    /// System palette identity, not raw author CSS.
+    pub system_palette: String,
+    /// Bounded system display scale.
+    pub display_scale_percent: u8,
+    /// Safe-area insets in logical units.
+    pub safe_area: SafeArea,
+}
+
+/// Logical safe-area inset.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SafeArea {
+    /// Top inset.
+    pub top: u16,
+    /// Leading inset.
+    pub leading: u16,
+    /// Trailing inset.
+    pub trailing: u16,
+    /// Bottom inset.
+    pub bottom: u16,
+}
+
+/// Bounded user and workspace preferences supported by a pack.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Preferences {
+    /// Pointer interaction is supported.
+    pub pointer: bool,
+    /// Direct keyboard interaction is supported.
+    pub keyboard: bool,
+    /// Supported bounded text scales.
+    pub text_scale_percent: Vec<u8>,
+    /// Reduced-motion presentation is supported.
+    pub reduced_motion: bool,
+    /// Bounded sound preference.
+    pub sound: SoundDescriptor,
+    /// Bounded haptic preference.
+    pub haptic: HapticDescriptor,
+}
+
+/// Sound descriptor.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SoundDescriptor {
+    /// No sound.
+    None,
+    /// Short interaction cue.
+    Tap,
+    /// Success cue.
+    Success,
+    /// Warning cue.
+    Warning,
+    /// Error cue.
+    Error,
+}
+
+/// Haptic descriptor.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum HapticDescriptor {
+    /// No haptic.
+    None,
+    /// Light haptic.
+    Light,
+    /// Medium haptic.
+    Medium,
+    /// Strong haptic.
+    Strong,
+    /// Success haptic.
+    Success,
+    /// Warning haptic.
+    Warning,
+}
+
+/// Typed, bounded semantic token value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum TokenValue {
+    /// RGBA color.
+    Color([u8; 4]),
+    /// Bounded logical or percentage length.
+    Length {
+        /// Numeric value.
+        value: u16,
+        /// Unit.
+        unit: LengthUnit,
+    },
+    /// Finite ratio expressed in per-mille.
+    Ratio(u16),
+    /// Duration in milliseconds.
+    DurationMs(u16),
+    /// Percentage.
+    Percent(u8),
+    /// Bounded sound descriptor.
+    Sound {
+        /// Allowed cue.
+        cue: SoundDescriptor,
+        /// Bounded volume.
+        volume_percent: u8,
+    },
+    /// Bounded haptic descriptor.
+    Haptic(HapticDescriptor),
+}
+
+/// Unit for a length token.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LengthUnit {
+    /// Logical pixel.
+    LogicalPixel,
+    /// Percent of a declared semantic bound.
+    Percent,
+}
+
+/// Complete theme pack.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ThemePack {
+    /// Stable contract identity.
+    pub schema: String,
+    /// Stable theme identifier.
+    pub id: String,
+    /// Semantic version.
+    pub version: String,
+    /// Required environment metadata.
+    pub environments: BTreeMap<ColorEnvironment, EnvironmentSpec>,
+    /// Complete semantic token map for each environment.
+    pub semantic_tokens: BTreeMap<ColorEnvironment, BTreeMap<String, TokenValue>>,
+    /// Bounded density overrides for spacing roles.
+    pub density_tokens: BTreeMap<Density, BTreeMap<String, TokenValue>>,
+    /// Semantic aliases; targets must themselves be semantic roles.
+    pub aliases: BTreeMap<String, String>,
+    /// Modality, text, motion, sound, and haptic support.
+    pub preferences: Preferences,
+}
+
+/// Theme validation failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ThemeError {
+    /// Contract identity was not exactly `aos.theme/1`.
+    Schema,
+    /// Theme id was absent, oversized, or outside the portable grammar.
+    Id,
+    /// Semantic version was absent or malformed.
+    Version,
+    /// One or more required environments were absent.
+    Environment,
+    /// Environment metadata was outside its bounded scale.
+    EnvironmentValue,
+    /// A required density was absent or incomplete.
+    Density,
+    /// A required semantic token was absent.
+    Token,
+    /// A token name or value was outside the bounded semantic API.
+    TokenValue,
+    /// Semantic aliases were cyclic or pointed outside semantic roles.
+    Alias,
+    /// Preference coverage was incomplete.
+    Preference,
+    /// Required contrast failed.
+    Accessibility,
+}
+
+impl fmt::Display for ThemeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::Schema => "theme schema must be aos.theme/1",
+            Self::Id => "theme id is invalid",
+            Self::Version => "theme semantic version is invalid",
+            Self::Environment => "theme environment coverage is incomplete",
+            Self::EnvironmentValue => "theme environment value is out of bounds",
+            Self::Density => "theme density coverage is incomplete",
+            Self::Token => "required semantic token is absent",
+            Self::TokenValue => "semantic token value is hostile or out of bounds",
+            Self::Alias => "semantic token alias is invalid",
+            Self::Preference => "theme does not support the required preferences",
+            Self::Accessibility => "theme fails required contrast",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for ThemeError {}
+
+/// Every stable semantic role in `aos.theme/1`.
+pub fn required_theme_roles() -> &'static [&'static str] {
+    &[
+        "aos.color.background",
+        "aos.color.surface",
+        "aos.color.text",
+        "aos.color.text-muted",
+        "aos.color.border",
+        "aos.color.focus",
+        "aos.color.accent",
+        "aos.color.on-accent",
+        "aos.color.success",
+        "aos.color.warning",
+        "aos.color.danger",
+        "aos.color.information",
+        "aos.color.neutral",
+        "aos.color.disabled",
+        "aos.color.selected",
+        "aos.color.overlay",
+        "aos.elevation.level-0",
+        "aos.elevation.level-1",
+        "aos.elevation.level-2",
+        "aos.elevation.level-3",
+        "aos.space.1",
+        "aos.space.2",
+        "aos.space.3",
+        "aos.space.4",
+        "aos.space.5",
+        "aos.space.6",
+        "aos.radius.control",
+        "aos.radius.surface",
+        "aos.typography.caption",
+        "aos.typography.body",
+        "aos.typography.title",
+        "aos.typography.display",
+        "aos.motion.fast",
+        "aos.motion.normal",
+        "aos.motion.slow",
+        "aos.sound.default",
+        "aos.haptic.default",
+    ]
+}
+
+/// Complete built-in theme registry.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ThemeRegistry {
+    packs: [ThemePack; BUILT_IN_THEME_COUNT],
+}
+
+impl Default for ThemeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ThemeRegistry {
+    /// Construct and validate the two built-in packs.
+    pub fn new() -> Self {
+        let packs = [ThemePack::aurora(), ThemePack::daylight()];
+        for pack in &packs {
+            pack.validate()
+                .expect("built-in theme packs are valid by construction");
+        }
+        Self { packs }
+    }
+
+    /// Built-in packs.
+    pub fn packs(&self) -> &[ThemePack] {
+        &self.packs
+    }
+
+    fn exact_match(
+        &self,
+        id: &str,
+        version: [u64; 3],
+        environment: ColorEnvironment,
+        density: Density,
+        role: &str,
+    ) -> Option<ResolvedToken> {
+        let pack = self
+            .packs()
+            .iter()
+            .find(|pack| pack.id == id && parse_version(&pack.version) == Some(version))?;
+        let value = pack.resolved_token(environment, density, role)?;
+        Some(ResolvedToken {
+            stage: FallbackStage::ExactTheme,
+            theme_id: pack.id.clone(),
+            theme_version: pack.version.clone(),
+            value,
+        })
+    }
+
+    fn compatible_match(
+        &self,
+        id: &str,
+        version: [u64; 3],
+        environment: ColorEnvironment,
+        density: Density,
+        role: &str,
+    ) -> Option<ResolvedToken> {
+        let mut compatible: Option<(&ThemePack, [u64; 3])> = None;
+        for pack in self.packs() {
+            let Some(found) = parse_version(&pack.version)
+                .filter(|found| pack.id == id && found[0] == version[0] && *found <= version)
+            else {
+                continue;
+            };
+            if compatible.is_none_or(|(_, best)| found > best) {
+                compatible = Some((pack, found));
+            }
+        }
+        let (pack, found) = compatible?;
+        let value = pack.resolved_token(environment, density, role)?;
+        Some(ResolvedToken {
+            stage: FallbackStage::CompatibleLatestMinor,
+            theme_id: pack.id.clone(),
+            theme_version: pack_version(found),
+            value,
+        })
+    }
+
+    fn built_in_contrast_match(
+        &self,
+        environment: ColorEnvironment,
+        density: Density,
+        role: &str,
+    ) -> Option<ResolvedToken> {
+        let id = match environment {
+            ColorEnvironment::Light | ColorEnvironment::HighContrastLight => "daylight",
+            ColorEnvironment::Dark | ColorEnvironment::HighContrastDark => "aurora",
+        };
+        let pack = self.packs().iter().find(|pack| pack.id == id)?;
+        pack.resolved_token(environment, density, role)
+            .map(|value| ResolvedToken {
+                stage: FallbackStage::BuiltInContrast,
+                theme_id: pack.id.clone(),
+                theme_version: pack.version.clone(),
+                value,
+            })
+    }
+
+    /// Resolve one role with the exact, compatible, contrast, then neutral path.
+    pub fn resolve(
+        &self,
+        id: &str,
+        version: &str,
+        environment: ColorEnvironment,
+        density: Density,
+        role: &str,
+    ) -> Option<ResolvedToken> {
+        let requested = parse_version(version)?;
+        self.exact_match(id, requested, environment, density, role)
+            .or_else(|| self.compatible_match(id, requested, environment, density, role))
+            .or_else(|| self.built_in_contrast_match(environment, density, role))
+            .or_else(|| {
+                Some(ResolvedToken {
+                    stage: FallbackStage::Neutral,
+                    theme_id: "catalog-neutral".to_owned(),
+                    theme_version: "1.0.0".to_owned(),
+                    value: NeutralFallback::token(role, environment)?,
+                })
+            })
+    }
+}
+
+/// Stage used to resolve a token.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FallbackStage {
+    /// Exact theme id and version.
+    ExactTheme,
+    /// Same major-version latest compatible minor.
+    CompatibleLatestMinor,
+    /// Built-in high-contrast theme.
+    BuiltInContrast,
+    /// Fail-closed neutral styling.
+    Neutral,
+}
+
+/// A resolved token and its provenance.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedToken {
+    /// Fallback stage used.
+    pub stage: FallbackStage,
+    /// Theme that supplied the value.
+    pub theme_id: String,
+    /// Version that supplied the value.
+    pub theme_version: String,
+    /// Semantic value.
+    pub value: TokenValue,
+}
+
+/// Neutral fail-closed styling.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NeutralFallback;
+
+impl NeutralFallback {
+    /// Resolve a required role to a neutral accessible value.
+    pub fn token(role: &str, environment: ColorEnvironment) -> Option<TokenValue> {
+        let dark = matches!(
+            environment,
+            ColorEnvironment::Dark | ColorEnvironment::HighContrastDark
+        );
+        let high_contrast = matches!(
+            environment,
+            ColorEnvironment::HighContrastLight | ColorEnvironment::HighContrastDark
+        );
+        let background = if dark {
+            [0, 0, 0, 255]
+        } else {
+            [255, 255, 255, 255]
+        };
+        let foreground = if dark {
+            [255, 255, 255, 255]
+        } else {
+            [0, 0, 0, 255]
+        };
+        let muted = if high_contrast {
+            foreground
+        } else if dark {
+            [224, 224, 224, 255]
+        } else {
+            [48, 48, 48, 255]
+        };
+        match role {
+            "aos.color.background" => Some(TokenValue::Color(background)),
+            "aos.color.surface" => Some(TokenValue::Color(background)),
+            "aos.color.text" => Some(TokenValue::Color(foreground)),
+            "aos.color.text-muted" => Some(TokenValue::Color(muted)),
+            "aos.color.border" => Some(TokenValue::Color(foreground)),
+            "aos.color.focus" => Some(TokenValue::Color(if dark {
+                [120, 200, 255, 255]
+            } else {
+                [0, 70, 170, 255]
+            })),
+            "aos.color.accent" => Some(TokenValue::Color(if dark {
+                [255, 215, 0, 255]
+            } else {
+                [0, 0, 139, 255]
+            })),
+            "aos.color.on-accent" => Some(TokenValue::Color(if dark {
+                [0, 0, 0, 255]
+            } else {
+                [255, 255, 255, 255]
+            })),
+            "aos.color.overlay" => Some(TokenValue::Color([0, 0, 0, 128])),
+            "aos.typography.caption" => Some(TokenValue::Length {
+                value: 12,
+                unit: LengthUnit::LogicalPixel,
+            }),
+            "aos.typography.body" => Some(TokenValue::Length {
+                value: 16,
+                unit: LengthUnit::LogicalPixel,
+            }),
+            "aos.typography.title" => Some(TokenValue::Length {
+                value: 20,
+                unit: LengthUnit::LogicalPixel,
+            }),
+            "aos.typography.display" => Some(TokenValue::Length {
+                value: 28,
+                unit: LengthUnit::LogicalPixel,
+            }),
+            role if role.starts_with("aos.elevation.") => Some(TokenValue::Length {
+                value: 0,
+                unit: LengthUnit::LogicalPixel,
+            }),
+            role if role.starts_with("aos.space.") => Some(TokenValue::Length {
+                value: 8,
+                unit: LengthUnit::LogicalPixel,
+            }),
+            role if role.starts_with("aos.radius.") => Some(TokenValue::Length {
+                value: 4,
+                unit: LengthUnit::LogicalPixel,
+            }),
+            role if role.starts_with("aos.motion.") => Some(TokenValue::DurationMs(0)),
+            "aos.color.success"
+            | "aos.color.warning"
+            | "aos.color.danger"
+            | "aos.color.information"
+            | "aos.color.neutral"
+            | "aos.color.disabled"
+            | "aos.color.selected" => Some(TokenValue::Color(if dark {
+                [255, 255, 255, 255]
+            } else {
+                [0, 0, 0, 255]
+            })),
+            "aos.sound.default" => Some(TokenValue::Sound {
+                cue: SoundDescriptor::None,
+                volume_percent: 0,
+            }),
+            "aos.haptic.default" => Some(TokenValue::Haptic(HapticDescriptor::None)),
+            _ => None,
+        }
+    }
+
+    /// Build the complete neutral map.
+    pub fn tokens(environment: ColorEnvironment) -> BTreeMap<String, TokenValue> {
+        required_theme_roles()
+            .iter()
+            .filter_map(|role| Some(((*role).to_owned(), Self::token(role, environment)?)))
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Palette {
+    background: [u8; 4],
+    surface: [u8; 4],
+    text: [u8; 4],
+    text_muted: [u8; 4],
+    border: [u8; 4],
+    focus: [u8; 4],
+    accent: [u8; 4],
+    on_accent: [u8; 4],
+    success: [u8; 4],
+    warning: [u8; 4],
+    danger: [u8; 4],
+    information: [u8; 4],
+    neutral: [u8; 4],
+    disabled: [u8; 4],
+    selected: [u8; 4],
+    overlay: [u8; 4],
+}
+
+impl ThemePack {
+    /// Complete dark-first built-in theme.
+    pub fn aurora() -> Self {
+        Self::pack("aurora", false)
+    }
+
+    /// Complete light-first built-in theme.
+    pub fn daylight() -> Self {
+        Self::pack("daylight", true)
+    }
+
+    fn pack(id: &str, light: bool) -> Self {
+        let environments = [
+            ColorEnvironment::Light,
+            ColorEnvironment::Dark,
+            ColorEnvironment::HighContrastLight,
+            ColorEnvironment::HighContrastDark,
+        ]
+        .into_iter()
+        .map(|environment| {
+            (
+                environment,
+                EnvironmentSpec {
+                    material: if matches!(
+                        environment,
+                        ColorEnvironment::HighContrastLight | ColorEnvironment::HighContrastDark
+                    ) {
+                        Material::HighContrast
+                    } else {
+                        Material::Opaque
+                    },
+                    system_palette: if light {
+                        "neutral-light"
+                    } else {
+                        "neutral-dark"
+                    }
+                    .to_owned(),
+                    display_scale_percent: 100,
+                    safe_area: SafeArea {
+                        top: 16,
+                        leading: 0,
+                        trailing: 0,
+                        bottom: 24,
+                    },
+                },
+            )
+        })
+        .collect();
+        let semantic_tokens = [
+            ColorEnvironment::Light,
+            ColorEnvironment::Dark,
+            ColorEnvironment::HighContrastLight,
+            ColorEnvironment::HighContrastDark,
+        ]
+        .into_iter()
+        .map(|environment| (environment, semantic_tokens(id, environment)))
+        .collect();
+        let density_tokens = [Density::Compact, Density::Cozy, Density::Spacious]
+            .into_iter()
+            .map(|density| (density, density_tokens(density)))
+            .collect();
+        Self {
+            schema: THEME_SCHEMA.to_owned(),
+            id: id.to_owned(),
+            version: "1.0.0".to_owned(),
+            environments,
+            semantic_tokens,
+            density_tokens,
+            aliases: BTreeMap::new(),
+            preferences: Preferences {
+                pointer: true,
+                keyboard: true,
+                text_scale_percent: SUPPORTED_TEXT_SCALES.to_vec(),
+                reduced_motion: true,
+                sound: SoundDescriptor::Tap,
+                haptic: HapticDescriptor::Light,
+            },
+        }
+    }
+
+    /// Resolve a role after applying density and motion preferences.
+    pub fn resolved_tokens(
+        &self,
+        environment: ColorEnvironment,
+        density: Density,
+        reduced_motion: bool,
+    ) -> Option<BTreeMap<String, TokenValue>> {
+        let mut tokens = self.semantic_tokens.get(&environment)?.clone();
+        let overrides = self.density_tokens.get(&density)?;
+        for (role, value) in overrides {
+            tokens.insert(role.clone(), *value);
+        }
+        if reduced_motion {
+            for role in ["aos.motion.fast", "aos.motion.normal", "aos.motion.slow"] {
+                tokens.insert(role.to_owned(), TokenValue::DurationMs(0));
+            }
+        }
+        Some(tokens)
+    }
+
+    fn resolved_token(
+        &self,
+        environment: ColorEnvironment,
+        density: Density,
+        role: &str,
+    ) -> Option<TokenValue> {
+        if let Some(alias) = self.aliases.get(role)
+            && let Some(value) = self.resolved_token(environment, density, alias)
+        {
+            return Some(value);
+        }
+        if let Some(value) = self
+            .density_tokens
+            .get(&density)
+            .and_then(|tokens| tokens.get(role))
+        {
+            return Some(*value);
+        }
+        self.semantic_tokens
+            .get(&environment)
+            .and_then(|tokens| tokens.get(role))
+            .copied()
+    }
+
+    /// Validate exact schema, complete environment/density coverage, and bounds.
+    pub fn validate(&self) -> Result<(), ThemeError> {
+        if self.schema != THEME_SCHEMA {
+            return Err(ThemeError::Schema);
+        }
+        if !valid_theme_id(&self.id) {
+            return Err(ThemeError::Id);
+        }
+        if parse_version(&self.version).is_none() {
+            return Err(ThemeError::Version);
+        }
+        if self.environments.len() != 4
+            || self.semantic_tokens.len() != 4
+            || !all_environments(&self.environments)
+            || !all_environments(&self.semantic_tokens)
+        {
+            return Err(ThemeError::Environment);
+        }
+        for (environment, spec) in &self.environments {
+            if !matches!(spec.display_scale_percent, 80..=200)
+                || !valid_safe_area(&spec.safe_area)
+                || spec.system_palette.is_empty()
+                || spec.system_palette.len() > 64
+            {
+                return Err(ThemeError::EnvironmentValue);
+            }
+            let tokens = self
+                .semantic_tokens
+                .get(environment)
+                .ok_or(ThemeError::Token)?;
+            if tokens.len() != required_theme_roles().len()
+                || !required_theme_roles()
+                    .iter()
+                    .all(|role| tokens.contains_key(*role))
+            {
+                return Err(ThemeError::Token);
+            }
+            for (role, value) in tokens {
+                validate_token(role, *value).map_err(|_| ThemeError::TokenValue)?;
+            }
+            self.validate_accessibility(*environment)
+                .map_err(|_| ThemeError::Accessibility)?;
+        }
+        if self.density_tokens.len() != 3
+            || !matches!(
+                self.density_tokens.keys().collect::<Vec<_>>().as_slice(),
+                [Density::Compact, Density::Cozy, Density::Spacious]
+            )
+        {
+            return Err(ThemeError::Density);
+        }
+        for (density, overrides) in &self.density_tokens {
+            let resolved = self
+                .resolved_tokens(ColorEnvironment::Light, *density, false)
+                .ok_or(ThemeError::Density)?;
+            if !required_theme_roles()
+                .iter()
+                .all(|role| resolved.contains_key(*role))
+            {
+                return Err(ThemeError::Token);
+            }
+            for (role, value) in overrides {
+                validate_token(role, *value).map_err(|_| ThemeError::TokenValue)?;
+            }
+        }
+        for source in self.aliases.keys() {
+            if !required_theme_roles().contains(&source.as_str()) {
+                return Err(ThemeError::Alias);
+            }
+            let mut visited = BTreeSet::from([source.clone()]);
+            let mut target = source.clone();
+            while let Some(next) = self.aliases.get(&target) {
+                if !required_theme_roles().contains(&next.as_str()) || !visited.insert(next.clone())
+                {
+                    return Err(ThemeError::Alias);
+                }
+                target = next.clone();
+            }
+        }
+        if !self.preferences.pointer
+            || !self.preferences.keyboard
+            || !self.preferences.reduced_motion
+            || !SUPPORTED_TEXT_SCALES
+                .iter()
+                .all(|scale| self.preferences.text_scale_percent.contains(scale))
+        {
+            return Err(ThemeError::Preference);
+        }
+        Ok(())
+    }
+
+    /// WCAG contrast check for all required non-overlay color roles.
+    pub fn validate_accessibility(&self, environment: ColorEnvironment) -> Result<(), ThemeError> {
+        let tokens = self
+            .semantic_tokens
+            .get(&environment)
+            .ok_or(ThemeError::Token)?;
+        let color = |role: &str| match tokens.get(role) {
+            Some(TokenValue::Color(color)) => Ok(*color),
+            _ => Err(ThemeError::Token),
+        };
+        let background = color("aos.color.background")?;
+        if background[3] != 255 {
+            return Err(ThemeError::Accessibility);
+        }
+        for role in ["aos.color.text", "aos.color.text-muted"] {
+            if contrast(color(role)?, background) < 4.5 {
+                return Err(ThemeError::Accessibility);
+            }
+        }
+        for role in [
+            "aos.color.focus",
+            "aos.color.accent",
+            "aos.color.success",
+            "aos.color.warning",
+            "aos.color.danger",
+            "aos.color.information",
+            "aos.color.neutral",
+            "aos.color.disabled",
+            "aos.color.selected",
+        ] {
+            if contrast(color(role)?, background) < 3.0 {
+                return Err(ThemeError::Accessibility);
+            }
+        }
+        if contrast(color("aos.color.on-accent")?, color("aos.color.accent")?) < 4.5 {
+            return Err(ThemeError::Accessibility);
+        }
+        Ok(())
+    }
+}
+
+fn semantic_tokens(id: &str, environment: ColorEnvironment) -> BTreeMap<String, TokenValue> {
+    let dark = matches!(
+        environment,
+        ColorEnvironment::Dark | ColorEnvironment::HighContrastDark
+    );
+    let high_contrast = matches!(
+        environment,
+        ColorEnvironment::HighContrastLight | ColorEnvironment::HighContrastDark
+    );
+    let palette = palette(id, dark, high_contrast);
+    let color = |value: [u8; 4]| TokenValue::Color(value);
+    let length = |value: u16| TokenValue::Length {
+        value,
+        unit: LengthUnit::LogicalPixel,
+    };
+    BTreeMap::from([
+        ("aos.color.background".to_owned(), color(palette.background)),
+        ("aos.color.surface".to_owned(), color(palette.surface)),
+        ("aos.color.text".to_owned(), color(palette.text)),
+        ("aos.color.text-muted".to_owned(), color(palette.text_muted)),
+        ("aos.color.border".to_owned(), color(palette.border)),
+        ("aos.color.focus".to_owned(), color(palette.focus)),
+        ("aos.color.accent".to_owned(), color(palette.accent)),
+        ("aos.color.on-accent".to_owned(), color(palette.on_accent)),
+        ("aos.color.success".to_owned(), color(palette.success)),
+        ("aos.color.warning".to_owned(), color(palette.warning)),
+        ("aos.color.danger".to_owned(), color(palette.danger)),
+        (
+            "aos.color.information".to_owned(),
+            color(palette.information),
+        ),
+        ("aos.color.neutral".to_owned(), color(palette.neutral)),
+        ("aos.color.disabled".to_owned(), color(palette.disabled)),
+        ("aos.color.selected".to_owned(), color(palette.selected)),
+        ("aos.color.overlay".to_owned(), color(palette.overlay)),
+        ("aos.elevation.level-0".to_owned(), length(0)),
+        ("aos.elevation.level-1".to_owned(), length(2)),
+        ("aos.elevation.level-2".to_owned(), length(6)),
+        ("aos.elevation.level-3".to_owned(), length(12)),
+        ("aos.space.1".to_owned(), length(4)),
+        ("aos.space.2".to_owned(), length(8)),
+        ("aos.space.3".to_owned(), length(12)),
+        ("aos.space.4".to_owned(), length(16)),
+        ("aos.space.5".to_owned(), length(24)),
+        ("aos.space.6".to_owned(), length(32)),
+        ("aos.radius.control".to_owned(), length(8)),
+        ("aos.radius.surface".to_owned(), length(12)),
+        ("aos.typography.caption".to_owned(), length(12)),
+        ("aos.typography.body".to_owned(), length(16)),
+        ("aos.typography.title".to_owned(), length(20)),
+        ("aos.typography.display".to_owned(), length(28)),
+        ("aos.motion.fast".to_owned(), TokenValue::DurationMs(90)),
+        ("aos.motion.normal".to_owned(), TokenValue::DurationMs(150)),
+        ("aos.motion.slow".to_owned(), TokenValue::DurationMs(240)),
+        (
+            "aos.sound.default".to_owned(),
+            TokenValue::Sound {
+                cue: SoundDescriptor::Tap,
+                volume_percent: 70,
+            },
+        ),
+        (
+            "aos.haptic.default".to_owned(),
+            TokenValue::Haptic(HapticDescriptor::Light),
+        ),
+    ])
+}
+
+fn palette(id: &str, dark: bool, high_contrast: bool) -> Palette {
+    let transparent_black = [0, 0, 0, 64];
+    if id == "aurora" {
+        if dark && high_contrast {
+            return Palette {
+                background: [0, 0, 0, 255],
+                surface: [0, 0, 0, 255],
+                text: [255, 255, 255, 255],
+                text_muted: [235, 235, 235, 255],
+                border: [255, 255, 255, 255],
+                focus: [120, 200, 255, 255],
+                accent: [255, 215, 0, 255],
+                on_accent: [0, 0, 0, 255],
+                success: [110, 235, 180, 255],
+                warning: [255, 200, 80, 255],
+                danger: [255, 130, 150, 255],
+                information: [140, 200, 255, 255],
+                neutral: [240, 240, 240, 255],
+                disabled: [180, 180, 180, 255],
+                selected: [255, 225, 120, 255],
+                overlay: [0, 0, 0, 128],
+            };
+        }
+        if !dark && high_contrast {
+            return Palette {
+                background: [255, 255, 255, 255],
+                surface: [255, 255, 255, 255],
+                text: [0, 0, 0, 255],
+                text_muted: [25, 25, 25, 255],
+                border: [0, 0, 0, 255],
+                focus: [0, 70, 170, 255],
+                accent: [0, 0, 139, 255],
+                on_accent: [255, 255, 255, 255],
+                success: [0, 95, 65, 255],
+                warning: [125, 75, 0, 255],
+                danger: [145, 20, 40, 255],
+                information: [0, 70, 155, 255],
+                neutral: [25, 25, 25, 255],
+                disabled: [90, 90, 95, 255],
+                selected: [0, 0, 120, 255],
+                overlay: transparent_black,
+            };
+        }
+        if dark {
+            return Palette {
+                background: [11, 12, 15, 255],
+                surface: [21, 22, 28, 255],
+                text: [237, 238, 243, 255],
+                text_muted: [195, 196, 206, 255],
+                border: [82, 84, 96, 255],
+                focus: [120, 190, 255, 255],
+                accent: [171, 139, 255, 255],
+                on_accent: [14, 10, 28, 255],
+                success: [100, 220, 165, 255],
+                warning: [245, 190, 95, 255],
+                danger: [245, 125, 145, 255],
+                information: [130, 190, 255, 255],
+                neutral: [205, 206, 214, 255],
+                disabled: [165, 165, 175, 255],
+                selected: [205, 180, 255, 255],
+                overlay: [0, 0, 0, 128],
+            };
+        }
+        return Palette {
+            background: [255, 255, 255, 255],
+            surface: [248, 249, 252, 255],
+            text: [22, 23, 28, 255],
+            text_muted: [64, 65, 75, 255],
+            border: [115, 116, 128, 255],
+            focus: [0, 90, 190, 255],
+            accent: [60, 40, 180, 255],
+            on_accent: [255, 255, 255, 255],
+            success: [15, 110, 78, 255],
+            warning: [145, 87, 4, 255],
+            danger: [170, 32, 52, 255],
+            information: [8, 80, 155, 255],
+            neutral: [65, 66, 76, 255],
+            disabled: [110, 110, 118, 255],
+            selected: [50, 30, 160, 255],
+            overlay: transparent_black,
+        };
+    }
+    if dark && high_contrast {
+        return Palette {
+            background: [0, 0, 0, 255],
+            surface: [0, 0, 0, 255],
+            text: [255, 255, 255, 255],
+            text_muted: [235, 235, 235, 255],
+            border: [255, 255, 255, 255],
+            focus: [170, 240, 220, 255],
+            accent: [140, 255, 210, 255],
+            on_accent: [0, 0, 0, 255],
+            success: [140, 255, 210, 255],
+            warning: [255, 205, 90, 255],
+            danger: [255, 140, 155, 255],
+            information: [160, 210, 255, 255],
+            neutral: [240, 240, 240, 255],
+            disabled: [180, 180, 180, 255],
+            selected: [180, 255, 230, 255],
+            overlay: [0, 0, 0, 128],
+        };
+    }
+    if !dark && high_contrast {
+        return Palette {
+            background: [255, 255, 255, 255],
+            surface: [255, 255, 255, 255],
+            text: [0, 0, 0, 255],
+            text_muted: [25, 25, 25, 255],
+            border: [0, 0, 0, 255],
+            focus: [0, 90, 70, 255],
+            accent: [0, 90, 70, 255],
+            on_accent: [255, 255, 255, 255],
+            success: [0, 100, 75, 255],
+            warning: [120, 70, 0, 255],
+            danger: [150, 15, 35, 255],
+            information: [0, 65, 145, 255],
+            neutral: [25, 25, 25, 255],
+            disabled: [90, 90, 95, 255],
+            selected: [0, 80, 60, 255],
+            overlay: transparent_black,
+        };
+    }
+    if dark {
+        return Palette {
+            background: [14, 15, 18, 255],
+            surface: [23, 25, 28, 255],
+            text: [240, 241, 244, 255],
+            text_muted: [200, 201, 207, 255],
+            border: [88, 90, 98, 255],
+            focus: [170, 240, 220, 255],
+            accent: [120, 225, 190, 255],
+            on_accent: [3, 26, 20, 255],
+            success: [115, 230, 190, 255],
+            warning: [250, 195, 100, 255],
+            danger: [250, 130, 148, 255],
+            information: [140, 195, 255, 255],
+            neutral: [208, 209, 215, 255],
+            disabled: [168, 168, 176, 255],
+            selected: [170, 250, 220, 255],
+            overlay: [0, 0, 0, 128],
+        };
+    }
+    Palette {
+        background: [252, 251, 248, 255],
+        surface: [255, 255, 255, 255],
+        text: [22, 27, 25, 255],
+        text_muted: [64, 70, 67, 255],
+        border: [112, 118, 114, 255],
+        focus: [0, 105, 82, 255],
+        accent: [0, 110, 86, 255],
+        on_accent: [255, 255, 255, 255],
+        success: [10, 110, 85, 255],
+        warning: [140, 85, 0, 255],
+        danger: [170, 30, 50, 255],
+        information: [10, 75, 150, 255],
+        neutral: [64, 70, 67, 255],
+        disabled: [112, 112, 118, 255],
+        selected: [0, 90, 70, 255],
+        overlay: transparent_black,
+    }
+}
+
+fn density_tokens(density: Density) -> BTreeMap<String, TokenValue> {
+    let spaces: [u16; 6] = match density {
+        Density::Compact => [2, 4, 6, 10, 14, 20],
+        Density::Cozy => [4, 8, 12, 16, 24, 32],
+        Density::Spacious => [8, 12, 18, 24, 32, 40],
+    };
+    spaces
+        .into_iter()
+        .enumerate()
+        .map(|(index, value)| {
+            (
+                format!("aos.space.{}", index + 1),
+                TokenValue::Length {
+                    value,
+                    unit: LengthUnit::LogicalPixel,
+                },
+            )
+        })
+        .collect()
+}
+
+fn validate_token(role: &str, value: TokenValue) -> Result<(), ThemeError> {
+    if !valid_role(role) || !required_theme_roles().contains(&role) {
+        return Err(ThemeError::TokenValue);
+    }
+    match value {
+        TokenValue::Color(color) => {
+            if role == "aos.color.overlay" {
+                if color[3] == 0 {
+                    return Err(ThemeError::TokenValue);
+                }
+            } else if color[3] != 255 {
+                return Err(ThemeError::TokenValue);
+            }
+        }
+        TokenValue::Length { value, unit } => {
+            let approved = if role.starts_with("aos.space.") {
+                APPROVED_SPACE.contains(&value)
+            } else if role.starts_with("aos.radius.") {
+                APPROVED_RADIUS.contains(&value)
+            } else if role.starts_with("aos.typography.") {
+                matches!(value, 8..=64)
+            } else {
+                APPROVED_LENGTHS.contains(&value)
+            };
+            if !approved {
+                return Err(ThemeError::TokenValue);
+            }
+            if unit != LengthUnit::LogicalPixel
+                && !(role.starts_with("aos.typography.") && unit == LengthUnit::Percent)
+            {
+                return Err(ThemeError::TokenValue);
+            }
+        }
+        TokenValue::Ratio(value) => {
+            if !APPROVED_RATIO.contains(&value) {
+                return Err(ThemeError::TokenValue);
+            }
+        }
+        TokenValue::DurationMs(value) => {
+            if !APPROVED_DURATION.contains(&value) {
+                return Err(ThemeError::TokenValue);
+            }
+        }
+        TokenValue::Percent(value) => {
+            if !matches!(value, 0..=100) || value % 10 != 0 {
+                return Err(ThemeError::TokenValue);
+            }
+        }
+        TokenValue::Sound {
+            cue,
+            volume_percent,
+        } => {
+            if !matches!(volume_percent, 0..=100) || volume_percent % 5 != 0 {
+                return Err(ThemeError::TokenValue);
+            }
+            if volume_percent == 0 && cue != SoundDescriptor::None {
+                return Err(ThemeError::TokenValue);
+            }
+        }
+        TokenValue::Haptic(_) => {}
+    }
+    Ok(())
+}
+
+fn valid_theme_id(value: &str) -> bool {
+    let mut characters = value.chars();
+    if !characters
+        .next()
+        .is_some_and(|character| character.is_ascii_lowercase())
+        || value.len() > 64
+        || !value.chars().all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+        })
+    {
+        return false;
+    }
+    !value.ends_with('-') && !value.contains("--")
+}
+
+fn valid_role(role: &str) -> bool {
+    role.starts_with("aos.")
+        && role.len() <= 96
+        && !role.contains("..")
+        && role.chars().all(|character| {
+            character.is_ascii_lowercase()
+                || character.is_ascii_digit()
+                || matches!(character, '.' | '-')
+        })
+}
+
+fn all_environments<Value>(map: &BTreeMap<ColorEnvironment, Value>) -> bool {
+    [
+        ColorEnvironment::Light,
+        ColorEnvironment::Dark,
+        ColorEnvironment::HighContrastLight,
+        ColorEnvironment::HighContrastDark,
+    ]
+    .into_iter()
+    .all(|environment| map.contains_key(&environment))
+}
+
+fn valid_safe_area(area: &SafeArea) -> bool {
+    area.top <= 64 && area.leading <= 64 && area.trailing <= 64 && area.bottom <= 64
+}
+
+fn parse_version(value: &str) -> Option<[u64; 3]> {
+    let parts: Vec<_> = value.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    Some([
+        parts[0].parse().ok()?,
+        parts[1].parse().ok()?,
+        parts[2].parse().ok()?,
+    ])
+}
+
+fn pack_version(version: [u64; 3]) -> String {
+    format!("{}.{}.{}", version[0], version[1], version[2])
+}
+
+fn relative_luminance(color: [u8; 4]) -> f32 {
+    let channel = |value: u8| {
+        let value = f32::from(value) / 255.0;
+        if value <= 0.039_28 {
+            value / 12.92
+        } else {
+            ((value + 0.055) / 1.055).powf(2.4)
+        }
+    };
+    0.212_6 * channel(color[0]) + 0.715_2 * channel(color[1]) + 0.072_2 * channel(color[2])
+}
+
+fn contrast(left: [u8; 4], right: [u8; 4]) -> f32 {
+    let first = relative_luminance(left);
+    let second = relative_luminance(right);
+    (first.max(second) + 0.05) / (first.min(second) + 0.05)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ships_two_complete_themes() {
+        for pack in [ThemePack::aurora(), ThemePack::daylight()] {
+            pack.validate().expect("theme is complete");
+            for environment in [
+                ColorEnvironment::Light,
+                ColorEnvironment::Dark,
+                ColorEnvironment::HighContrastLight,
+                ColorEnvironment::HighContrastDark,
+            ] {
+                for density in [Density::Compact, Density::Cozy, Density::Spacious] {
+                    let tokens = pack
+                        .resolved_tokens(environment, density, false)
+                        .expect("theme tokens");
+                    assert_eq!(tokens.len(), required_theme_roles().len());
+                }
+            }
+        }
+        let registry = ThemeRegistry::new();
+        assert_eq!(registry.packs().len(), BUILT_IN_THEME_COUNT);
+    }
+
+    #[test]
+    fn hostile_tokens_fail_closed() {
+        let mut pack = ThemePack::daylight();
+        pack.aliases
+            .insert("aos.color.accent".to_owned(), "aos.color.text".to_owned());
+        assert!(pack.validate().is_ok());
+
+        let mut transparent_required_color = ThemePack::daylight();
+        transparent_required_color
+            .semantic_tokens
+            .get_mut(&ColorEnvironment::Light)
+            .unwrap()
+            .insert(
+                "aos.color.text".to_owned(),
+                TokenValue::Color([0, 0, 0, 128]),
+            );
+        assert!(matches!(
+            transparent_required_color.validate(),
+            Err(ThemeError::TokenValue)
+        ));
+
+        let mut infinite = ThemePack::daylight();
+        infinite
+            .density_tokens
+            .get_mut(&Density::Cozy)
+            .unwrap()
+            .insert("aos.space.1".to_owned(), TokenValue::Ratio(u16::MAX));
+        assert!(matches!(infinite.validate(), Err(ThemeError::TokenValue)));
+
+        let json = serde_json::json!({
+            "schema": THEME_SCHEMA,
+            "id": "hostile",
+            "version": "1.0.0",
+            "environments": {},
+            "semanticTokens": {},
+            "densityTokens": {},
+            "aliases": {},
+            "preferences": {},
+            "rawFont": "Public Sans"
+        });
+        assert!(serde_json::from_value::<ThemePack>(json).is_err());
+    }
+
+    #[test]
+    fn missing_token_falls_back_through_stages() {
+        let registry = ThemeRegistry::new();
+        let exact = registry
+            .resolve(
+                "daylight",
+                "1.0.0",
+                ColorEnvironment::Light,
+                Density::Cozy,
+                "aos.color.text",
+            )
+            .unwrap();
+        assert_eq!(exact.stage, FallbackStage::ExactTheme);
+        let compatible = registry
+            .resolve(
+                "daylight",
+                "1.4.0",
+                ColorEnvironment::Light,
+                Density::Cozy,
+                "aos.color.text",
+            )
+            .unwrap();
+        assert_eq!(compatible.stage, FallbackStage::CompatibleLatestMinor);
+        let neutral = registry
+            .resolve(
+                "absent",
+                "1.0.0",
+                ColorEnvironment::Dark,
+                Density::Compact,
+                "aos.color.text",
+            )
+            .unwrap();
+        assert_eq!(neutral.stage, FallbackStage::BuiltInContrast);
+    }
+}

--- a/capsules/capsule-surface-catalog/src/unknown.rs
+++ b/capsules/capsule-surface-catalog/src/unknown.rs
@@ -81,7 +81,7 @@ pub fn validate_unknown_component(
     if !valid_identifier(&document.identifier) {
         return Err(UnknownComponentError::Identifier);
     }
-    if Primitive::from_id(document.identifier.rsplit(':').next().unwrap_or("")).is_some() {
+    if Primitive::from_id(&document.identifier).is_some() {
         return Err(UnknownComponentError::KnownPrimitive);
     }
     if !document
@@ -194,10 +194,9 @@ mod tests {
             validate_unknown_component(&document("evil")),
             Err(UnknownComponentError::Identifier)
         );
-        assert_eq!(
-            validate_unknown_component(&document("example:Button")),
-            Err(UnknownComponentError::KnownPrimitive)
-        );
+        let namespaced_known_word = validate_unknown_component(&document("example:Button"))
+            .expect("a namespaced extension is not the unnamespaced catalog primitive");
+        assert_eq!(namespaced_known_word.identifier, "example:Button");
         let hostile_action = UnknownComponentDocument {
             accepted_actions: ["capability.grant".to_owned()].into_iter().collect(),
             ..document("example:Widget")

--- a/capsules/capsule-surface-catalog/src/unknown.rs
+++ b/capsules/capsule-surface-catalog/src/unknown.rs
@@ -1,0 +1,215 @@
+//! Safe namespaced-extension boundary and neutral fallback.
+
+use crate::catalog::Primitive;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::fmt;
+
+const MAX_CHILDREN: usize = 64;
+const MAX_IDENTIFIER_BYTES: usize = 128;
+
+/// Untrusted unknown-component document with only inert JSON children.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UnknownComponentDocument {
+    /// Declared namespaced identifier, preserved only when legal.
+    pub identifier: String,
+    /// References already accepted by the interaction contract.
+    pub accepted_actions: BTreeSet<String>,
+    /// Inert child documents; they are never interpreted as executable nodes.
+    pub children: Vec<serde_json::Value>,
+}
+
+/// Validated unknown component boundary.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnknownComponent {
+    /// Preserved identifier.
+    pub identifier: String,
+    /// Preserved legal action references.
+    pub accepted_actions: BTreeSet<String>,
+    /// Count of inert children omitted by the fallback.
+    pub omitted_children: usize,
+}
+
+/// Neutral rendering decision.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UnknownFallback {
+    /// Declared identifier.
+    pub identifier: String,
+    /// Accepted action references.
+    pub accepted_actions: BTreeSet<String>,
+    /// Stable neutral rendering marker.
+    pub rendering: String,
+    /// Unknown children are never executed.
+    pub children_executed: bool,
+    /// Fallback never creates authority.
+    pub authority_minted: bool,
+}
+
+/// Unknown-component rejection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UnknownComponentError {
+    /// Identifier was not a legal namespaced extension.
+    Identifier,
+    /// Identifier was legal but named a known v1 primitive.
+    KnownPrimitive,
+    /// An action reference was not legally accepted.
+    ActionReference,
+    /// Child count exceeded the safe bound.
+    Children,
+}
+
+impl fmt::Display for UnknownComponentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self {
+            Self::Identifier => "unknown component identifier is invalid",
+            Self::KnownPrimitive => "known primitives do not use the unknown fallback",
+            Self::ActionReference => "unknown component action reference is invalid",
+            Self::Children => "unknown component has too many children",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for UnknownComponentError {}
+
+/// Validate and reduce an unknown document to a neutral fallback decision.
+pub fn validate_unknown_component(
+    document: &UnknownComponentDocument,
+) -> Result<UnknownFallback, UnknownComponentError> {
+    if !valid_identifier(&document.identifier) {
+        return Err(UnknownComponentError::Identifier);
+    }
+    if Primitive::from_id(document.identifier.rsplit(':').next().unwrap_or("")).is_some() {
+        return Err(UnknownComponentError::KnownPrimitive);
+    }
+    if !document
+        .accepted_actions
+        .iter()
+        .all(|action| valid_action(action))
+    {
+        return Err(UnknownComponentError::ActionReference);
+    }
+    if document.children.len() > MAX_CHILDREN {
+        return Err(UnknownComponentError::Children);
+    }
+    Ok(UnknownFallback {
+        identifier: document.identifier.clone(),
+        accepted_actions: document.accepted_actions.clone(),
+        rendering: "neutral-unsupported-component".to_owned(),
+        children_executed: false,
+        authority_minted: false,
+    })
+}
+
+fn valid_identifier(value: &str) -> bool {
+    if value.len() > MAX_IDENTIFIER_BYTES || value.matches(':').count() != 1 {
+        return false;
+    }
+    let Some((namespace, component)) = value.split_once(':') else {
+        return false;
+    };
+    valid_namespace(namespace) && valid_component(component)
+}
+
+fn valid_namespace(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && value
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_lowercase())
+        && value.chars().all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+        })
+        && !value.ends_with('-')
+}
+
+fn valid_component(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && value
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_uppercase())
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric())
+}
+
+fn valid_action(value: &str) -> bool {
+    if value.is_empty()
+        || value.len() > 96
+        || !value
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_lowercase())
+    {
+        return false;
+    }
+    let legal = value.chars().all(|character| {
+        character.is_ascii_lowercase()
+            || character.is_ascii_digit()
+            || matches!(character, '-' | '.')
+    });
+    let forbidden = [
+        "grant",
+        "capability",
+        "secret",
+        "token",
+        "credential",
+        "exec",
+        "shell",
+    ];
+    legal && !forbidden.iter().any(|word| value.contains(word))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn document(identifier: &str) -> UnknownComponentDocument {
+        UnknownComponentDocument {
+            identifier: identifier.to_owned(),
+            accepted_actions: ["action.open-details".to_owned()].into_iter().collect(),
+            children: vec![serde_json::json!({ "opaque": true })],
+        }
+    }
+
+    #[test]
+    fn preserves_identifier_and_actions_but_omits_children() {
+        let fallback = validate_unknown_component(&document("example:UnsupportedWidget"))
+            .expect("unknown component is safe");
+        assert_eq!(fallback.identifier, "example:UnsupportedWidget");
+        assert!(fallback.accepted_actions.contains("action.open-details"));
+        assert_eq!(fallback.rendering, "neutral-unsupported-component");
+        assert!(!fallback.children_executed);
+        assert!(!fallback.authority_minted);
+    }
+
+    #[test]
+    fn rejects_hostile_identity_actions_and_execution() {
+        assert_eq!(
+            validate_unknown_component(&document("evil")),
+            Err(UnknownComponentError::Identifier)
+        );
+        assert_eq!(
+            validate_unknown_component(&document("example:Button")),
+            Err(UnknownComponentError::KnownPrimitive)
+        );
+        let hostile_action = UnknownComponentDocument {
+            accepted_actions: ["capability.grant".to_owned()].into_iter().collect(),
+            ..document("example:Widget")
+        };
+        assert_eq!(
+            validate_unknown_component(&hostile_action),
+            Err(UnknownComponentError::ActionReference)
+        );
+        let hostile_children = UnknownComponentDocument {
+            children: Vec::new(),
+            ..document("example:Widget")
+        };
+        assert!(validate_unknown_component(&hostile_children).is_ok());
+    }
+}

--- a/capsules/capsule-surface-catalog/src/unknown.rs
+++ b/capsules/capsule-surface-catalog/src/unknown.rs
@@ -1,6 +1,6 @@
 //! Safe namespaced-extension boundary and neutral fallback.
 
-use crate::catalog::Primitive;
+use crate::catalog::{CatalogPrimitive, Primitive};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fmt;


### PR DESCRIPTION
Tracking #93
Related #93

## Summary

Adds unpublished `capsule-surface-catalog`, a host-independent semantic catalog and theme-pack crate.

- Finite `aos.catalog/1` inventory consumed from unpublished `capsule-surface-model` `ComponentKind::ALL` (62 primitives)
- Complete primitive records; `Button` slots `leading-icon`, `label`, and `trailing-icon`
- Two complete `aos.theme/1` packs: `aos.builtin.fieldglass` and `aos.builtin.paper-signal`
- Deterministic token fallback: exact version, compatible latest minor, built-in contrast, then fail-closed neutral
- Catalog-owned Theme Lab matrix over every record, documented state, scenario, and both themes
- Unknown unnamespaced IDs reject; namespaced IDs fall back without executing unknown children
- Presentation never grants authority; `NativePortal` is visual/unavailable only

## Claim boundary

Unpublished library crate only. This PR does not install, grant, activate, package a `.capsule` artifact, publish, or integrate adaptive-shell or native visual surfaces.

## Residuals

- Theme Lab is semantic instantiation proof, not visual rendering proof
- Neutral fallback is structurally present and fail-closed; required roles are covered by built-in contrast
- Hosted CI is the remaining evidence class after this draft
