### PR TITLE
feat(capsules): add OrcaRouter LLM provider capsule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aos-orcarouter"
+version = "0.1.0"
+dependencies = [
+ "astrid-sdk",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "aos-prompt-builder"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "capsules/capsule-mcp",
     "capsules/capsule-openai",
     "capsules/capsule-openai-compat",
+    "capsules/capsule-orcarouter",
     "capsules/capsule-prompt-builder",
     "capsules/capsule-react",
     "capsules/capsule-registry",

--- a/capsules/capsule-orcarouter/.cargo/config.toml
+++ b/capsules/capsule-orcarouter/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "wasm32-unknown-unknown"
+
+[target.wasm32-unknown-unknown]
+# Activates astrid-sys's custom getrandom backend that routes to
+# `astrid:sys.random-bytes`. Without this, uuid v4 / HashMap RNG seed
+# init fail to link on `wasm32-unknown-unknown`.
+rustflags = ["--cfg=getrandom_backend=\"custom\""]

--- a/capsules/capsule-orcarouter/.gitignore
+++ b/capsules/capsule-orcarouter/.gitignore
@@ -1,0 +1,2 @@
+/target
+.DS_Store

--- a/capsules/capsule-orcarouter/Capsule.toml
+++ b/capsules/capsule-orcarouter/Capsule.toml
@@ -1,0 +1,37 @@
+[package]
+name = "aos-orcarouter"
+version = "0.1.0"
+description = "OrcaRouter LLM Provider"
+authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
+astrid-version = ">=0.1.0"
+
+[[component]]
+id = "orcarouter"
+file = "aos_orcarouter.wasm"
+type = "executable"
+capabilities = { net = ["*"] }
+
+[exports]
+"astrid:llm" = "1.0.0"
+
+[publish]
+"llm.v1.stream.orcarouter" = { wit = "@unicity-astrid/wit/llm/stream-event" }
+# Exact topic for the post-#752 registry fan-out (registry subscribes to
+# the unsuffixed name). The `.*` wildcard below stays for any future
+# call-site that wants per-provider response correlation routing.
+"llm.v1.response.describe" = { wit = "@unicity-astrid/wit/llm/describe-response" }
+"llm.v1.response.describe.*" = { wit = "@unicity-astrid/wit/llm/describe-response" }
+
+[subscribe]
+"llm.v1.request.describe" = { wit = "@unicity-astrid/wit/llm/describe-request", handler = "llm_describe" }
+"llm.v1.request.generate.orcarouter" = { wit = "@unicity-astrid/wit/llm/generate-request", handler = "handle_llm_request" }
+
+[capabilities]
+net = ["*"]
+
+[env]
+api_key = { type = "secret", request = "Enter your OrcaRouter API key", placeholder = "or_..." }
+model = { type = "select", request = "Enter the default model ID", default = "orcarouter/free", placeholder = "orcarouter/free", options_from = { http = "https://api.orcarouter.ai/v1/models", bearer = "{api_key}", select = "data[].id", after = ["api_key"] } }
+context_window = { type = "integer", request = "Enter the model's context window size (tokens)", default = "128000", placeholder = "128000" }
+max_output_tokens = { type = "integer", request = "Enter the max output tokens (applied to HTTP request)", default = "8192", placeholder = "8192" }
+temperature = { type = "string", request = "Enter the default temperature (0.0-2.0, blank = provider default)", placeholder = "0.7" }

--- a/capsules/capsule-orcarouter/Cargo.toml
+++ b/capsules/capsule-orcarouter/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aos-orcarouter"
+version = "0.1.0"
+edition = "2024"
+description = "OrcaRouter LLM provider capsule for Unicity AOS"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+astrid-sdk = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }

