### PR TITLE
fix(bootstrap): confirm authoritative AOS stop

### DIFF
--- a/changes/109.fixed.md
+++ b/changes/109.fixed.md
@@ -1,0 +1,3 @@
+Make `aos stop` fail closed unless delegated shutdown removes every daemon and
+MCP gateway coordination marker and releases the runtime singleton lock, while
+preserving the delegated runtime failure when confirmation also fails.

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -532,24 +532,33 @@ fn handle_runtime_stop(args: &[OsString]) -> ExitCode {
         }
     };
 
-    if output.status.success() {
+    let expected_disconnect = expected_shutdown_disconnect(&output);
+    let confirmation = wait_for_confirmed_stop(&home);
+    if confirmation.is_ok() && (output.status.success() || expected_disconnect) {
+        if expected_disconnect {
+            if let Err(error) = std::io::stdout().write_all(&output.stdout) {
+                return runtime_output_error(error);
+            }
+            if output.stdout.is_empty() {
+                println!("Unicity AOS stopped.");
+            }
+            return ExitCode::SUCCESS;
+        }
         return emit_runtime_output(&output)
             .map_or_else(runtime_output_error, |()| ExitCode::SUCCESS);
     }
 
-    if expected_shutdown_disconnect(&output) && wait_for_confirmed_stop(&home) {
-        if let Err(error) = std::io::stdout().write_all(&output.stdout) {
-            return runtime_output_error(error);
-        }
-        if output.stdout.is_empty() {
-            println!("Unicity AOS stopped.");
-        }
-        return ExitCode::SUCCESS;
+    let output_result = emit_runtime_output(&output);
+    if let Err(error) = confirmation {
+        eprintln!("aos: shutdown confirmation failed: {error}");
     }
-
-    match emit_runtime_output(&output) {
-        Ok(()) => child_exit_code(output.status),
-        Err(error) => runtime_output_error(error),
+    if let Err(error) = output_result {
+        return runtime_output_error(error);
+    }
+    if output.status.success() {
+        ExitCode::FAILURE
+    } else {
+        child_exit_code(output.status)
     }
 }
 
@@ -562,21 +571,29 @@ fn expected_shutdown_disconnect(output: &std::process::Output) -> bool {
         && stderr.contains("connection closed before astrid.v1.response.shutdown.")
 }
 
-fn wait_for_confirmed_stop(home: &AosHome) -> bool {
+fn wait_for_confirmed_stop(home: &AosHome) -> Result<(), String> {
     const ATTEMPTS: usize = 100;
     const INTERVAL: Duration = Duration::from_millis(50);
 
+    let mut last_failure = "runtime stopped-state confirmation returned no result".to_owned();
     for attempt in 0..ATTEMPTS {
-        if unicity_aos_bootstrap::status::confirm_stopped(home)
-            .is_ok_and(|status| status.state == "stopped")
-        {
-            return true;
+        match unicity_aos_bootstrap::status::confirm_stopped(home) {
+            Ok(status) if status.state == "stopped" => return Ok(()),
+            Ok(status) => {
+                last_failure = format!(
+                    "runtime stopped-state confirmation returned '{}'",
+                    status.state
+                );
+            }
+            Err(error) => last_failure = error,
         }
         if attempt + 1 < ATTEMPTS {
             std::thread::sleep(INTERVAL);
         }
     }
-    false
+    Err(format!(
+        "runtime did not reach a confirmed stopped state within 5 seconds: {last_failure}"
+    ))
 }
 
 fn emit_runtime_output(output: &std::process::Output) -> io::Result<()> {

--- a/crates/unicity-aos-bootstrap/src/status.rs
+++ b/crates/unicity-aos-bootstrap/src/status.rs
@@ -14,6 +14,14 @@ use crate::AosHome;
 
 const STATUS_TIMEOUT: Duration = Duration::from_secs(5);
 const RUNTIME_COMPATIBILITY: &str = include_str!("../../../release/runtime-compatibility.toml");
+const COORDINATION_MARKERS: [&str; 6] = [
+    "system.sock",
+    "system.pid",
+    "system.ready",
+    "system.token",
+    "mcp-gateway.sock",
+    "mcp-gateway.ready",
+];
 
 /// Product status derived from the typed runtime status response.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -109,13 +117,10 @@ pub async fn read_for_principal(
 /// every transient marker is gone and the runtime lock can be acquired.
 pub fn confirm_stopped(home: &AosHome) -> Result<AosStatus, String> {
     let run_dir = home.runtime_home().join("run");
-    for marker in ["system.sock", "system.pid", "system.ready", "system.token"] {
+    let mut present = Vec::new();
+    for marker in COORDINATION_MARKERS {
         match fs::symlink_metadata(run_dir.join(marker)) {
-            Ok(_) => {
-                return Err(format!(
-                    "runtime coordination marker {marker} is still present"
-                ));
-            }
+            Ok(_) => present.push(marker),
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
             Err(error) => {
                 return Err(format!(
@@ -123,6 +128,12 @@ pub fn confirm_stopped(home: &AosHome) -> Result<AosStatus, String> {
                 ));
             }
         }
+    }
+    if !present.is_empty() {
+        return Err(format!(
+            "runtime coordination marker(s) still present: {}",
+            present.join(", ")
+        ));
     }
 
     let lock_path = run_dir.join("system.lock");
@@ -246,5 +257,39 @@ mod tests {
 
         fs2::FileExt::unlock(&lock).expect("release runtime lock");
         fs::remove_dir_all(root).expect("remove running status fixture");
+    }
+
+    #[test]
+    fn refuses_to_report_stopped_while_any_coordination_marker_remains() {
+        for marker in super::COORDINATION_MARKERS {
+            let root = temporary_status_home(marker);
+            let home = AosHome::from_root(&root);
+            let run_dir = home.runtime_home().join("run");
+            fs::create_dir_all(&run_dir).expect("create runtime run dir");
+            fs::write(run_dir.join(marker), []).expect("create coordination marker");
+
+            let error = confirm_stopped(&home).expect_err("marker must prevent stopped status");
+            assert!(error.contains(marker), "{marker} was not named in: {error}");
+
+            fs::remove_dir_all(root).expect("remove marker fixture");
+        }
+    }
+
+    #[test]
+    fn reports_every_remaining_system_and_gateway_marker() {
+        let root = temporary_status_home("combined-markers");
+        let home = AosHome::from_root(&root);
+        let run_dir = home.runtime_home().join("run");
+        fs::create_dir_all(&run_dir).expect("create runtime run dir");
+        for marker in super::COORDINATION_MARKERS {
+            fs::write(run_dir.join(marker), []).expect("create coordination marker");
+        }
+
+        let error = confirm_stopped(&home).expect_err("markers must prevent stopped status");
+        for marker in super::COORDINATION_MARKERS {
+            assert!(error.contains(marker), "{marker} was not named in: {error}");
+        }
+
+        fs::remove_dir_all(root).expect("remove combined marker fixture");
     }
 }

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 struct Fixture {
     root: PathBuf,
@@ -364,6 +364,153 @@ exit 1
     assert_eq!(
         String::from_utf8(output.stdout).expect("utf8 stop output"),
         "Unicity AOS stopped.\n"
+    );
+}
+
+#[test]
+fn inherited_exit_zero_stop_waits_for_confirmation() {
+    let fixture = Fixture::new("confirmed-zero-stop");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+echo 'runtime stop complete'
+exit 0
+"#,
+    );
+
+    let ready_marker = fixture.home.join("runtime/run/system.ready");
+    fs::create_dir_all(ready_marker.parent().expect("runtime run directory"))
+        .expect("create runtime run directory");
+    fs::write(&ready_marker, []).expect("create runtime ready marker");
+    let marker_to_remove = ready_marker.clone();
+    let shutdown = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(200));
+        fs::remove_file(marker_to_remove).expect("remove runtime ready marker");
+    });
+
+    let output = fixture
+        .command()
+        .arg("stop")
+        .output()
+        .expect("run successful inherited stop");
+    shutdown.join().expect("finish runtime shutdown");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("utf8 stop output"),
+        "runtime stop complete\n"
+    );
+    assert!(output.stderr.is_empty());
+    assert!(!ready_marker.exists());
+}
+
+#[test]
+fn inherited_exit_zero_stop_fails_while_the_runtime_token_remains() {
+    let fixture = Fixture::new("unconfirmed-zero-stop");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+echo 'runtime claimed stop complete'
+exit 0
+"#,
+    );
+
+    let token = fixture.home.join("runtime/run/system.token");
+    fs::create_dir_all(token.parent().expect("runtime run directory"))
+        .expect("create runtime run directory");
+    fs::write(&token, b"stale token").expect("create stale runtime token");
+
+    let started = Instant::now();
+    let output = fixture
+        .command()
+        .arg("stop")
+        .output()
+        .expect("run unconfirmed inherited stop");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        started.elapsed() < Duration::from_secs(10),
+        "stop confirmation must remain bounded"
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("utf8 stop output"),
+        "runtime claimed stop complete\n"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stop error");
+    assert!(stderr.contains("aos: shutdown confirmation failed:"));
+    assert!(stderr.contains("system.token"));
+    assert!(token.exists(), "confirmation must not hide a stale marker");
+}
+
+#[test]
+fn inherited_stop_preserves_the_primary_failure_before_confirmation_failure() {
+    let fixture = Fixture::new("primary-and-confirmation-failure");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+echo 'primary runtime stop failure' >&2
+exit 23
+"#,
+    );
+
+    let gateway = fixture.home.join("runtime/run/mcp-gateway.ready");
+    fs::create_dir_all(gateway.parent().expect("runtime run directory"))
+        .expect("create runtime run directory");
+    fs::write(&gateway, b"stale gateway").expect("create stale gateway marker");
+
+    let output = fixture
+        .command()
+        .arg("stop")
+        .output()
+        .expect("run failed inherited stop");
+
+    assert_eq!(output.status.code(), Some(23));
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stop error");
+    let primary = stderr
+        .find("primary runtime stop failure")
+        .expect("primary failure must be retained");
+    let confirmation = stderr
+        .find("aos: shutdown confirmation failed:")
+        .expect("confirmation failure must be reported separately");
+    assert!(primary < confirmation);
+    assert!(stderr.contains("mcp-gateway.ready"));
+    assert!(
+        gateway.exists(),
+        "confirmation must not hide a stale marker"
+    );
+}
+
+#[test]
+fn expected_disconnect_is_not_suppressed_when_confirmation_fails() {
+    let fixture = Fixture::new("disconnect-and-confirmation-failure");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+echo 'error: connection lost waiting on astrid.v1.response.shutdown.test: connection lost: connection closed before astrid.v1.response.shutdown.test' >&2
+exit 1
+"#,
+    );
+
+    let gateway = fixture.home.join("runtime/run/mcp-gateway.sock");
+    fs::create_dir_all(gateway.parent().expect("runtime run directory"))
+        .expect("create runtime run directory");
+    fs::write(&gateway, b"stale gateway endpoint").expect("create stale gateway endpoint");
+
+    let output = fixture
+        .command()
+        .arg("stop")
+        .output()
+        .expect("run disconnected inherited stop");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stop error");
+    let disconnect = stderr
+        .find("connection lost waiting on astrid.v1.response.shutdown.test")
+        .expect("disconnect must remain visible when confirmation fails");
+    let confirmation = stderr
+        .find("aos: shutdown confirmation failed:")
+        .expect("confirmation failure must be reported separately");
+    assert!(disconnect < confirmation);
+    assert!(stderr.contains("mcp-gateway.sock"));
+    assert!(
+        gateway.exists(),
+        "confirmation must not hide a stale gateway endpoint"
     );
 }
 


