### PR TITLE
fix(install): launch Astrid from immutable releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ be true before a tag can publish. The latter is approved only after the exact
 candidate preserves a frozen standalone-home clone and boots with freshly
 generated runtime coordination state.
 
+Installed host executables and capsule assets are retained together beneath
+`~/.aos/releases/<version>/`. The public `~/.aos/bin/aos` launcher executes the
+Astrid CLI and daemon from that exact release tree; it never launches the
+mutable compatibility copies under `~/.aos/runtime/bin` that the released
+2026.1.x state importer still requires. Those compatibility copies are removed
+by the authenticated single-volume cutover, not by the packaging transaction.
+
+`~/.aos/run` is reserved for process-only sockets, tokens, PID files, readiness
+markers, and scratch data. The currently pinned Astrid release still derives
+those paths as `ASTRID_HOME/run`, so AOS does not redirect them with a symlink or
+an unrecognized environment variable. Completing that relocation requires an
+explicit Astrid transient-root contract before the single-volume layout can be
+claimed.
+
 ## Command boundary
 
 AOS owns its product roots, including `init`, `status`, `migrate`, `update`,

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -1,9 +1,10 @@
 //! Product-owned runtime layout and launcher for Unicity AOS.
 //!
 //! Astrid Runtime keeps its standalone `ASTRID_HOME` and `.astrid` compatibility
-//! contract. AOS instead owns `~/.aos` and passes a private runtime home
-//! to the bundled runtime process only; it never changes the caller's process
-//! environment or rewrites a standalone runtime installation.
+//! contract. AOS instead owns `~/.aos`, executes the bundled runtime from the
+//! exact product-versioned release tree, and passes a private runtime home to
+//! the child process only. It never changes the caller's process environment or
+//! rewrites a standalone runtime installation.
 
 use std::ffi::{OsStr, OsString};
 use std::fs;
@@ -108,6 +109,30 @@ impl AosHome {
         self.root.join("runtime")
     }
 