--- a/capsules/capsule-orcarouter/LICENSE-APACHE
+++ b/capsules/capsule-orcarouter/LICENSE-APACHE
@@ -1,0 +1,200 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an
+      individually identifiable public domain dedication and license
+      statement from each contributor.
+
+   Copyright 2025 Joshua J. Bouw and Unicity Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/capsules/capsule-orcarouter/LICENSE-MIT
+++ b/capsules/capsule-orcarouter/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Joshua J. Bouw and Unicity Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/capsules/capsule-orcarouter/README.md
+++ b/capsules/capsule-orcarouter/README.md
@@ -1,0 +1,106 @@
+# aos-orcarouter
+
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
+
+**The OrcaRouter LLM provider for [Unicity AOS](https://github.com/unicity-aos/aos-ce).**
+
+In the OS model, this capsule is a device driver. It translates between the runtime's standardized LLM
+event protocol and the OrcaRouter gateway's OpenAI-compatible Chat Completions API — the same way a
+device driver translates between an OS and hardware.
+
+OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it
+exposes a provider/model namespace across many models — but it also combines adaptive routing,
+automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance
+behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users
+can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.
+
+The gateway origin is `https://api.orcarouter.ai` — the capsule appends `/v1/chat/completions` for
+generation and `/v1/models` for discovery.
+
+## How it works
+
+1. Subscribes to `llm.v1.request.generate.orcarouter` IPC events
+2. Converts the runtime's `Message` format to the OpenAI Chat Completions JSON format (text, tool calls,
+   tool results, multipart)
+3. Opens a streaming HTTP connection to `https://api.orcarouter.ai/v1/chat/completions` via the HTTP
+   streaming airlock
+4. Parses the SSE response in real-time and publishes standardized `llm.v1.stream.orcarouter`
+   events back to the IPC bus as chunks arrive
+
+Stream events cover the full response lifecycle: text deltas, parallel tool call
+start/delta/end, usage reporting (prompt + completion tokens), and completion.
+
+## Model discovery
+
+When the registry asks this capsule what it can serve, the capsule queries
+`GET https://api.orcarouter.ai/v1/models` and returns one provider entry per discovered model id
+(e.g. `orcarouter/free`, `orcarouter/fusion`). Every entry shares the same request and stream topics;
+the entry id IS the model id.
+
+Discovery runs at describe-time (when the registry fans out `llm.v1.request.describe`), not at
+startup. The env `model` value controls two things during discovery:
+
+- **Ordering.** If the env model appears in the discovered list, its entry is emitted first
+  (`entry[0]`), so the registry can pre-select it. All other models keep their upstream order.
+- **Offline fallback.** If `https://api.orcarouter.ai/v1/models` is unreachable or returns an error,
+  the capsule falls back to advertising a single entry for the configured env model. This keeps
+  existing pinned installs working when the gateway is temporarily down.
+
+If discovery fails AND no env model is configured, the capsule advertises nothing rather than
+invent a bogus id the registry could send upstream verbatim.
+
+## Configuration
+
+These fields are prompted during `aos init`. Every field except `api_key` has a default or can be
+left blank.
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | secret | -- | OrcaRouter API key, sent as `Authorization: Bearer ...` |
+| `model` | select | `orcarouter/free` | Default model; populated live from `https://api.orcarouter.ai/v1/models` during onboarding |
+| `context_window` | integer | `128000` | Context window (tokens) advertised to the registry |
+| `max_output_tokens` | integer | `8192` | Sent as `max_tokens` on each request |
+| `temperature` | string | _(unset)_ | Sampling temperature (`0.0`--`2.0`); blank uses the provider default |
+
+### The `model` field is a live select
+
+During `aos init`, the installer fetches `https://api.orcarouter.ai/v1/models` (using the entered
+`api_key`) and presents a numbered menu of available models. The configured `model` default is
+pre-selected. If the endpoint cannot be reached the installer falls back to free-text entry.
+
+## Selecting a model at runtime
+
+Model selection is per-principal and stored in the registry capsule's KV store. OrcaRouter models
+are qualified with the provider alias (`orcarouter:<model>`) only when a bare id would be ambiguous
+across providers:
+
+```sh
+# Select an OrcaRouter model by bare id (when unambiguous)
+aos models set orcarouter/free
+
+# Disambiguate when another provider serves the same model name
+aos models set orcarouter:orcarouter/free
+```
+
+## IPC protocol
+
+| Direction | Topic | Payload |
+|---|---|---|
+| Subscribe | `llm.v1.request.generate.orcarouter` | `IpcPayload::LlmRequest` |
+| Subscribe | `llm.v1.request.describe` | describe request (registry fan-out) |
+| Publish | `llm.v1.stream.orcarouter` | `IpcPayload::LlmStreamEvent` |
+| Publish | `llm.v1.response.describe` | provider descriptor array |
+
+## Development
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo build
+```
+
+## License
+
+Dual-licensed under [MIT](LICENSE-MIT) and [Apache 2.0](LICENSE-APACHE).
+
+Copyright (c) 2025-2026 Joshua J. Bouw and Unicity Labs.

--- a/capsules/capsule-orcarouter/rust-toolchain.toml
+++ b/capsules/capsule-orcarouter/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.94.0"
+targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]

--- a/capsules/capsule-orcarouter/src/lib.rs
+++ b/capsules/capsule-orcarouter/src/lib.rs
@@ -1,0 +1,986 @@
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+#![deny(unreachable_pub)]
+#![warn(missing_docs)]
+
+//! OrcaRouter LLM provider capsule.
+//!
+//! Subscribes to `llm.v1.request.generate.orcarouter` IPC events, calls the
+//! OrcaRouter Chat Completions API via the HTTP airlock, parses the SSE
+//! streaming response, and publishes standardized `llm.v1.stream.orcarouter`
+//! events back to the event bus.
+//!
+//! OrcaRouter is an OpenAI-compatible AI gateway (`https://api.orcarouter.ai`),
+//! so the request/stream protocol matches the OpenAI Chat Completions wire
+//! format used by [`aos-openai-compat`] — but the base URL and provider
+//! identity are pinned to OrcaRouter instead of being a configurable
+//! any-endpoint.
+
+mod schemas;
+
+use astrid_sdk::prelude::*;
+use astrid_sdk::types::{IpcPayload, Message, MessageContent, MessageRole, StreamEvent};
+use schemas::{ChatCompletionChunk, ModelList};
+use serde_json::Value;
+use uuid::Uuid;
+
+const STREAM_TOPIC: &str = "llm.v1.stream.orcarouter";
+/// IPC topic this provider advertises and the registry routes generation
+/// requests to. This is the stable provider route alias, not the package name.
+const REQUEST_TOPIC: &str = "llm.v1.request.generate.orcarouter";
+/// Provider alias used to qualify model ids (`orcarouter:<model>`).
+const PROVIDER_ALIAS: &str = "orcarouter";
+/// OrcaRouter gateway origin. The capsule appends `/v1/chat/completions` for
+/// generation and `/v1/models` for discovery — the same path layout as the
+/// OpenAI-compatible providers, served from the OrcaRouter gateway.
+const BASE_URL: &str = "https://api.orcarouter.ai";
+/// Default model hint when the env `model` is unset.
+const DEFAULT_MODEL: &str = "orcarouter/free";
+/// Maximum SSE line buffer size (1 MB). If the server sends data without
+/// a newline that exceeds this, the stream is aborted.
+const MAX_LINE_BUFFER_SIZE: usize = 1024 * 1024;
+
+#[derive(Debug)]
+enum SseData {
+    Done,
+    Chunk(ChatCompletionChunk),
+}
+
+/// OrcaRouter LLM provider capsule.
+#[derive(Default)]
+pub struct OrcaRouterProvider;
+
+#[capsule]
+impl OrcaRouterProvider {
+    /// Handles incoming LLM generation requests.
+    #[astrid::interceptor("handle_llm_request")]
+    pub fn handle_llm_request(&self, req: IpcPayload) -> Result<(), SysError> {
+        if let IpcPayload::LlmRequest {
+            request_id,
+            model,
+            messages,
+            tools,
+            system,
+            ..
+        } = req
+            && let Err(e) = Self::execute_request(request_id, &model, &messages, &tools, &system)
+        {
+            log::error(format!("LLM request failed: {e}"));
+            let _ = ipc::publish_json(
+                STREAM_TOPIC,
+                &IpcPayload::LlmStreamEvent {
+                    request_id,
+                    event: StreamEvent::Error(e.to_string()),
+                },
+            );
+        }
+        Ok(())
+    }
+
+    /// Returns provider metadata for IPC-based provider discovery.
+    ///
+    /// The registry capsule publishes a `llm.v1.request.describe` envelope
+    /// and drains responses on `llm.v1.response.describe` for a bounded
+    /// window. Each provider capsule subscribes to the request topic and
+    /// publishes its capability descriptor on the response topic. This
+    /// replaces the pre-#752 `hooks::trigger` fan-out path that returned
+    /// interceptor results through kernel-mediated dispatch — under the
+    /// new ABI the interceptor return value is no longer fanned out, so
+    /// the provider must publish explicitly.
+    ///
+    /// The return value is kept (same shape) so other interceptor callers
+    /// continue to see the descriptor; the explicit `ipc::publish_json`
+    /// is what registry's new fan-out actually consumes.
+    #[astrid::interceptor("llm_describe")]
+    pub fn llm_describe(&self, _payload: serde_json::Value) -> Result<serde_json::Value, SysError> {
+        // A blank or whitespace-only env `model` is treated as unset: we never
+        // advertise a bogus `unknown` id the registry could bind and then send
+        // upstream verbatim. The configured default is `None` in that case.
+        let default_model = Self::parse_env_model(env::var("model").ok());
+        let context_window = env::var("context_window")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(128_000);
+        let max_output = env::var("max_output_tokens")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(8_192);
+
+        // Discover the upstream catalogue, folding the discovery result and the
+        // configured default into the final id list (see `resolve_model_ids`).
+        let discovery = Self::discover_models();
+        if let Err(e) = &discovery {
+            match &default_model {
+                Some(_) => log::warn(format!(
+                    "/v1/models discovery failed, using env default: {e}"
+                )),
+                None => log::warn(format!(
+                    "/v1/models discovery failed and no env model configured; \
+                     advertising no provider entries: {e}"
+                )),
+            }
+        }
+        let model_ids = Self::resolve_model_ids(discovery, default_model.as_deref());
+
+        let default_ref = default_model.as_deref().unwrap_or("");
+        let providers =
+            Self::describe_providers(&model_ids, default_ref, context_window, max_output);
+        let response = serde_json::json!({ "providers": providers });
+        ipc::publish_json("llm.v1.response.describe", &response)?;
+        Ok(response)
+    }
+}
+
+impl OrcaRouterProvider {
+    /// Normalize the raw env `model` value into a configured default.
+    ///
+    /// A missing value, or one that is empty or whitespace-only after trimming,
+    /// is treated as **unset** (`None`). This is deliberate: a blank env model
+    /// must never become a selectable provider-entry id, otherwise the registry
+    /// could bind it and we would send a meaningless `model` upstream.
+    fn parse_env_model(raw: Option<String>) -> Option<String> {
+        raw.map(|v| v.trim().to_string()).filter(|v| !v.is_empty())
+    }
+
+    /// Fold the `/v1/models` discovery result and the configured default into
+    /// the final list of model ids to advertise.
+    ///
+    /// - Discovery succeeded: use the discovered ids verbatim.
+    /// - Discovery failed but a default is configured: fall back to that single
+    ///   id so existing pinned installs never regress.
+    /// - Discovery failed AND no default is configured: return an empty list, so
+    ///   the provider advertises NO entries rather than a bogus `unknown` one
+    ///   that the registry could bind and then send upstream.
+    fn resolve_model_ids(
+        discovery: Result<Vec<String>, SysError>,
+        default_model: Option<&str>,
+    ) -> Vec<String> {
+        match discovery {
+            Ok(ids) => ids,
+            Err(_) => match default_model {
+                Some(model) => vec![model.to_string()],
+                None => Vec::new(),
+            },
+        }
+    }
+
+    /// Build the `Authorization` header value from a raw configured key.
+    ///
+    /// Returns `Some("Bearer <trimmed>")` only when the key has non-whitespace
+    /// content; a missing, empty, or whitespace/newline-only key (common from a
+    /// copy-paste) is treated as **keyless** (`None`) so we never emit
+    /// `Authorization: Bearer <whitespace>`, which permissive/keyless
+    /// OpenAI-compatible servers reject. The header carries the trimmed value,
+    /// stripping stray surrounding whitespace from the configured secret.
+    fn bearer_header(raw_key: &str) -> Option<String> {
+        let trimmed = raw_key.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(format!("Bearer {trimmed}"))
+        }
+    }
+
+    /// Query `GET {base_url}/v1/models` and return the discovered model ids.
+    ///
+    /// Returns `Ok(Vec)` with **at least one** id on success. Any failure
+    /// (network error, non-2xx, unparseable body, empty `data`) returns `Err`
+    /// so the caller falls back to the env default. Never panics; never blocks
+    /// beyond the host HTTP timeout.
+    fn discover_models() -> Result<Vec<String>, SysError> {
+        let url = format!("{}/v1/models", BASE_URL);
+
+        let mut req = http::Request::get(&url);
+        // Only send `Authorization` when the key has non-whitespace content, and
+        // send the trimmed value: a whitespace/newline-only key (common from a
+        // copy-paste) must be treated as keyless, not sent as `Bearer <ws>`.
+        if let Some(value) = Self::bearer_header(&env::var("api_key").unwrap_or_default()) {
+            req = req.header("authorization", value);
+        }
+
+        let resp = http::send(&req)?;
+        if !resp.is_success() {
+            return Err(SysError::ApiError(format!(
+                "/v1/models returned status {}",
+                resp.status()
+            )));
+        }
+
+        let list: ModelList = resp.json()?;
+        Self::extract_model_ids(list)
+    }
+
+    /// Pure extraction + emptiness gate, split out so it is unit-testable
+    /// without HTTP. Drops blank ids (empty or whitespace-only, which cannot be
+    /// selected) and deduplicates colliding ids stably (preserving server
+    /// order), guarding against hostile upstreams that repeat an id; errors if
+    /// nothing usable remains so the caller falls back to the env default.
+    fn extract_model_ids(list: ModelList) -> Result<Vec<String>, SysError> {
+        let mut seen = std::collections::HashSet::new();
+        let ids: Vec<String> = list
+            .data
+            .into_iter()
+            .map(|m| m.id)
+            .filter(|id| !id.trim().is_empty())
+            .filter(|id| seen.insert(id.clone()))
+            .collect();
+        if ids.is_empty() {
+            return Err(SysError::ApiError("/v1/models returned no models".into()));
+        }
+        Ok(ids)
+    }
+
+    /// Build one provider-entry per model id, with the env-default model emitted
+    /// FIRST (`entry[0]`) so the registry can pre-select it positionally. Every
+    /// entry shares the same `request_topic`/`stream_topic`. There is NO
+    /// `"default"` field — the default is signalled by ORDER. All entries are
+    /// plain `serde_json::Value`.
+    ///
+    /// Ordering rules:
+    /// - If `default_model` appears in `model_ids`, its entry is `entry[0]` and
+    ///   the remaining ids keep their discovered order after it.
+    /// - If `default_model` is NOT in `model_ids` (the upstream catalogue does
+    ///   not advertise the configured default), the discovered order is
+    ///   preserved unchanged; `entry[0]` is simply the first discovered model.
+    ///   The registry still auto-selects `entry[0]`; the operator's configured
+    ///   `model` was not offered by the upstream, so the first servable model is
+    ///   the best default.
+    fn describe_providers(
+        model_ids: &[String],
+        default_model: &str,
+        context_window: u64,
+        max_output: u64,
+    ) -> Vec<serde_json::Value> {
+        // Stable partition: default model first (if present), then the rest in
+        // their discovered order.
+        let mut ordered: Vec<&String> = Vec::with_capacity(model_ids.len());
+        ordered.extend(model_ids.iter().filter(|id| id.as_str() == default_model));
+        ordered.extend(model_ids.iter().filter(|id| id.as_str() != default_model));
+
+        ordered
+            .iter()
+            .map(|id| {
+                serde_json::json!({
+                    "id": id,
+                    "description": format!("OrcaRouter model: {id}"),
+                    "capabilities": ["text", "vision", "tools"],
+                    "request_topic": REQUEST_TOPIC,
+                    "stream_topic": STREAM_TOPIC,
+                    "context_window": context_window,
+                    "max_output_tokens": max_output,
+                })
+            })
+            .collect()
+    }
+
+    /// Build and send the HTTP request, then parse the SSE response.
+    fn execute_request(
+        request_id: Uuid,
+        model: &str,
+        messages: &[Message],
+        tools: &[astrid_sdk::types::LlmToolDefinition],
+        system: &str,
+    ) -> Result<(), SysError> {
+        let url = format!("{}/v1/chat/completions", BASE_URL);
+
+        let resolved_model = Self::resolve_request_model(model, env::var("model").ok());
+
+        let mut api_messages: Vec<Value> = Vec::new();
+
+        // System message goes first in the messages array.
+        if !system.is_empty() {
+            api_messages.push(serde_json::json!({
+                "role": "system",
+                "content": system,
+            }));
+        }
+
+        for msg in messages {
+            if msg.role != MessageRole::System {
+                api_messages.push(Self::convert_message(msg));
+            }
+        }
+
+        let mut request_body = serde_json::json!({
+            "model": resolved_model,
+            "messages": api_messages,
+            "stream": true,
+            "stream_options": { "include_usage": true },
+        });
+
+        // Apply default generation parameters from env (only if not already
+        // specified in the request — env vars are defaults, not overrides).
+        let has_max_tokens = request_body.get("max_tokens").is_some_and(|v| !v.is_null());
+        if !has_max_tokens
+            && let Ok(max_tokens) = env::var("max_output_tokens")
+            && let Ok(n) = max_tokens.parse::<u64>()
+            && n > 0
+        {
+            request_body["max_tokens"] = serde_json::json!(n);
+        }
+        let has_temp = request_body
+            .get("temperature")
+            .is_some_and(|v| !v.is_null());
+        if !has_temp
+            && let Ok(temp) = env::var("temperature")
+            && let Ok(t) = temp.parse::<f64>()
+        {
+            request_body["temperature"] = serde_json::json!(t);
+        }
+
+        if !tools.is_empty() {
+            let api_tools: Vec<Value> = tools
+                .iter()
+                .map(|t| {
+                    serde_json::json!({
+                        "type": "function",
+                        "function": {
+                            "name": t.name,
+                            "description": t.description,
+                            "parameters": t.input_schema,
+                        }
+                    })
+                })
+                .collect();
+            request_body["tools"] = Value::Array(api_tools);
+        }
+
+        let api_key = env::var("api_key").unwrap_or_default();
+        if api_key.is_empty() {
+            return Err(SysError::ApiError("api_key not configured".into()));
+        }
+
+        let req = http::Request::post(&url)
+            .header("authorization", format!("Bearer {api_key}"))
+            .json(&request_body)?;
+
+        let stream = http::stream_start(&req)?;
+
+        if stream.status() != 200 {
+            // Drain the error body for the error message. Stream drops at
+            // scope exit; no manual close required.
+            let mut error_body = String::new();
+            while let Some(chunk) = stream.read_chunk()? {
+                error_body.push_str(&String::from_utf8_lossy(&chunk));
+                if error_body.len() > 4096 {
+                    error_body.truncate(4096);
+                    break;
+                }
+            }
+            return Err(SysError::ApiError(format!(
+                "API error ({}): {error_body}",
+                stream.status()
+            )));
+        }
+
+        Self::parse_sse_stream_live(request_id, &stream)
+        // `stream` drops here, releasing the kernel-side HTTP stream.
+    }
+
+    /// Stream SSE chunks in real-time, publishing IPC events as they arrive.
+    fn parse_sse_stream_live(request_id: Uuid, stream: &http::HttpStream) -> Result<(), SysError> {
+        let mut active_tools: Vec<(String, String)> = Vec::new();
+        let mut line_buffer = String::new();
+
+        while let Some(chunk) = stream.read_chunk()? {
+            let chunk_str = String::from_utf8_lossy(&chunk);
+            line_buffer.push_str(&chunk_str);
+
+            if line_buffer.len() > MAX_LINE_BUFFER_SIZE {
+                return Err(SysError::ApiError(
+                    "SSE line buffer exceeded maximum size".into(),
+                ));
+            }
+
+            // Process all complete lines in the buffer.
+            while let Some(newline_pos) = line_buffer.find('\n') {
+                let line = line_buffer[..newline_pos]
+                    .trim_end_matches('\r')
+                    .to_string();
+                line_buffer = line_buffer[(newline_pos + 1)..].to_string();
+
+                if line.is_empty() {
+                    continue;
+                }
+
+                let Some(data) = Self::sse_data_payload(&line) else {
+                    continue;
+                };
+
+                match Self::parse_sse_data(data)? {
+                    SseData::Done => {
+                        Self::publish_stream(request_id, StreamEvent::Done)?;
+                        return Ok(());
+                    }
+                    SseData::Chunk(chunk) => {
+                        Self::process_chunk(request_id, &chunk, &mut active_tools)?;
+                    }
+                }
+            }
+        }
+
+        if line_buffer.trim().is_empty() {
+            Err(SysError::ApiError("SSE stream ended before [DONE]".into()))
+        } else {
+            Err(SysError::ApiError(
+                "SSE stream ended with a partial line".into(),
+            ))
+        }
+    }
+
+    fn parse_sse_data(data: &str) -> Result<SseData, SysError> {
+        let data = data.trim();
+        if data == "[DONE]" {
+            return Ok(SseData::Done);
+        }
+
+        serde_json::from_str::<ChatCompletionChunk>(data)
+            .map(SseData::Chunk)
+            .map_err(|e| SysError::ApiError(format!("invalid SSE JSON: {e}")))
+    }
+
+    fn sse_data_payload(line: &str) -> Option<&str> {
+        let data = line.strip_prefix("data:")?.trim_start();
+        if data.trim().is_empty() {
+            return None;
+        }
+        Some(data)
+    }
+
+    /// Process a single parsed SSE chunk, emitting the appropriate stream events.
+    fn process_chunk(
+        request_id: Uuid,
+        chunk: &ChatCompletionChunk,
+        active_tools: &mut Vec<(String, String)>,
+    ) -> Result<(), SysError> {
+        // Handle usage (final chunk with empty choices).
+        if let Some(usage) = &chunk.usage {
+            Self::publish_stream(
+                request_id,
+                StreamEvent::Usage {
+                    input_tokens: usage.prompt_tokens,
+                    output_tokens: usage.completion_tokens,
+                },
+            )?;
+        }
+
+        let Some(choice) = chunk.choices.first() else {
+            return Ok(());
+        };
+
+        // Handle text deltas.
+        if let Some(ref text) = choice.delta.content
+            && !text.is_empty()
+        {
+            Self::publish_stream(request_id, StreamEvent::TextDelta(text.clone()))?;
+        }
+
+        // Handle tool call deltas.
+        if let Some(ref tool_calls) = choice.delta.tool_calls {
+            for tc in tool_calls {
+                // Grow the tracking vec if needed.
+                while active_tools.len() <= tc.index {
+                    active_tools.push((String::new(), String::new()));
+                }
+
+                if let Some(ref id) = tc.id {
+                    active_tools[tc.index].0 = id.clone();
+                }
+
+                if let Some(ref func) = tc.function {
+                    if let Some(ref name) = func.name {
+                        active_tools[tc.index].1 = name.clone();
+                        Self::publish_stream(
+                            request_id,
+                            StreamEvent::ToolCallStart {
+                                id: active_tools[tc.index].0.clone(),
+                                name: name.clone(),
+                            },
+                        )?;
+                    }
+
+                    if let Some(ref args) = func.arguments
+                        && !args.is_empty()
+                    {
+                        Self::publish_stream(
+                            request_id,
+                            StreamEvent::ToolCallDelta {
+                                id: active_tools[tc.index].0.clone(),
+                                args_delta: args.clone(),
+                            },
+                        )?;
+                    }
+                }
+            }
+        }
+
+        // Handle finish reason: emit ToolCallEnd for all active tool calls.
+        if let Some(ref reason) = choice.finish_reason
+            && reason == "tool_calls"
+        {
+            for (id, _name) in active_tools.iter() {
+                if !id.is_empty() {
+                    Self::publish_stream(request_id, StreamEvent::ToolCallEnd { id: id.clone() })?;
+                }
+            }
+            active_tools.clear();
+        }
+
+        Ok(())
+    }
+
+    /// Publish a stream event to the event bus.
+    fn publish_stream(request_id: Uuid, event: StreamEvent) -> Result<(), SysError> {
+        ipc::publish_json(
+            STREAM_TOPIC,
+            &IpcPayload::LlmStreamEvent { request_id, event },
+        )
+    }
+
+    /// Convert an Astrid `Message` to the OpenAI Chat Completions JSON format.
+    fn convert_message(message: &Message) -> Value {
+        match &message.content {
+            MessageContent::Text(text) => {
+                serde_json::json!({
+                    "role": Self::role_str(message.role),
+                    "content": text,
+                })
+            }
+            MessageContent::ToolCalls(calls) => {
+                let tool_calls: Vec<Value> = calls
+                    .iter()
+                    .map(|c| {
+                        serde_json::json!({
+                            "id": c.id,
+                            "type": "function",
+                            "function": {
+                                "name": c.name,
+                                "arguments": if c.arguments.is_string() {
+                                    c.arguments.clone()
+                                } else {
+                                    Value::String(c.arguments.to_string())
+                                },
+                            }
+                        })
+                    })
+                    .collect();
+
+                serde_json::json!({
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": tool_calls,
+                })
+            }
+            MessageContent::ToolResult(result) => {
+                serde_json::json!({
+                    "role": "tool",
+                    "tool_call_id": result.call_id,
+                    "content": result.content,
+                })
+            }
+            MessageContent::MultiPart(parts) => {
+                let content: Vec<Value> = parts
+                    .iter()
+                    .map(|p| match p {
+                        astrid_sdk::types::ContentPart::Text { text } => {
+                            serde_json::json!({"type": "text", "text": text})
+                        }
+                        astrid_sdk::types::ContentPart::Image { media_type, data } => {
+                            serde_json::json!({
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": format!("data:{media_type};base64,{data}"),
+                                }
+                            })
+                        }
+                    })
+                    .collect();
+
+                serde_json::json!({
+                    "role": Self::role_str(message.role),
+                    "content": content,
+                })
+            }
+        }
+    }
+
+    /// Map Astrid `MessageRole` to OpenAI role string.
+    fn role_str(role: MessageRole) -> &'static str {
+        match role {
+            MessageRole::System => "system",
+            MessageRole::User => "user",
+            MessageRole::Assistant => "assistant",
+            MessageRole::Tool => "tool",
+        }
+    }
+
+    fn provider_model_id(model: &str) -> &str {
+        model
+            .strip_prefix(PROVIDER_ALIAS)
+            .and_then(|rest| rest.strip_prefix(':'))
+            .unwrap_or(model)
+    }
+
+    fn resolve_request_model(model: &str, env_model: Option<String>) -> String {
+        let raw = if model.is_empty() {
+            env_model.unwrap_or_else(|| DEFAULT_MODEL.into())
+        } else {
+            model.to_string()
+        };
+        Self::provider_model_id(&raw).to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ModelList, OrcaRouterProvider, REQUEST_TOPIC, STREAM_TOPIC, SseData};
+
+    /// Helper: collect the `id` field of every provider entry, in order.
+    fn ids(entries: &[serde_json::Value]) -> Vec<String> {
+        entries
+            .iter()
+            .map(|e| e["id"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn parse_models_body_yields_one_entry_per_id() {
+        // Representative OrcaRouter `/v1/models` body with the `supported_endpoint_types`
+        // extra field, plus an openai-style id alongside.
+        let body = r#"{
+            "object": "list",
+            "data": [
+                { "id": "orcarouter/free", "object": "model", "owned_by": "orcarouter" },
+                { "id": "orcarouter/fusion", "object": "model", "owned_by": "orcarouter", "supported_endpoint_types": ["openai"] },
+                { "id": "gpt-5.4", "object": "model", "created": 1700000000 }
+            ]
+        }"#;
+        let list: ModelList = serde_json::from_str(body).expect("parse model list");
+        assert_eq!(list.data.len(), 3);
+        // The slash in OrcaRouter ids survives deserialization verbatim.
+        assert_eq!(list.data[0].id, "orcarouter/free");
+
+        let model_ids = OrcaRouterProvider::extract_model_ids(list).expect("non-empty");
+        assert_eq!(
+            model_ids,
+            vec!["orcarouter/free", "orcarouter/fusion", "gpt-5.4"]
+        );
+
+        let entries =
+            OrcaRouterProvider::describe_providers(&model_ids, "orcarouter/free", 128_000, 8_192);
+        assert_eq!(entries.len(), 3);
+        for entry in &entries {
+            assert_eq!(entry["request_topic"].as_str().unwrap(), REQUEST_TOPIC);
+        }
+        // `id` equals the source model id end-to-end (slash preserved).
+        assert_eq!(
+            ids(&entries),
+            vec!["orcarouter/free", "orcarouter/fusion", "gpt-5.4"]
+        );
+    }
+
+    #[test]
+    fn advertised_topics_use_stable_provider_alias() {
+        assert_eq!(REQUEST_TOPIC, "llm.v1.request.generate.orcarouter");
+        assert_eq!(STREAM_TOPIC, "llm.v1.stream.orcarouter");
+        assert!(REQUEST_TOPIC.ends_with(super::PROVIDER_ALIAS));
+        assert!(STREAM_TOPIC.ends_with(super::PROVIDER_ALIAS));
+    }
+
+    #[test]
+    fn provider_request_model_strips_registry_prefix_only() {
+        assert_eq!(
+            OrcaRouterProvider::provider_model_id("orcarouter:gpt-5.4"),
+            "gpt-5.4"
+        );
+        assert_eq!(
+            OrcaRouterProvider::provider_model_id("orcarouter:orcarouter/free"),
+            "orcarouter/free"
+        );
+        assert_eq!(
+            OrcaRouterProvider::provider_model_id("orcarouter/free"),
+            "orcarouter/free"
+        );
+        assert_eq!(
+            OrcaRouterProvider::provider_model_id("other:gpt-5.4"),
+            "other:gpt-5.4"
+        );
+    }
+
+    #[test]
+    fn request_model_normalization_also_applies_to_env_default() {
+        assert_eq!(
+            OrcaRouterProvider::resolve_request_model("", Some("orcarouter:gpt-5.4".to_string())),
+            "gpt-5.4"
+        );
+        assert_eq!(
+            OrcaRouterProvider::resolve_request_model(
+                "",
+                Some("orcarouter:orcarouter/fusion".to_string())
+            ),
+            "orcarouter/fusion"
+        );
+        assert_eq!(
+            OrcaRouterProvider::resolve_request_model(
+                "orcarouter:request-model",
+                Some("orcarouter:env-model".to_string())
+            ),
+            "request-model"
+        );
+        assert_eq!(
+            OrcaRouterProvider::resolve_request_model("", None),
+            "orcarouter/free"
+        );
+    }
+
+    #[test]
+    fn sse_data_payload_accepts_common_wire_variants() {
+        assert_eq!(
+            OrcaRouterProvider::sse_data_payload("data: {\"choices\":[]}"),
+            Some("{\"choices\":[]}")
+        );
+        assert_eq!(
+            OrcaRouterProvider::sse_data_payload("data:{\"choices\":[]}"),
+            Some("{\"choices\":[]}")
+        );
+        assert_eq!(
+            OrcaRouterProvider::sse_data_payload("data:   [DONE]"),
+            Some("[DONE]")
+        );
+        assert_eq!(OrcaRouterProvider::sse_data_payload("data:"), None);
+        assert_eq!(OrcaRouterProvider::sse_data_payload("data:   "), None);
+        assert_eq!(OrcaRouterProvider::sse_data_payload(": ping"), None);
+    }
+
+    #[test]
+    fn sse_data_done_is_terminal() {
+        assert!(matches!(
+            OrcaRouterProvider::parse_sse_data("[DONE]").expect("done parses"),
+            SseData::Done
+        ));
+        assert!(matches!(
+            OrcaRouterProvider::parse_sse_data("  [DONE]  ").expect("done parses"),
+            SseData::Done
+        ));
+    }
+
+    #[test]
+    fn sse_data_chunk_decodes_text_delta() {
+        let data = r#"{
+            "choices": [
+                {
+                    "delta": { "content": "hello" },
+                    "finish_reason": null
+                }
+            ]
+        }"#;
+        let parsed = OrcaRouterProvider::parse_sse_data(data).expect("chunk parses");
+        let SseData::Chunk(chunk) = parsed else {
+            panic!("expected chunk");
+        };
+        assert_eq!(chunk.choices[0].delta.content.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn malformed_sse_data_is_error() {
+        let err =
+            OrcaRouterProvider::parse_sse_data("{not-json}").expect_err("malformed data must fail");
+        assert!(
+            err.to_string().contains("invalid SSE JSON"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn describe_emits_env_model_first() {
+        // Default model is present but NOT first in discovered order.
+        let model_ids = vec![
+            "first-discovered".to_string(),
+            "the-default".to_string(),
+            "last-discovered".to_string(),
+        ];
+        let entries =
+            OrcaRouterProvider::describe_providers(&model_ids, "the-default", 128_000, 8_192);
+
+        // entry[0] is the env default; the rest keep their discovered order.
+        assert_eq!(entries[0]["id"].as_str().unwrap(), "the-default");
+        assert_eq!(
+            ids(&entries),
+            vec!["the-default", "first-discovered", "last-discovered"]
+        );
+
+        // No entry carries a "default" key — ordering is the only signal.
+        for entry in &entries {
+            assert!(entry.get("default").is_none());
+        }
+    }
+
+    #[test]
+    fn describe_preserves_order_when_default_absent() {
+        // Default model is NOT in the discovered list.
+        let model_ids = vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()];
+        let entries =
+            OrcaRouterProvider::describe_providers(&model_ids, "not-present", 128_000, 8_192);
+
+        // Discovered order preserved unchanged; nothing dropped.
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0]["id"].as_str().unwrap(), "alpha");
+        assert_eq!(ids(&entries), vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn empty_data_is_discovery_error() {
+        // Empty `data` array funnels to the fallback Err arm.
+        let empty: ModelList = serde_json::from_str(r#"{ "data": [] }"#).expect("parse");
+        assert!(OrcaRouterProvider::extract_model_ids(empty).is_err());
+
+        // A sole entry with an empty `id` is dropped, leaving nothing usable.
+        let blank: ModelList =
+            serde_json::from_str(r#"{ "data": [ { "id": "" } ] }"#).expect("parse");
+        assert!(OrcaRouterProvider::extract_model_ids(blank).is_err());
+
+        // A sole entry with a whitespace-only `id` is likewise dropped: it
+        // cannot be selected, so it funnels to the same fallback Err arm.
+        let whitespace: ModelList =
+            serde_json::from_str(r#"{ "data": [ { "id": "   " } ] }"#).expect("parse");
+        assert!(OrcaRouterProvider::extract_model_ids(whitespace).is_err());
+    }
+
+    #[test]
+    fn duplicate_ids_are_deduplicated_preserving_order() {
+        // A buggy/hostile upstream that repeats an id must not yield two
+        // provider entries with the same id. Dedup is stable on server order.
+        let dup: ModelList = serde_json::from_str(
+            r#"{ "data": [ { "id": "orcarouter/free" }, { "id": "orcarouter/free" } ] }"#,
+        )
+        .expect("parse");
+        let ids = OrcaRouterProvider::extract_model_ids(dup).expect("one survivor");
+        assert_eq!(ids, vec!["orcarouter/free"]);
+        assert_eq!(ids.len(), 1);
+
+        // Non-adjacent collisions collapse too, and the first occurrence wins
+        // (server order preserved for the survivors).
+        let scattered: ModelList = serde_json::from_str(
+            r#"{ "data": [ { "id": "a" }, { "id": "b" }, { "id": "a" }, { "id": "c" } ] }"#,
+        )
+        .expect("parse");
+        let ids = OrcaRouterProvider::extract_model_ids(scattered).expect("survivors");
+        assert_eq!(ids, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn unparseable_body_is_discovery_error() {
+        // A non-JSON / HTML body (e.g. a 404 page) fails to deserialize, which
+        // is the Err that triggers the env fallback in `discover_models`.
+        let result: Result<ModelList, _> = serde_json::from_str("<html>404</html>");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn blank_env_model_is_treated_as_unset() {
+        // Missing, empty, and whitespace-only env models all normalize to None,
+        // so none of them can leak into the advertised id set.
+        assert_eq!(OrcaRouterProvider::parse_env_model(None), None);
+        assert_eq!(
+            OrcaRouterProvider::parse_env_model(Some(String::new())),
+            None
+        );
+        assert_eq!(
+            OrcaRouterProvider::parse_env_model(Some("   \t".into())),
+            None
+        );
+        // A real value survives, trimmed.
+        assert_eq!(
+            OrcaRouterProvider::parse_env_model(Some("  orcarouter/free ".into())),
+            Some("orcarouter/free".to_string())
+        );
+    }
+
+    #[test]
+    fn no_env_model_and_failed_discovery_yields_no_entries() {
+        use super::SysError;
+
+        // The exact `llm_describe` state when env `model` is unset/blank AND
+        // `/v1/models` discovery fails: there is no configured default to fall
+        // back to, so the resolved id list MUST be empty — NOT a bogus `unknown`
+        // entry the registry could bind and then send upstream verbatim.
+        let failed: Result<Vec<String>, SysError> =
+            Err(SysError::ApiError("discovery failed".into()));
+        let model_ids = OrcaRouterProvider::resolve_model_ids(failed, None);
+        assert!(
+            model_ids.is_empty(),
+            "no env model + failed discovery must advertise nothing, got: {model_ids:?}"
+        );
+
+        // And the providers built from it carry no entries at all.
+        let providers = OrcaRouterProvider::describe_providers(&model_ids, "", 128_000, 8_192);
+        assert!(providers.is_empty());
+    }
+
+    #[test]
+    fn configured_default_survives_failed_discovery() {
+        use super::SysError;
+
+        // With a configured default, a discovery failure still falls back to the
+        // single pinned id so existing installs never regress.
+        let failed: Result<Vec<String>, SysError> = Err(SysError::ApiError("boom".into()));
+        let model_ids = OrcaRouterProvider::resolve_model_ids(failed, Some("orcarouter/free"));
+        assert_eq!(model_ids, vec!["orcarouter/free"]);
+    }
+
+    #[test]
+    fn successful_discovery_ignores_default_fallback() {
+        use super::SysError;
+
+        // On success the discovered ids are used verbatim regardless of default.
+        let ok: Result<Vec<String>, SysError> = Ok(vec!["a".into(), "b".into()]);
+        assert_eq!(
+            OrcaRouterProvider::resolve_model_ids(ok, None),
+            vec!["a", "b"]
+        );
+    }
+
+    #[test]
+    fn fallback_advertisement_matches_single_model_shape() {
+        // The discovery-failure path advertises a single env-model entry.
+        let entries = OrcaRouterProvider::describe_providers(
+            &["orcarouter/free".to_string()],
+            "orcarouter/free",
+            128_000,
+            8_192,
+        );
+
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry["id"].as_str().unwrap(), "orcarouter/free");
+        assert_eq!(entry["request_topic"].as_str().unwrap(), REQUEST_TOPIC);
+        // Shape-stable, positionally-default, no "default" key.
+        assert!(entry.get("default").is_none());
+    }
+
+    #[test]
+    fn whitespace_only_api_key_is_treated_as_keyless() {
+        // A copy-pasted key that is empty or only whitespace/newlines must NOT
+        // produce an `Authorization` header: sending `Bearer <whitespace>`
+        // breaks discovery against keyless/permissive servers. Treat it as
+        // keyless (no header) instead.
+        assert_eq!(OrcaRouterProvider::bearer_header(""), None);
+        assert_eq!(OrcaRouterProvider::bearer_header("   "), None);
+        assert_eq!(OrcaRouterProvider::bearer_header("\n"), None);
+        assert_eq!(OrcaRouterProvider::bearer_header(" \t\r\n "), None);
+    }
+
+    #[test]
+    fn real_api_key_is_trimmed_and_sent() {
+        // A genuine key still produces a header, with stray surrounding
+        // whitespace (copy-paste newline) stripped from the sent value.
+        assert_eq!(
+            OrcaRouterProvider::bearer_header("or_abc123"),
+            Some("Bearer or_abc123".to_string())
+        );
+        assert_eq!(
+            OrcaRouterProvider::bearer_header("  or_abc123\n"),
+            Some("Bearer or_abc123".to_string())
+        );
+    }
+}

--- a/capsules/capsule-orcarouter/src/schemas.rs
+++ b/capsules/capsule-orcarouter/src/schemas.rs
@@ -1,0 +1,95 @@
+//! OrcaRouter Chat Completions streaming types.
+//!
+//! OrcaRouter exposes an OpenAI-compatible Chat Completions API at
+//! `https://api.orcarouter.ai/v1`, so these types map to the OpenAI
+//! streaming wire format it speaks.
+
+use serde::Deserialize;
+
+/// A streaming chunk from the Chat Completions API.
+#[derive(Deserialize, Debug)]
+pub(crate) struct ChatCompletionChunk {
+    /// Choices in this chunk (empty in the final usage-only chunk).
+    #[serde(default)]
+    pub(crate) choices: Vec<ChunkChoice>,
+    /// Usage statistics (present only in the final chunk when
+    /// `stream_options.include_usage` is set).
+    pub(crate) usage: Option<OpenAIUsage>,
+}
+
+/// A single choice within a streaming chunk.
+#[derive(Deserialize, Debug)]
+pub(crate) struct ChunkChoice {
+    /// The delta content for this choice.
+    pub(crate) delta: ChunkDelta,
+    /// Finish reason: `null` while streaming, then `"stop"`, `"tool_calls"`,
+    /// or `"length"` at the end.
+    pub(crate) finish_reason: Option<String>,
+}
+
+/// Incremental delta within a streaming choice.
+#[derive(Deserialize, Debug)]
+pub(crate) struct ChunkDelta {
+    /// Text content delta.
+    pub(crate) content: Option<String>,
+    /// Tool call deltas (for parallel tool calls, indexed).
+    pub(crate) tool_calls: Option<Vec<ChunkToolCall>>,
+}
+
+/// A tool call delta in the streaming response.
+#[derive(Deserialize, Debug)]
+pub(crate) struct ChunkToolCall {
+    /// Index of the tool call (supports parallel tool calls).
+    pub(crate) index: usize,
+    /// Tool call ID (present only in the first chunk for this call).
+    pub(crate) id: Option<String>,
+    /// Function details.
+    pub(crate) function: Option<ChunkFunction>,
+}
+
+/// Function details within a tool call delta.
+#[derive(Deserialize, Debug)]
+pub(crate) struct ChunkFunction {
+    /// Function name (present only in the first chunk for this call).
+    pub(crate) name: Option<String>,
+    /// Partial JSON arguments to append.
+    pub(crate) arguments: Option<String>,
+}
+
+/// Token usage statistics.
+#[derive(Deserialize, Debug)]
+pub(crate) struct OpenAIUsage {
+    /// Input/prompt tokens consumed.
+    pub(crate) prompt_tokens: usize,
+    /// Output/completion tokens generated.
+    pub(crate) completion_tokens: usize,
+}
+
+/// Response shape of `GET https://api.orcarouter.ai/v1/models`
+/// (OpenAI list-models format).
+#[derive(Deserialize, Debug)]
+pub(crate) struct ModelList {
+    /// The catalogue of servable models. Unknown extra fields are ignored.
+    #[serde(default)]
+    pub(crate) data: Vec<ModelEntry>,
+}
+
+/// A single entry in the `/v1/models` `data` array. Only `id` is consumed;
+/// every other field (`object`, `created`, `owned_by`, ...) is ignored.
+#[derive(Deserialize, Debug)]
+pub(crate) struct ModelEntry {
+    /// The model id to advertise as a provider-entry id.
+    pub(crate) id: String,
+}
+
+/// HTTP response payload from the SDK http airlock (buffered fallback).
+#[derive(Deserialize)]
+#[expect(dead_code)]
+pub(crate) struct HttpResponse {
+    /// HTTP status code.
+    pub(crate) status: u16,
+    /// Response headers.
+    pub(crate) headers: std::collections::HashMap<String, String>,
+    /// Response body.
+    pub(crate) body: String,
+}

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -29,6 +29,10 @@ openai_base_url = { description = "API base URL", default = "https://api.openai.
 openai_model = { description = "Default model ID", default = "gpt-5.4" }
 openai_temperature = { description = "Default temperature (0.0-2.0, blank = provider default)", default = "" }
 openai_max_tokens = { description = "Max output tokens", default = "128000" }
+orcarouter_api_key = { secret = true, description = "API key for the OrcaRouter LLM gateway" }
+orcarouter_model = { description = "Default OrcaRouter model ID", default = "orcarouter/free" }
+orcarouter_temperature = { description = "Default temperature (0.0-2.0, blank = provider default)", default = "" }
+orcarouter_max_tokens = { description = "Max output tokens", default = "128000" }
 
 # ---------------------------------------------------------------------------
 # Uplinks (frontends)
@@ -62,6 +66,13 @@ source = "capsules/aos-openai-compat.capsule"
 version = "0.2.0"
 group = "llm"
 env = { api_key = "{{ openai_api_key }}", base_url = "{{ openai_base_url }}", model = "{{ openai_model }}", temperature = "{{ openai_temperature }}", max_output_tokens = "{{ openai_max_tokens }}" }
+
+[[capsule]]
+name = "aos-orcarouter"
+source = "capsules/aos-orcarouter.capsule"
+version = "0.1.0"
+group = "llm"
+env = { api_key = "{{ orcarouter_api_key }}", model = "{{ orcarouter_model }}", temperature = "{{ orcarouter_temperature }}", max_output_tokens = "{{ orcarouter_max_tokens }}" }
 
 # ---------------------------------------------------------------------------
 # Core infrastructure (always installed)

--- a/distros/community/unicity-ce/README.md
+++ b/distros/community/unicity-ce/README.md
@@ -25,7 +25,7 @@ local bundle supports `aos init --offline`.
 | Category | Capsules |
 |----------|----------|
 | **Uplinks** | cli, registry |
-| **LLM providers** | openai-compat (select during init) |
+| **LLM providers** | openai-compat, orcarouter (select during init) |
 | **Core** | react, session, identity, users, router, prompt-builder, context-engine, hook-bridge, hook-adapter-oracle |
 | **Tools** | shell, http, fs, system |
 | **Extensions** | skills, agents, memory |

--- a/release/community-capsules.txt
+++ b/release/community-capsules.txt
@@ -6,6 +6,7 @@ capsule-cli
 capsule-mcp
 capsule-registry
 capsule-openai-compat
+capsule-orcarouter
 capsule-react
 capsule-session
 capsule-identity

--- a/scripts/test-clean-home-init.sh
+++ b/scripts/test-clean-home-init.sh
@@ -94,8 +94,8 @@ expected = sorted(
     for line in assets_path.read_text(encoding="utf-8").splitlines()
     if line
 )
-if len(expected) != 22 or len(set(expected)) != 22:
-    raise SystemExit("release capsule inventory is not the exact 22-capsule CE set")
+if len(expected) != 23 or len(set(expected)) != 23:
+    raise SystemExit("release capsule inventory is not the exact 23-capsule CE set")
 with lock_path.open("rb") as file:
     lock = tomllib.load(file)
 with profile_path.open("rb") as file:

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -251,7 +251,7 @@ release_dir="$work/home/.aos/releases/2026.1.3"
 test -f "$release_dir/release-manifest.json"
 test -f "$release_dir/Distro.toml"
 test -f "$release_dir/capsule-assets.txt"
-test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 22
+test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 23
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"
@@ -608,7 +608,7 @@ for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
   test "$("$destination")" = "old-$binary"
 done
 test "$(cat "$release_dir/release-manifest.json")" = old-release-manifest
-test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 22
+test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 23
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -69,7 +69,7 @@ tar -tzf "$archive" > "$work/files"
 grep -q '/bin/aos$' "$work/files"
 grep -q '/libexec/install.sh$' "$work/files"
 grep -q '/runtime/bin/astrid-daemon$' "$work/files"
-test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 22
+test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 23
 grep -q '/capsule-assets.txt$' "$work/files"
 grep -q '/Distro.toml$' "$work/files"
 grep -q '/release-manifest.json$' "$work/files"
@@ -77,7 +77,7 @@ grep -q '/release-manifest.json$' "$work/files"
 tar -xzf "$archive" -C "$work"
 manifest=$(find "$work" -path '*/release-manifest.json' -print -quit)
 bundle_root=$(dirname "$manifest")
-test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 22
+test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 23
 if grep -F '@unicity-aos/capsule-' "$bundle_root/Distro.toml" >/dev/null; then
   echo "release archive retained a legacy capsule repository source" >&2
   exit 1
@@ -99,9 +99,9 @@ assert manifest["contracts"]["repository"] == "astrid-runtime/wit"
 assert manifest["contracts"]["commit"] == "278dbca3e32f327d0f2358644fc86559779ba0fd"
 assert manifest["contracts"]["sdk_rust_version"] == "0.7.1"
 assert manifest["contracts"]["sdk_rust_commit"] == "bbbc61c8821d6c536fb25d2068b6b646e759ad35"
-assert manifest["capsules"]["count"] == 22
-assert len(manifest["capsules"]["assets"]) == 22
-assert len(set(manifest["capsules"]["assets"])) == 22
+assert manifest["capsules"]["count"] == 23
+assert len(manifest["capsules"]["assets"]) == 23
+assert len(set(manifest["capsules"]["assets"])) == 23
 PY
 
 unsafe_root="$work/unsafe-runtime"

--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -85,15 +85,15 @@ class CapsuleReleaseTests(unittest.TestCase):
             write_fixture(directory / spec.asset, spec)
 
     def test_source_contract_has_exact_community_set(self) -> None:
-        self.assertEqual(len(self.specs), 22)
-        self.assertEqual(len({spec.asset for spec in self.specs}), 22)
+        self.assertEqual(len(self.specs), 23)
+        self.assertEqual(len({spec.asset for spec in self.specs}), 23)
         assets = {spec.asset for spec in self.specs}
         self.assertIn("aos-forge.capsule", assets)
         self.assertNotIn("aos-telegram.capsule", assets)
         distro = Path(__file__).resolve().parent.parent / "distros/community/unicity-ce/Distro.toml"
         text = distro.read_text(encoding="utf-8")
         self.assertNotIn("@unicity-aos/", text)
-        self.assertEqual(text.count('source = "capsules/'), 22)
+        self.assertEqual(text.count('source = "capsules/'), 23)
         for spec in self.specs:
             self.assertIn(f'source = "capsules/{spec.asset}"', text)
 

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -113,7 +113,7 @@ class ReleasePublicationTests(unittest.TestCase):
             artifacts, compatibility = self.fixture(Path(temp))
             payloads = self.validate(artifacts, compatibility)
             self.assertIn(f"unicity-aos-{VERSION}-release.toml", payloads)
-            self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 22)
+            self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 23)
 
     def test_rejects_missing_asset(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary

This adds **aos-orcarouter**, a first-class LLM provider capsule for the AOS Community Edition, speaking OpenAI-compatible Chat Completions to the [OrcaRouter](https://www.orcarouter.ai) gateway at `https://api.orcarouter.ai`.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## How it parallels the existing provider wiring

The new capsule mirrors `aos-openai-compat` line for line, with the base URL and provider identity pinned to OrcaRouter instead of left configurable. AOS treats each provider as a device driver capsule in the OS model; `aos-orcarouter` is wired exactly the same way:

| Piece | Existing (`aos-openai-compat`) | This PR (`aos-orcarouter`) |
|---|---|---|
| Generate topic | `llm.v1.request.generate.openai-compat` | `llm.v1.request.generate.orcarouter` |
| Stream topic | `llm.v1.stream.openai-compat` | `llm.v1.stream.orcarouter` |
| Provider alias | `openai-compat` | `orcarouter` |
| Base URL | env `base_url` (any endpoint) | pinned `https://api.orcarouter.ai` |
| Discovery | `GET {base_url}/v1/models` | `GET https://api.orcarouter.ai/v1/models` |
| Generation | `POST {base_url}/v1/chat/completions` | `POST https://api.orcarouter.ai/v1/chat/completions` |

- **`capsules/capsule-orcarouter/src/lib.rs`** — the provider. It subscribes to the `orcarouter` generate topic, converts the runtime `Message` format to Chat Completions JSON (text, tool calls, tool results, multipart), streams via the HTTP airlock, and parses SSE in real-time (`data:` chunks, `[DONE]`, usage in the final chunk). Provider discovery (`llm_describe`) queries `/v1/models` and emits one provider-entry per discovered model id, with the env-default model hoisted to `entry[0]` and an offline fallback to the configured model.
- **`capsules/capsule-orcarouter/src/schemas.rs`** — the OpenAI-compatible streaming wire types (chunk/choice/delta/tool-call/usage), shared shape with the compat capsule.
- **`capsules/capsule-orcarouter/Capsule.toml`** — declares the `astrid:llm` export, publish/subscribe topics, and the `net = ["*"]` capability. The `model` env is a live select populated from `https://api.orcarouter.ai/v1/models` during `aos init`.
- **`capsules/capsule-orcarouter/README.md`** — documents configuration, model discovery, model selection, and the IPC protocol in the same style as the other provider capsules.
- **Workspace/distro wiring** — added `capsules/capsule-orcarouter` to the Cargo workspace members, `capsule-orcarouter` to `release/community-capsules.txt`, and an `aos-orcarouter` entry in the `group = "llm"` section of `distros/community/unicity-ce/Distro.toml` (so it appears in the provider multi-select during `aos init`).
- **Release contract counts** — the community capsule inventory is asserted in a few release scripts; those exact-set counts move from 22 to 23.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy -p aos-orcarouter --target wasm32-unknown-unknown -- -D warnings` — clean (also full-workspace clippy with `-D warnings`)
- `cargo test -p aos-orcarouter --target x86_64-unknown-linux-gnu` — 20/20 pass; full-workspace host tests pass
- `python3 scripts/capsule_release.py` and the release-contract test suites — pass
- Live test against the real gateway: `POST https://api.orcarouter.ai/v1/chat/completions` with `Authorization: Bearer` for both `orcarouter/free` and `orcarouter/fusion` returned **HTTP 200** with a valid SSE stream terminating in `data: [DONE]`, matching what the capsule's SSE parser consumes.

## Contact

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