### PR DESCRIPTION
## Linked Issue

Refs #109
Refs astrid-runtime/astrid#1804

## Changes

- Confirm the stopped state after every delegated runtime stop outcome, including exit 0.
- Require all system and persistent MCP gateway coordination markers to be absent and the singleton lock to be available.
- Preserve a nonzero delegated runtime exit code and stderr while reporting confirmation failure separately.
- Add single-marker, combined-marker, delayed-cleanup, stale-token, stale-gateway, and expected-disconnect regressions; retain the existing held-lock coverage.

## Verification

- cargo fmt --all -- --check
- cargo test --locked -p unicity-aos-bootstrap -- --test-threads=1
- cargo clippy --locked -p unicity-aos-bootstrap --all-targets --all-features -- -D warnings
- git diff --check

## AI / Tool Assistance

Implemented and adversarially tested with Codex. The final diff, exact ancestry, signature, DCO, and test output were reviewed before publication.

## Claim Limits

This is the AOS fail-closed stop/status boundary. It does not close #109 by itself. Current Astrid main has no supported persistent MCP gateway stop operation, so this change deliberately does not invent PID signalling or claim race-free end-to-end gateway teardown. Full product shutdown remains dependency-blocked on astrid-runtime/astrid#1804; until that lands, a remaining gateway marker makes AOS stop return nonzero.
