### PR TITLE
docs: record accepted release architecture without shipping it

### DIFF
--- a/apps/adaptive-shell/README.md
+++ b/apps/adaptive-shell/README.md
@@ -19,8 +19,10 @@ The current tranche is intentionally headless. It provides:
   identity-preserving fixture transitions, and one-card phone presentation.
 
 No browser, DOM, WebView, JavaScript, daemon, network, LLM, process, or
-authority integration is present. A future winit/GPU adapter can consume the
-display list without entering the semantic model.
+authority integration is present. The semantic catalog and layout rules are
+independent of CPU architecture and of Linux Realm; they do not assume a
+guest ISA. A future winit/GPU adapter can consume the display list without
+entering the semantic model.
 
 ```text
 cargo run -p adaptive-shell -- --headless --fixture desktop

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# AOS Community Edition documentation
+
+Product and operator documentation for Unicity AOS Community Edition.
+
+Published product identity on `main` is `2026.1.3`, pinned to Astrid Runtime
+`0.10.4`. Later identities such as AOS `2026.9.0` are accepted release
+targets, not published tags.
+
+| Page | What it covers |
+|---|---|
+| [Signed release channels](release-channels.md) | Current `stable` / `dev` / `nightly` pointers and the published `YYYY.MINOR.PATCH` rule |
+| [Runtime layout](runtime-layout.md) | Current `~/.aos` layout versus the accepted single-volume layout, which is not shipped |
+| [Linux Realm consumer contract](principal-linux-realm.md) | Accepted Linux Realm boundary; not implemented on current `main` |
+| [Importing standalone runtime state](runtime-migration.md) | Copying compatible state from `~/.astrid` into `~/.aos` |
+| [Extending an agent's world](meta-harness.md) | Forge / meta-harness world model |
+| [Hooks](hooks.md) | Host hook routing |
+
+## Host MCP paths
+
+Claude Code and Grok Build use `aos --principal <host>-code mcp serve`.
+Codex's default Oracle path is a persistent `mcp attach` through the host
+plugin (`aos-up` and its stdio frame). Explicit `mcp serve` remains the Codex
+escape hatch. Installing or updating the Codex plugin does not inject tools
+into an already-running session; start a fresh Codex thread after enablement.
+
+The 2026.9.0 manual signed-install journey (verify artifacts, install with the
+daemon stopped, enable the plugin, then start a fresh Codex session) is not
+shipped.

--- a/docs/principal-linux-realm.md
+++ b/docs/principal-linux-realm.md
@@ -1,0 +1,71 @@
+# Linux Realm consumer contract
+
+Status: accepted architecture; **not implemented** on current `main`
+
+Last reviewed: 2026-09-01
+
+Linux Realm is an optional AOS capsule consumer. It is not an authority model,
+not a second kernel, and not a prerequisite for the Astrid native kernel
+track. `IMPLEMENTABLE_NOW=no` until source-to-artifact provenance, typed
+owner/actor projection, and a structured job lifecycle exist.
+
+Current `unicity-aos/aos-ce` `main` does not ship a Linux Realm capsule, guest
+image, or `docs` implementation of this contract. Historical RISC-V draft
+work and unmerged pull requests are not product authority.
+
+## Independent tracks
+
+- The **native kernel track** owns ring-0 isolation, capabilities, IPC, and
+  hardware mediation in Astrid.
+- The **Linux Realm track** owns a confined Linux-shaped workbench above the
+  stable Astrid capsule boundary.
+
+Either track may proceed without waiting for the other. A hosted or native
+Astrid success does not prove Linux Realm, and a Linux Realm prototype does
+not prove the native kernel.
+
+## Frontend independence
+
+AOS product frontends, including the Adaptive Shell semantic catalog, are
+independent of guest ISA. Shell, MCP, and catalog work must not assume a
+Realm architecture or a particular Linux machine.
+
+## Production ISA recommendation
+
+When Linux Realm becomes implementable, the production guest recommendation is
+the **host ISA**: `x86_64` first, then `arm64`. That matching-host path is the
+only production recommendation recorded here.
+
+RV64-in-WASM remains an inventory and falsifier path. It is not a production
+Realm, not a substitute for host-ISA Linux, and not evidence that a RISC-V
+machine is the product.
+
+Issue `unicity-aos/aos-ce#76` still describes a RISC-V capsule in its opening
+body. Later freeze comments supersede that body for implementation: Linux
+remains a confined consumer, provenance is unresolved, and no implementation
+should resume from preserved untracked artifacts.
+
+## What Realm may be
+
+A principal-scoped Linux compatibility environment that:
+
+- receives an admitted Astrid view rather than choosing its owner from a path;
+- projects workspace and a private home without `host_process` authority;
+- keeps Linux syscall emulation, shells, compilers, and package policy out of
+  the Astrid native kernel;
+- exposes structured jobs, streams, and receipts rather than ambient Bash as
+  the product contract.
+
+## What Realm must not be
+
+- a production RISC-V or RV64-in-WASM operating system
+- a path-derived authority or second identity model
+- a Linux-specific public WIT world
+- proof of native-kernel readiness
+- a shipped AOS 2026.1.3 feature
+
+## Current honest state
+
+Fleet-computer documentation already states that the fleet computer does not
+require Linux and is not itself a Realm. That remains the correct product
+boundary until a new signed source-to-artifact Linux Realm candidate exists.

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -51,6 +51,13 @@ https://github.com/unicity-aos/aos-ce/.github/workflows/promote-channel.yml@refs
 Product versions use `YYYY.MINOR.PATCH`: the year is calendar-based, while
 minor and patch are canonical SemVer numbers rather than months.
 