+    /// The transient AOS process-coordination root reserved for a runtime that
+    /// supports an explicit run-directory contract.
+    ///
+    /// Astrid releases that derive `run/` only from `ASTRID_HOME` cannot consume
+    /// this path yet. Keeping the accessor distinct prevents launchers from
+    /// treating the durable runtime root as the long-term socket and scratch
+    /// location.
+    #[must_use]
+    pub fn run_root(&self) -> PathBuf {
+        self.root.join("run")
+    }
+
+    /// The immutable assets installed for this exact AOS product version.
+    #[must_use]
+    pub fn release_dir(&self) -> PathBuf {
+        self.root.join("releases").join(PRODUCT_VERSION)
+    }
+
+    /// The release-owned directory containing the bundled Astrid executables.
+    #[must_use]
+    pub fn release_runtime_bin_dir(&self) -> PathBuf {
+        self.release_dir().join("runtime").join("bin")
+    }
+
     /// The receipt written only after a successful standalone-runtime import.
     #[must_use]
     pub fn migration_receipt(&self) -> PathBuf {
@@ -141,11 +166,7 @@ impl AosHome {
         let configured = get("UNICITY_AOS_CAPSULE_DIR");
         let path = match configured {
             Some(path) => Self::validated_environment_root(path, "UNICITY_AOS_CAPSULE_DIR")?,
-            None => self
-                .root
-                .join("releases")
-                .join(PRODUCT_VERSION)
-                .join("capsules"),
+            None => self.release_dir().join("capsules"),
         };
         validate_capsule_dir(&path, &capsule_assets_from_manifest()?)
     }
@@ -259,7 +280,7 @@ impl AosHome {
         {
             return path;
         }
-        self.runtime_home().join("bin").join(runtime_binary_name())
+        self.release_runtime_bin_dir().join(runtime_binary_name())
     }
 
     /// Import a standalone Astrid Runtime home into this product installation.
@@ -283,7 +304,7 @@ impl AosHome {
         migration::imported_legacy_distros(self)
     }
 
-    /// Create the product and bundled-runtime state directories.
+    /// Create the mutable product and bundled-runtime state directories.
     ///
     /// This intentionally creates neither a standalone Astrid home nor a
     /// project `.astrid` directory.
@@ -292,8 +313,7 @@ impl AosHome {
     /// Returns an error when the directories cannot be created.
     pub fn ensure_layout(&self) -> io::Result<()> {
         create_private_dir(&self.root)?;
-        create_private_dir(&self.runtime_home())?;
-        create_private_dir(&self.runtime_home().join("bin"))
+        create_private_dir(&self.runtime_home())
     }
 
     /// Build a command for the bundled runtime with a process-local home.
@@ -302,7 +322,7 @@ impl AosHome {
     /// therefore can bundle the neutral runtime without changing the host
     /// shell, another AOS install, or a standalone Astrid Runtime installation.
     /// # Errors
-    /// Returns an error when the private runtime bin or inherited host PATH
+    /// Returns an error when the release runtime bin or inherited host PATH
     /// cannot be represented safely as a child PATH.
     pub fn runtime_command(&self) -> io::Result<Command> {
         self.runtime_command_with_args(std::iter::empty::<&OsStr>())
@@ -314,7 +334,7 @@ impl AosHome {
     /// argument boundaries and leaves the runtime in charge of its established
     /// local socket, credentials, and operator protocol.
     /// # Errors
-    /// Returns an error when the private runtime bin or inherited host PATH
+    /// Returns an error when the release runtime bin or inherited host PATH
     /// cannot be represented safely as a child PATH.
     pub fn runtime_command_with_args<I, S>(&self, args: I) -> io::Result<Command>
     where
@@ -808,23 +828,56 @@ mod tests {
     }
 
     #[test]
-    fn runtime_is_scoped_beneath_the_product_home() {
+    fn runtime_executes_from_the_exact_product_release() {
         let home = AosHome::from_root("/tmp/unicity-aos-test");
         assert_eq!(home.root(), PathBuf::from("/tmp/unicity-aos-test"));
         assert_eq!(
             home.runtime_home(),
             PathBuf::from("/tmp/unicity-aos-test/runtime")
         );
+        assert_eq!(home.run_root(), PathBuf::from("/tmp/unicity-aos-test/run"));
+        assert_eq!(
+            home.release_dir(),
+            PathBuf::from(format!(
+                "/tmp/unicity-aos-test/releases/{}",
+                env!("CARGO_PKG_VERSION")
+            ))
+        );
         assert_eq!(
             home.runtime_binary(),
-            home.runtime_home().join("bin").join(runtime_binary_name())
+            home.release_runtime_bin_dir().join(runtime_binary_name())
         );
         assert_eq!(
             home.runtime_daemon_binary(),
-            home.runtime_home()
-                .join("bin")
+            home.release_runtime_bin_dir()
                 .join(runtime_daemon_binary_name())
         );
+    }
+
+    #[test]
+    fn mutable_runtime_copy_cannot_substitute_for_a_missing_release_binary() {
+        let fixture = temporary_home();
+        let home = AosHome::from_root(&fixture);
+        let mutable_binary = home.runtime_home().join("bin").join(runtime_binary_name());
+        fs::create_dir_all(mutable_binary.parent().expect("mutable binary parent"))
+            .expect("create mutable runtime bin");
+        fs::write(&mutable_binary, b"mutable compatibility copy")
+            .expect("write mutable compatibility copy");
+
+        let error = home
+            .ensure_runtime_available()
+            .expect_err("mutable compatibility copy must not satisfy release lookup");
+
+        assert_eq!(error.kind(), ErrorKind::NotFound);
+        assert!(
+            error.to_string().contains(
+                home.release_runtime_bin_dir()
+                    .join(runtime_binary_name())
+                    .to_string_lossy()
+                    .as_ref()
+            )
+        );
+        fs::remove_dir_all(fixture).expect("remove mutable runtime fixture");
     }
 
     #[test]
@@ -832,7 +885,7 @@ mod tests {
         let home = AosHome::from_root("/tmp/unicity-aos-test");
         assert_eq!(
             home.runtime_binary_with(|_| Some(OsString::from("runtime/astrid"))),
-            home.runtime_home().join("bin").join(runtime_binary_name())
+            home.release_runtime_bin_dir().join(runtime_binary_name())
         );
         assert_eq!(
             home.runtime_binary_with(|_| Some(OsString::from("/opt/aos/runtime/bin/astrid"))),
@@ -858,7 +911,10 @@ mod tests {
         let path_entries: Vec<_> = std::env::split_paths(env_value("PATH")).collect();
         assert_eq!(
             path_entries.first(),
-            Some(&PathBuf::from("/tmp/unicity-aos-test/runtime/bin"))
+            Some(&PathBuf::from(format!(
+                "/tmp/unicity-aos-test/releases/{}/runtime/bin",
+                env!("CARGO_PKG_VERSION")
+            )))
         );
         assert_eq!(std::env::var_os("PATH"), caller_path);
     }
@@ -896,7 +952,7 @@ mod tests {
         let fixture = temporary_home();
         let home = AosHome::from_root(&fixture);
         install_capsule_fixtures(home.root());
-        let runtime_bin = home.runtime_home().join("bin");
+        let runtime_bin = home.release_runtime_bin_dir();
         fs::create_dir_all(&runtime_bin).expect("create runtime bin");
         fs::write(home.runtime_daemon_binary(), b"daemon").expect("write daemon fixture");
         #[cfg(unix)]
@@ -946,7 +1002,7 @@ mod tests {
         let fixture = temporary_home();
         let home = AosHome::from_root(&fixture);
         install_capsule_fixtures(home.root());
-        let runtime_bin = home.runtime_home().join("bin");
+        let runtime_bin = home.release_runtime_bin_dir();
         fs::create_dir_all(&runtime_bin).expect("create runtime bin");
         fs::write(home.runtime_daemon_binary(), b"daemon").expect("write daemon fixture");
 
@@ -1009,13 +1065,16 @@ mod tests {
         let home = AosHome::from_root("/tmp/unicity-aos-test");
         let host_entries = [PathBuf::from("/usr/local/bin"), PathBuf::from("/usr/bin")];
         let host_path = std::env::join_paths(&host_entries).expect("build host PATH");
-        let runtime_bin = home.runtime_home().join("bin");
+        let runtime_bin = home.release_runtime_bin_dir();
         let child_path =
             AosHome::runtime_child_path(&runtime_bin, Some(host_path)).expect("build child PATH");
         assert_eq!(
             std::env::split_paths(&child_path).collect::<Vec<_>>(),
             [
-                PathBuf::from("/tmp/unicity-aos-test/runtime/bin"),
+                PathBuf::from(format!(
+                    "/tmp/unicity-aos-test/releases/{}/runtime/bin",
+                    env!("CARGO_PKG_VERSION")
+                )),
                 PathBuf::from("/usr/local/bin"),
                 PathBuf::from("/usr/bin"),
             ]
@@ -1025,7 +1084,10 @@ mod tests {
             AosHome::runtime_child_path(&runtime_bin, None).expect("build private-only child PATH");
         assert_eq!(
             std::env::split_paths(&child_path).collect::<Vec<_>>(),
-            [PathBuf::from("/tmp/unicity-aos-test/runtime/bin")]
+            [PathBuf::from(format!(
+                "/tmp/unicity-aos-test/releases/{}/runtime/bin",
+                env!("CARGO_PKG_VERSION")
+            ))]
         );
     }
 
@@ -1084,7 +1146,6 @@ mod tests {
         for directory in [
             &root,
             &home.runtime_home(),
-            &home.runtime_home().join("bin"),
             &root.join("distributions"),
             &root.join("distributions/unicity-ce"),
         ] {
@@ -1097,6 +1158,10 @@ mod tests {
                 0o700
             );
         }
+        assert!(
+            !home.runtime_home().join("bin").exists(),
+            "fresh mutable runtime state must not receive executable copies"
+        );
         assert_eq!(
             fs::metadata(manifest)
                 .expect("read manifest metadata")

--- a/install.sh
+++ b/install.sh
@@ -817,7 +817,20 @@ fi
 release_dir="$AOS_HOME/releases/$staged_version"
 release_stage="$AOS_HOME/releases/.${staged_version}.new.$$"
 release_backup="$AOS_HOME/releases/.${staged_version}.rollback.$$"
-for managed in "$AOS_HOME" "$AOS_HOME/libexec" "$AOS_HOME/runtime" "$AOS_HOME/runtime/bin" "$AOS_HOME/releases" "$release_dir" "$release_dir/capsules" "$AOS_HOME/update" "$AOS_HOME/update/channels"; do
+for managed in \
+  "$AOS_HOME" \
+  "$AOS_HOME/libexec" \
+  "$AOS_HOME/runtime" \
+  "$AOS_HOME/runtime/bin" \
+  "$AOS_HOME/releases" \
+  "$release_dir" \
+  "$release_dir/bin" \
+  "$release_dir/libexec" \
+  "$release_dir/runtime" \
+  "$release_dir/runtime/bin" \
+  "$release_dir/capsules" \
+  "$AOS_HOME/update" \
+  "$AOS_HOME/update/channels"; do
   [ ! -L "$managed" ] || { echo "refusing symlinked managed path: $managed" >&2; exit 1; }
 done
 if [ -e "$release_dir" ] && [ ! -d "$release_dir" ]; then
@@ -960,15 +973,25 @@ restore() {
 }
 
 installation_started=1
-if ! install_one "$bundle/bin/aos" "$AOS_BIN_DIR/aos" aos 755; then exit 1; fi
-if ! install_one "$bundle/libexec/install.sh" "$AOS_HOME/libexec/install.sh" installer 600; then exit 1; fi
-for name in astrid astrid-daemon astrid-build astrid-emit; do
-  if ! install_one "$bundle/runtime/bin/$name" "$AOS_HOME/runtime/bin/$name" "$name" 755; then exit 1; fi
-done
 mkdir "$release_stage"
 chmod 700 "$release_stage"
-mkdir "$release_stage/capsules"
-chmod 700 "$release_stage/capsules"
+mkdir \
+  "$release_stage/bin" \
+  "$release_stage/libexec" \
+  "$release_stage/runtime" \
+  "$release_stage/runtime/bin" \
+  "$release_stage/capsules"
+chmod 700 \
+  "$release_stage/bin" \
+  "$release_stage/libexec" \
+  "$release_stage/runtime" \
+  "$release_stage/runtime/bin" \
+  "$release_stage/capsules"
+install -m 0700 "$bundle/bin/aos" "$release_stage/bin/aos"
+install -m 0600 "$bundle/libexec/install.sh" "$release_stage/libexec/install.sh"
+for name in astrid astrid-daemon astrid-build astrid-emit; do
+  install -m 0700 "$bundle/runtime/bin/$name" "$release_stage/runtime/bin/$name"
+done
 install -m 0600 "$bundle/release-manifest.json" "$release_stage/release-manifest.json"
 install -m 0600 "$bundle/Distro.toml" "$release_stage/Distro.toml"
 install -m 0600 "$bundle/capsule-assets.txt" "$release_stage/capsule-assets.txt"
@@ -983,6 +1006,15 @@ if ! mv "$release_stage" "$release_dir"; then
   exit 1
 fi
 release_committed=1
+if ! install_one "$release_dir/bin/aos" "$AOS_BIN_DIR/aos" aos 755; then exit 1; fi
+if ! install_one "$release_dir/libexec/install.sh" "$AOS_HOME/libexec/install.sh" installer 600; then exit 1; fi
+# Released 2026.1.x migration reads the bundled executables from this legacy
+# location while constructing its replacement tree. Keep those compatibility
+# copies until the authenticated single-volume migrator replaces that contract;
+# the AOS launcher executes only the immutable release-tree copies above.
+for name in astrid astrid-daemon astrid-build astrid-emit; do
+  if ! install_one "$release_dir/runtime/bin/$name" "$AOS_HOME/runtime/bin/$name" "$name" 755; then exit 1; fi
+done
 stage_channel_receipt
 installation_started=0
 rm -rf "$release_backup"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -115,6 +115,11 @@ manifest = {
     "schema_version": 2,
     "product": {"name": "Unicity AOS Community Edition", "version": product},
     "target": target,
+    "layout": {
+        "release_directory": f"releases/{product}",
+        "runtime_executables": "runtime/bin",
+        "capsule_assets": "capsules",
+    },
     "runtime": {
         "repository": runtime_repo,
         "version": runtime,

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -248,6 +248,18 @@ sh "$repo_root/install.sh" --yes --no-migrate-prompt
 test -x "$work/home/.aos/bin/aos"
 test -x "$work/home/.aos/runtime/bin/astrid-daemon"
 release_dir="$work/home/.aos/releases/2026.1.3"
+test -x "$release_dir/bin/aos"
+test -f "$release_dir/libexec/install.sh"
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  test -x "$release_dir/runtime/bin/$binary"
+  cmp "$release_dir/runtime/bin/$binary" "$work/home/.aos/runtime/bin/$binary"
+done
+printf '#!/bin/sh\necho mutable-runtime-copy-used\nexit 91\n' \
+  > "$work/home/.aos/runtime/bin/astrid"
+chmod 755 "$work/home/.aos/runtime/bin/astrid"
+test "$(HOME="$work/home" "$work/home/.aos/bin/aos" doctor)" = astrid
+cp "$release_dir/runtime/bin/astrid" "$work/home/.aos/runtime/bin/astrid"
+chmod 755 "$work/home/.aos/runtime/bin/astrid"
 test -f "$release_dir/release-manifest.json"
 test -f "$release_dir/Distro.toml"
 test -f "$release_dir/capsule-assets.txt"
@@ -264,6 +276,7 @@ test ! -e "$fixture/path-cosign-called"
 test "$(stat -c '%a' "$work/home/.aos" 2>/dev/null || stat -f '%Lp' "$work/home/.aos")" = 700
 test "$(stat -c '%a' "$release_dir/release-manifest.json" 2>/dev/null || stat -f '%Lp' "$release_dir/release-manifest.json")" = 600
 test "$(stat -c '%a' "$release_dir/capsules" 2>/dev/null || stat -f '%Lp' "$release_dir/capsules")" = 700
+test "$(stat -c '%a' "$release_dir/runtime/bin/astrid" 2>/dev/null || stat -f '%Lp' "$release_dir/runtime/bin/astrid")" = 700
 
 python=${PYTHON3:-python3}
 "$python" "$repo_root/scripts/release_metadata.py" render-channel \
@@ -573,6 +586,10 @@ for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
   chmod 755 "$destination"
 done
 printf 'old-release-manifest\n' > "$release_dir/release-manifest.json"
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  printf '#!/bin/sh\necho old-release-%s\n' "$binary" > "$release_dir/runtime/bin/$binary"
+  chmod 700 "$release_dir/runtime/bin/$binary"
+done
 
 fail_bin="$work/fail-bin"
 mkdir "$fail_bin"
@@ -595,7 +612,7 @@ if PATH="$fail_bin:$fake_bin:$PATH" \
   AOS_VERSION=2026.1.3 \
   REAL_MV="$real_mv" \
   MV_FAILED="$work/mv-failed" \
-  MV_FAIL_DESTINATION="$release_dir" \
+  MV_FAIL_DESTINATION="$work/home/.aos/bin/aos" \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
   echo "installer ignored a mid-install failure" >&2
   exit 1
@@ -608,6 +625,9 @@ for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
   test "$("$destination")" = "old-$binary"
 done
 test "$(cat "$release_dir/release-manifest.json")" = old-release-manifest
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  test "$("$release_dir/runtime/bin/$binary")" = "old-release-$binary"
+done
 test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 22
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -91,6 +91,11 @@ manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 product_version, runtime_version, runtime_identity = sys.argv[2:]
 assert manifest["schema_version"] == 2
 assert manifest["product"]["version"] == product_version
+assert manifest["layout"] == {
+    "release_directory": f"releases/{product_version}",
+    "runtime_executables": "runtime/bin",
+    "capsule_assets": "capsules",
+}
 assert manifest["runtime"]["version"] == runtime_version
 assert manifest["runtime"]["digest"] == "blake3:" + "0" * 64
 assert "sha256" not in manifest["runtime"]

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -131,9 +131,14 @@ snapshot_shipped_assets() {
   local release=$home/releases/2026.1.3
   : > "$output"
   printf '%s|bin/aos\n' "$(b3sum -- "$home/bin/aos" | awk '{print $1}')" >> "$output"
+  printf '%s|releases/2026.1.3/bin/aos\n' \
+    "$(b3sum -- "$release/bin/aos" | awk '{print $1}')" >> "$output"
   for name in astrid astrid-daemon astrid-build astrid-emit; do
     printf '%s|runtime/bin/%s\n' \
       "$(b3sum -- "$home/runtime/bin/$name" | awk '{print $1}')" \
+      "$name" >> "$output"
+    printf '%s|releases/2026.1.3/runtime/bin/%s\n' \
+      "$(b3sum -- "$release/runtime/bin/$name" | awk '{print $1}')" \
       "$name" >> "$output"
   done
   while IFS= read -r capsule; do
@@ -161,7 +166,11 @@ mkdir -p "$home" "$fixture" "$fake_bin" "$capsules"
 python3 "$repo_root/scripts/create-astrid-094-fixture.py" "$legacy"
 
 cargo build --locked -p unicity-aos-bootstrap --bin aos
-product_binary=$repo_root/target/debug/aos
+target_dir=$(
+  cargo metadata --locked --no-deps --format-version 1 |
+    python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])'
+)
+product_binary=$target_dir/debug/aos
 test "$($product_binary --version)" = 'Unicity AOS 2026.1.3'
 
 PYTHONPATH="$repo_root/scripts" python3 - "$capsules" <<'PY'
@@ -356,6 +365,7 @@ test "$(find "$legacy/run" -type f | wc -l | tr -d ' ')" -eq 5
 install_candidate
 test -x "$aos_home/bin/aos"
 test -x "$aos_home/runtime/bin/astrid-daemon"
+test -x "$aos_home/releases/2026.1.3/runtime/bin/astrid-daemon"
 HOME="$home" "$aos_home/bin/aos" migrate runtime --from "$legacy" > "$work/migrate.log"
 grep -F 'imported the standalone runtime; the source was left unchanged' "$work/migrate.log" >/dev/null
 assert_imported_activation_layout "$aos_home/runtime"
@@ -418,6 +428,14 @@ for name in aos astrid astrid-daemon astrid-build astrid-emit; do
   printf '#!/bin/sh\nexit 0\n' > "$destination"
   chmod 755 "$destination"
 done
+for name in aos astrid astrid-daemon astrid-build astrid-emit; do
+  case "$name" in
+    aos) destination=$aos_home/releases/2026.1.3/bin/aos ;;
+    *) destination=$aos_home/releases/2026.1.3/runtime/bin/$name ;;
+  esac
+  printf '#!/bin/sh\nexit 0\n' > "$destination"
+  chmod 755 "$destination"
+done
 while IFS= read -r capsule; do
   printf 'tampered capsule\n' > "$aos_home/releases/2026.1.3/capsules/$capsule"
 done < "$aos_home/releases/2026.1.3/capsule-assets.txt"
@@ -428,6 +446,10 @@ chmod 755 \
   "$aos_home/runtime/bin" \
   "$aos_home/releases" \
   "$aos_home/releases/2026.1.3" \
+  "$aos_home/releases/2026.1.3/bin" \
+  "$aos_home/releases/2026.1.3/libexec" \
+  "$aos_home/releases/2026.1.3/runtime" \
+  "$aos_home/releases/2026.1.3/runtime/bin" \
   "$aos_home/releases/2026.1.3/capsules"
 
 install_candidate
@@ -441,6 +463,10 @@ for directory in \
   "$aos_home/runtime/bin" \
   "$aos_home/releases" \
   "$aos_home/releases/2026.1.3" \
+  "$aos_home/releases/2026.1.3/bin" \
+  "$aos_home/releases/2026.1.3/libexec" \
+  "$aos_home/releases/2026.1.3/runtime" \
+  "$aos_home/releases/2026.1.3/runtime/bin" \
   "$aos_home/releases/2026.1.3/capsules"; do
   test "$(mode_of "$directory")" = 700
 done


### PR DESCRIPTION
## Linked Issue

Closes #108

## Changes

- Install the AOS launcher, private installer, Astrid executables, and capsule assets under the exact product-versioned `~/.aos/releases/<version>/` tree.
- Resolve bundled Astrid CLI, daemon, child `PATH`, and capsule defaults from that release tree; a mutable `~/.aos/runtime/bin` copy cannot substitute for a missing release executable.
- Publish or replace the complete release directory before switching the public launcher, and restore both the prior release tree and compatibility copies if a later install step fails.
- Record the release layout in the packaged manifest and document the bounded transition.

## Verification

- `cargo test --locked --workspace`
- `cargo test --locked -p unicity-aos-bootstrap` (57 library, 33 CLI, 26 boundary tests)
- `cargo clippy --locked -p unicity-aos-bootstrap --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash scripts/test-package-release.sh`
- `bash scripts/test-install.sh`
- `bash scripts/test-upgrade-self-heal.sh`
- shell syntax checks for the installer and touched test scripts
- `git diff --check`

The broader workspace Clippy pass reaches an unchanged `clippy::while_let_loop` error in `capsules/capsule-registry/src/lib.rs`; the touched bootstrap crate is clean under warnings-as-errors.

## Claim Limits

- This draft does not bump the product version or publish a release.
- Astrid currently derives transient paths from `ASTRID_HOME/run` and exposes no explicit transient-root contract. Moving process-only state to `~/.aos/run` remains blocked on astrid-runtime/astrid#1803; this change does not fake that contract with a symlink or ignored environment variable.
- The released 2026.1.x importer still consumes compatibility executables from `~/.aos/runtime/bin`. They remain installation-only compatibility copies and are never selected by the default AOS launcher. Removing them and publishing only `astrid.volume` belongs to the later authenticated migration cutover.
- Existing signed-archive verification remains installer-owned. This slice does not add a new per-launch Sigstore reauthentication protocol.

## AI / Tool Assistance

AI-assisted implementation and adversarial test expansion were used. The resulting changes, tests, and claim boundaries remain under maintainer review.