+That published rule is still in force for `2026.1.3` and any other currently
+tagged release. A later product line named `2026.9.0` is intended to become
+the first year-month-patch CalVer identity, with Astrid remaining SemVer for
+that release. `2026.9.0` is not tagged, not published, and not an installer
+target. Until a signed release exists, channel pointers and exact-version
+installs continue to use the published `YYYY.MINOR.PATCH` rule above.
+
 Stable and dev point only to canonical `YYYY.MINOR.PATCH` releases. Nightly is
 a deterministic prerelease of the reviewed product version:
 

--- a/docs/runtime-layout.md
+++ b/docs/runtime-layout.md
@@ -1,0 +1,62 @@
+# AOS runtime layout
+
+This page distinguishes the layout installed by current `main` from the
+accepted single-volume layout for a later AOS `2026.9.0` release. That later
+layout is not shipped.
+
+## Current published / `main` layout
+
+AOS product state lives under `~/.aos`. The public launcher is
+`~/.aos/bin/aos`. Direct installs authenticate signed channel metadata, then
+install a versioned tree under `~/.aos/releases/<version>/` **and** copy the
+bundled Astrid executables into `~/.aos/runtime/bin/`.
+
+Current launch still treats `ASTRID_HOME=~/.aos/runtime` as the hosted runtime
+home. Typical entries after install include:
+
+```text
+~/.aos/bin/aos
+~/.aos/libexec/install.sh
+~/.aos/releases/<version>/
+~/.aos/runtime/bin/astrid
+~/.aos/runtime/bin/astrid-daemon
+~/.aos/runtime/bin/astrid-build
+~/.aos/runtime/bin/astrid-emit
+~/.aos/runtime/run/          # sockets, PID, readiness, tokens
+~/.aos/update/               # signed channel generations
+```
+
+Mutable configuration, keys, principals, capsules, and logs currently remain
+native files under the runtime home, not a single stopped-state volume file.
+`runtime/run` is the live transient tree. Clean stop does not yet reduce
+`~/.aos/runtime` to one `astrid.volume`.
+
+The standalone importer in [runtime-migration.md](runtime-migration.md) still
+expects compatibility executables under `runtime/bin` and copies persistent
+directory state. It is not the 2026.9.0 single-volume cutover.
+
+## Accepted 2026.9.0 layout (not shipped)
+
+After a clean stop, the accepted runtime directory is exactly:
+
+```text
+~/.aos/runtime/astrid.volume
+```
+
+That file is the only durable authority under `runtime/`. Signed immutable AOS
+and Astrid executables and assets live under `~/.aos/releases/2026.9.0/`.
+`~/.aos/bin/aos` and private launcher helpers remain outside `runtime/`.
+
+Process-only sockets, PID files, readiness markers, tokens, gateway state, and
+scratch data live under mode-0700 `~/.aos/run/` and are removed completely on
+clean stop. Mutable config, keys, principals, capsules, WASM/WIT, audit
+records, receipts, and application data are authoritative only inside
+`astrid.volume`.
+
+`~/.aos/update` and `~/.aos/migrations` may hold signed installer or update
+receipts but never runtime authority. Project-local `.aos` remains workspace
+metadata, not a second global runtime home.
+
+This accepted layout depends on unlanded Astrid volume-root and stop work. Do
+not treat installer copies under `runtime/bin`, a `runtime/run` tree, or a
+draft packaging change as proof that the single-volume contract is live.


### PR DESCRIPTION
## Summary

Current product docs do not carry the accepted 2026.9.0 layout or Linux Realm consumer contract, and they still describe published CalVer as `YYYY.MINOR.PATCH` where minor/patch are not months.

This adds:

- `docs/README.md` navigation, including the current Codex `mcp attach` versus Claude/Grok `mcp serve` split
- `docs/runtime-layout.md` for the **current** `~/.aos` tree versus the accepted single-volume layout, labeled not shipped
- `docs/principal-linux-realm.md` as an accepted confined-consumer contract: frontend independent of ISA; native kernel and Linux Realm are separate tracks; production guest ISA is host `x86_64` then `arm64`; RV64-in-WASM remains inventory/falsifier; `IMPLEMENTABLE_NOW=no`
- a prospective CalVer note in `docs/release-channels.md` that does not claim `2026.9.0` exists
- one Adaptive Shell sentence stating ISA independence

Root `README.md` is intentionally untouched.

Related to #76, #108, and #110. Does not close them. Does not copy RISC-V draft implementation from #77.

## Claim limits

- Docs only. No installer, Distro, version, tag, or capsule change.
- Does not document unlanded `astrid.volume`-only runtime, `~/.aos/run` as a live transient root, or a published 2026.9.0.

## Verification

- `git diff --check`