### PR TITLE
fix(mcp): harden serve forwarding and lifecycle

### DIFF
--- a/changes/114.fixed.md
+++ b/changes/114.fixed.md
@@ -1,0 +1,5 @@
+- Made `aos mcp serve` release-grade for Claude and Grok hosts: exact
+  `--workspace` and `--request-timeout` forwarding, byte-preserving
+  newline-framed relay with isolated stderr, child exit/signal status
+  preservation, and parent-interruption cleanup without orphaning the runtime.
+  Persistent `mcp attach` remains the Codex default. Closes #114.

--- a/changes/114.fixed.md
+++ b/changes/114.fixed.md
@@ -1,5 +1,6 @@
 - Made `aos mcp serve` release-grade for Claude and Grok hosts: exact
   `--workspace` and `--request-timeout` forwarding, byte-preserving
-  newline-framed relay with isolated stderr, child exit/signal status
+  newline-framed relay with unchanged initialize frames kept byte-exact,
+  isolated stderr, child exit/signal status
   preservation, and parent-interruption cleanup without orphaning the runtime.
   Persistent `mcp attach` remains the Codex default. Closes #114.

--- a/crates/unicity-aos-bootstrap/src/mcp/mod.rs
+++ b/crates/unicity-aos-bootstrap/src/mcp/mod.rs
@@ -303,8 +303,7 @@ async fn serve(
                                 ))
                             })?;
                     },
-                    TransportAction::Rewrite(mut message) => {
-                        rewrite_server_identity(&mut message);
+                    TransportAction::Rewrite(message) => {
                         let frame = json_frame(&message).ok_or_else(|| {
                             ServeFailure::Io("failed to encode initialize response".to_owned())
                         })?;
@@ -460,10 +459,11 @@ fn prepare_client_message(
     *client_supports_form = supports_form_elicitation(&value);
     if matches!(mode, InteractionMode::Auto | InteractionMode::Native)
         && (mode == InteractionMode::Native || !*client_supports_form)
+        && advertise_form_elicitation(&mut value)
     {
-        advertise_form_elicitation(&mut value);
+        return Some(json_frame(&value).unwrap_or_else(|| frame.to_vec()));
     }
-    Some(json_frame(&value).unwrap_or_else(|| frame.to_vec()))
+    None
 }
 
 enum TransportAction {
@@ -481,15 +481,13 @@ fn transport_action(
     let Ok(text) = std::str::from_utf8(frame) else {
         return TransportAction::Forward;
     };
-    let Ok(message) = serde_json::from_str::<Value>(text) else {
+    let Ok(mut message) = serde_json::from_str::<Value>(text) else {
         return TransportAction::Forward;
     };
     let handling = elicitation_handling(&message, mode, client_supports_form);
     match handling {
         ElicitationHandling::Forward => {
-            if message.pointer("/result/protocolVersion").is_some()
-                && message.pointer("/result/capabilities").is_some()
-            {
+            if rewrite_server_identity(&mut message) {
                 TransportAction::Rewrite(message)
             } else {
                 TransportAction::Forward
@@ -506,19 +504,21 @@ fn supports_form_elicitation(initialize: &Value) -> bool {
         .is_some_and(Value::is_object)
 }
 
-fn advertise_form_elicitation(initialize: &mut Value) {
+fn advertise_form_elicitation(initialize: &mut Value) -> bool {
     let Some(params) = initialize.get_mut("params").and_then(Value::as_object_mut) else {
-        return;
+        return false;
     };
     let Some(capabilities) = object_entry(params, "capabilities") else {
-        return;
+        return false;
     };
     let Some(elicitation) = object_entry(capabilities, "elicitation") else {
-        return;
+        return false;
     };
-    elicitation
-        .entry("form".to_owned())
-        .or_insert_with(|| Value::Object(Map::new()));
+    if elicitation.contains_key("form") {
+        return false;
+    }
+    elicitation.insert("form".to_owned(), Value::Object(Map::new()));
+    true
 }
 
 fn object_entry<'a>(
@@ -565,24 +565,35 @@ fn elicitation_handling(
     }
 }
 
-fn rewrite_server_identity(message: &mut Value) {
+fn rewrite_server_identity(message: &mut Value) -> bool {
     if message.pointer("/result/protocolVersion").is_none()
         || message.pointer("/result/capabilities").is_none()
     {
-        return;
+        return false;
     }
     let Some(info) = message
         .pointer_mut("/result/serverInfo")
         .and_then(Value::as_object_mut)
     else {
-        return;
+        return false;
     };
-    info.insert("name".to_owned(), Value::String("unicity-aos".to_owned()));
-    info.insert("title".to_owned(), Value::String("Unicity AOS".to_owned()));
-    info.insert(
-        "version".to_owned(),
-        Value::String(env!("CARGO_PKG_VERSION").to_owned()),
-    );
+    let mut changed = false;
+    let name = Value::String("unicity-aos".to_owned());
+    if info.get("name") != Some(&name) {
+        info.insert("name".to_owned(), name);
+        changed = true;
+    }
+    let title = Value::String("Unicity AOS".to_owned());
+    if info.get("title") != Some(&title) {
+        info.insert("title".to_owned(), title);
+        changed = true;
+    }
+    let version = Value::String(env!("CARGO_PKG_VERSION").to_owned());
+    if info.get("version") != Some(&version) {
+        info.insert("version".to_owned(), version);
+        changed = true;
+    }
+    changed
 }
 
 #[cfg(test)]
@@ -621,20 +632,19 @@ mod tests {
                 .is_some()
         );
 
-        let mut supported = false;
-        let forwarded = prepare_client_message(
-            initialize(json!({ "elicitation": { "form": {} } })).as_bytes(),
-            InteractionMode::Auto,
-            &mut supported,
-        )
-        .expect("initialize is transformed");
-        let forwarded: Value = serde_json::from_slice(&forwarded).expect("json");
-        assert!(supported);
-        assert!(
-            forwarded
-                .pointer("/params/capabilities/elicitation/form")
-                .is_some()
-        );
+        for mode in [InteractionMode::Auto, InteractionMode::Native] {
+            let mut supported = false;
+            let forwarded = prepare_client_message(
+                initialize(json!({ "elicitation": { "form": {} } })).as_bytes(),
+                mode,
+                &mut supported,
+            );
+            assert!(supported);
+            assert!(
+                forwarded.is_none(),
+                "{mode:?} must preserve already-capable initialize bytes"
+            );
+        }
     }
 
     #[test]
@@ -642,13 +652,10 @@ mod tests {
         for mode in [InteractionMode::Client, InteractionMode::Deny] {
             let mut supported = false;
             let forwarded =
-                prepare_client_message(initialize(json!({})).as_bytes(), mode, &mut supported)
-                    .expect("initialize is transformed");
-            let forwarded: Value = serde_json::from_slice(&forwarded).expect("json");
+                prepare_client_message(initialize(json!({})).as_bytes(), mode, &mut supported);
             assert!(
-                forwarded
-                    .pointer("/params/capabilities/elicitation/form")
-                    .is_none()
+                forwarded.is_none(),
+                "{mode:?} must preserve unchanged initialize bytes"
             );
         }
     }
@@ -664,10 +671,11 @@ mod tests {
         .to_string();
         let mut supported = false;
         let forwarded =
-            prepare_client_message(malformed.as_bytes(), InteractionMode::Auto, &mut supported)
-                .expect("initialize is transformed");
-        let forwarded: Value = serde_json::from_slice(&forwarded).expect("json");
-        assert_eq!(forwarded["params"]["capabilities"], "not-an-object");
+            prepare_client_message(malformed.as_bytes(), InteractionMode::Auto, &mut supported);
+        assert!(
+            forwarded.is_none(),
+            "malformed capabilities must preserve raw bytes"
+        );
         assert!(!supported);
     }
 
@@ -729,8 +737,26 @@ mod tests {
                 "serverInfo": { "name": "astrid", "version": "0.10.4" }
             }
         });
-        rewrite_server_identity(&mut response);
+        assert!(rewrite_server_identity(&mut response));
         assert_eq!(response["result"]["serverInfo"]["name"], "unicity-aos");
         assert_eq!(response["result"]["serverInfo"]["title"], "Unicity AOS");
+    }
+
+    #[test]
+    fn initialize_response_with_correct_identity_is_not_rewritten() {
+        let mut response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "serverInfo": {
+                    "name": "unicity-aos",
+                    "title": "Unicity AOS",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            }
+        });
+        assert!(!rewrite_server_identity(&mut response));
     }
 }

--- a/crates/unicity-aos-bootstrap/src/mcp/mod.rs
+++ b/crates/unicity-aos-bootstrap/src/mcp/mod.rs
@@ -8,19 +8,141 @@
 mod interaction;
 
 use std::ffi::OsString;
-use std::process::{ExitCode, Stdio};
+use std::process::{ExitCode, ExitStatus, Stdio};
 
 use clap::{Args, ValueEnum};
 use serde_json::{Map, Value};
 use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::sync::mpsc::UnboundedReceiver;
 
 use unicity_aos_bootstrap::AosHome;
+
+#[cfg(unix)]
+mod unix_signals {
+    use std::os::fd::AsRawFd as _;
+    use std::os::raw::c_int;
+    use std::os::unix::net::UnixStream;
+    use std::sync::atomic::{AtomicI32, Ordering};
+
+    use tokio::sync::mpsc;
+
+    const SIGHUP: c_int = 1;
+    const SIGINT: c_int = 2;
+    const SIGTERM: c_int = 15;
+
+    static SIGNAL_SINK: AtomicI32 = AtomicI32::new(-1);
+
+    type SignalHandler = unsafe extern "C" fn(c_int);
+
+    unsafe extern "C" {
+        fn signal(number: c_int, handler: SignalHandler) -> usize;
+        fn write(file_descriptor: c_int, buffer: *const u8, count: usize) -> isize;
+    }
+
+    unsafe extern "C" fn note_signal(number: c_int) {
+        let sink = SIGNAL_SINK.load(Ordering::Acquire);
+        if sink >= 0 {
+            let byte = [number as u8];
+            unsafe {
+                let _ = write(sink, byte.as_ptr(), 1);
+            }
+        }
+    }
+
+    pub(super) fn interrupt_receiver() -> mpsc::UnboundedReceiver<super::InterruptSignal> {
+        let (stream_read, stream_write) = UnixStream::pair().expect("create signal pipe");
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let sink = stream_write.as_raw_fd();
+        SIGNAL_SINK.store(sink, Ordering::Release);
+        std::mem::forget(stream_write);
+
+        let mut stream_read = stream_read;
+        std::thread::spawn(move || {
+            let mut signal = [0_u8; 1];
+            while let Ok(1) = std::io::Read::read(&mut stream_read, &mut signal) {
+                let Some(signal) = super::InterruptSignal::from_raw(i32::from(signal[0])) else {
+                    continue;
+                };
+                if sender.send(signal).is_err() {
+                    break;
+                }
+            }
+        });
+
+        unsafe {
+            signal(SIGHUP, note_signal);
+            signal(SIGINT, note_signal);
+            signal(SIGTERM, note_signal);
+        }
+        receiver
+    }
+}
+
+#[cfg(unix)]
+fn interrupt_receiver() -> UnboundedReceiver<InterruptSignal> {
+    unix_signals::interrupt_receiver()
+}
+
+#[cfg(not(unix))]
+fn interrupt_receiver() -> UnboundedReceiver<InterruptSignal> {
+    let (_, receiver) = tokio::sync::mpsc::unbounded_channel();
+    receiver
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InterruptSignal {
+    Hangup,
+    Interrupt,
+    Terminate,
+}
+
+impl InterruptSignal {
+    fn from_raw(number: i32) -> Option<Self> {
+        match number {
+            1 => Some(Self::Hangup),
+            2 => Some(Self::Interrupt),
+            15 => Some(Self::Terminate),
+            _ => None,
+        }
+    }
+
+    fn exit_code(self) -> ExitCode {
+        #[cfg(unix)]
+        let number = match self {
+            Self::Hangup => 1,
+            Self::Interrupt => 2,
+            Self::Terminate => 15,
+        };
+
+        #[cfg(unix)]
+        return ExitCode::from(128 + number);
+
+        #[cfg(not(unix))]
+        {
+            let _ = self;
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ServeFailure {
+    Exit(ExitStatus),
+    Interrupted(InterruptSignal),
+    Io(String),
+}
 
 #[derive(Debug, Args)]
 pub(crate) struct ServeArgs {
     /// Choose where constrained approval forms are presented.
     #[arg(long, value_enum, default_value_t = InteractionMode::Auto)]
     interaction: InteractionMode,
+    /// Project directory the host attached to this runtime session.
+    #[arg(long, value_name = "PATH")]
+    workspace: Option<std::path::PathBuf>,
+    /// Runtime request timeout forwarded exactly by the product bridge.
+    #[arg(long = "request-timeout", value_name = "DURATION")]
+    request_timeout: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
@@ -54,162 +176,286 @@ pub(crate) fn handle_serve(principal: Option<String>, args: ServeArgs) -> ExitCo
             return ExitCode::FAILURE;
         }
     };
-    match runtime.block_on(serve(&home, principal.as_deref(), args.interaction)) {
+    match runtime.block_on(serve(&home, principal.as_deref(), &args)) {
         Ok(()) => ExitCode::SUCCESS,
-        Err(error) => {
+        Err(ServeFailure::Exit(status)) => {
+            eprintln!("aos mcp serve: bundled MCP transport exited with {status}");
+            transport_exit_code(status)
+        }
+        Err(ServeFailure::Interrupted(signal)) => signal.exit_code(),
+        Err(ServeFailure::Io(error)) => {
             eprintln!("aos mcp serve: {error}");
             ExitCode::FAILURE
         }
     }
 }
 
+fn runtime_arguments(principal: Option<&str>, args: &ServeArgs) -> Vec<OsString> {
+    let mut arguments = Vec::<OsString>::new();
+    if let Some(principal) = principal {
+        arguments.push(OsString::from("--principal"));
+        arguments.push(OsString::from(principal));
+    }
+    arguments.extend([OsString::from("mcp"), OsString::from("serve")]);
+    if let Some(workspace) = args.workspace.as_ref() {
+        arguments.push(OsString::from("--workspace"));
+        arguments.push(workspace.as_os_str().to_os_string());
+    }
+    if let Some(timeout) = args.request_timeout.as_ref() {
+        arguments.push(OsString::from("--request-timeout"));
+        arguments.push(OsString::from(timeout));
+    }
+    arguments
+}
+
 async fn serve(
     home: &AosHome,
     principal: Option<&str>,
-    mode: InteractionMode,
-) -> Result<(), String> {
-    let mut runtime_args = Vec::<OsString>::new();
-    if let Some(principal) = principal {
-        runtime_args.push(OsString::from("--principal"));
-        runtime_args.push(OsString::from(principal));
-    }
-    runtime_args.extend([OsString::from("mcp"), OsString::from("serve")]);
+    args: &ServeArgs,
+) -> Result<(), ServeFailure> {
+    let mode = args.interaction;
+    let runtime_args = runtime_arguments(principal, args);
 
     let mut standard_command = home
         .runtime_command_with_args(&runtime_args)
-        .map_err(|error| format!("failed to prepare bundled runtime: {error}"))?;
+        .map_err(|error| ServeFailure::Io(format!("failed to prepare bundled runtime: {error}")))?;
     standard_command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit());
     let mut command = tokio::process::Command::from(standard_command);
     command.kill_on_drop(true);
-    let mut child = command
-        .spawn()
-        .map_err(|error| format!("failed to start bundled MCP compatibility transport: {error}"))?;
+    let mut child = command.spawn().map_err(|error| {
+        ServeFailure::Io(format!(
+            "failed to start bundled MCP compatibility transport: {error}"
+        ))
+    })?;
     let child_stdin = child
         .stdin
         .take()
-        .ok_or_else(|| "bundled MCP transport did not expose stdin".to_owned())?;
-    let child_stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "bundled MCP transport did not expose stdout".to_owned())?;
+        .ok_or_else(|| ServeFailure::Io("bundled MCP transport did not expose stdin".to_owned()))?;
+    let child_stdout = child.stdout.take().ok_or_else(|| {
+        ServeFailure::Io("bundled MCP transport did not expose stdout".to_owned())
+    })?;
 
-    let mut upstream = BufReader::new(tokio::io::stdin()).lines();
-    let mut downstream = BufReader::new(child_stdout).lines();
+    let mut upstream = BufReader::new(tokio::io::stdin());
+    let mut downstream = BufReader::new(child_stdout);
+    let mut client_frame = Vec::new();
+    let mut transport_frame = Vec::new();
     let mut upstream_out = tokio::io::stdout();
     let mut downstream_in = Some(child_stdin);
     let mut client_supports_form = false;
     let mut presenter = interaction::NativePresenter;
     let mut upstream_open = true;
+    let mut interrupt_rx = Some(interrupt_receiver());
 
     loop {
         tokio::select! {
-            line = upstream.next_line(), if upstream_open => {
-                let Some(line) = line.map_err(|error| format!("failed to read MCP client: {error}"))? else {
+            result = read_frame(&mut upstream, &mut client_frame), if upstream_open => {
+                let bytes_read = result.map_err(|error| {
+                    ServeFailure::Io(format!("failed to read MCP client: {error}"))
+                })?;
+                if bytes_read == 0 {
                     downstream_in.take();
                     upstream_open = false;
                     continue;
-                };
-                let forwarded = prepare_client_message(&line, mode, &mut client_supports_form);
-                write_frame(
-                    downstream_in
-                        .as_mut()
-                        .ok_or_else(|| "bundled MCP transport input is closed".to_owned())?,
-                    &forwarded,
-                )
-                    .await
-                    .map_err(|error| format!("failed to write bundled MCP transport: {error}"))?;
-            },
-            line = downstream.next_line() => {
-                let Some(line) = line.map_err(|error| format!("failed to read bundled MCP transport: {error}"))? else {
-                    break;
-                };
-                let mut message = serde_json::from_str::<Value>(&line).ok();
-                let handling = message
-                    .as_ref()
-                    .map_or(ElicitationHandling::Forward, |value| {
-                        elicitation_handling(value, mode, client_supports_form)
-                    });
-                if handling != ElicitationHandling::Forward {
-                    let request = message.as_ref().expect("handling requires parsed JSON");
-                    let response = match handling {
-                        ElicitationHandling::Present => {
-                            match interaction::resolve(request, &mut presenter) {
-                                Ok(response) => response,
-                                Err(error) => {
-                                    eprintln!("aos mcp serve: local interaction denied: {error}");
-                                    interaction::cancelled_response(request).ok_or_else(|| {
-                                        "elicitation request did not carry a response id".to_owned()
-                                    })?
-                                },
-                            }
-                        },
-                        ElicitationHandling::Cancel => {
-                            interaction::cancelled_response(request).ok_or_else(|| {
-                                "elicitation request did not carry a response id".to_owned()
-                            })?
-                        },
-                        ElicitationHandling::Forward => unreachable!("handled above"),
-                    };
-                    let response = serde_json::to_string(&response)
-                        .map_err(|error| format!("failed to encode local interaction: {error}"))?;
-                    write_frame(
-                        downstream_in
-                            .as_mut()
-                            .ok_or_else(|| "bundled MCP transport input is closed".to_owned())?,
-                        &response,
-                    )
+                }
+                let Some(forwarded) =
+                    prepare_client_message(&client_frame, mode, &mut client_supports_form)
+                else {
+                    let transport_input = downstream_in.as_mut().ok_or_else(|| {
+                        ServeFailure::Io("bundled MCP transport input is closed".to_owned())
+                    })?;
+                    write_frame(transport_input, &client_frame)
                         .await
-                        .map_err(|error| format!("failed to answer local interaction: {error}"))?;
+                        .map_err(|error| {
+                            ServeFailure::Io(format!(
+                                "failed to write bundled MCP transport: {error}"
+                            ))
+                        })?;
+                    client_frame.clear();
                     continue;
+                };
+                let transport_input = downstream_in.as_mut().ok_or_else(|| {
+                    ServeFailure::Io("bundled MCP transport input is closed".to_owned())
+                })?;
+                write_frame(transport_input, &forwarded).await.map_err(|error| {
+                    ServeFailure::Io(format!("failed to write bundled MCP transport: {error}"))
+                })?;
+                client_frame.clear();
+            },
+            result = read_frame(&mut downstream, &mut transport_frame) => {
+                let bytes_read = result.map_err(|error| {
+                    ServeFailure::Io(format!(
+                        "failed to read bundled MCP transport: {error}"
+                    ))
+                })?;
+                if bytes_read == 0 {
+                    break;
                 }
-                if let Some(value) = message.as_mut() {
-                    rewrite_server_identity(value);
+                match transport_action(&transport_frame, mode, client_supports_form) {
+                    TransportAction::Forward => {
+                        write_frame(&mut upstream_out, &transport_frame)
+                            .await
+                            .map_err(|error| {
+                                ServeFailure::Io(format!(
+                                    "failed to write MCP client: {error}"
+                                ))
+                            })?;
+                    },
+                    TransportAction::Rewrite(mut message) => {
+                        rewrite_server_identity(&mut message);
+                        let frame = json_frame(&message).ok_or_else(|| {
+                            ServeFailure::Io("failed to encode initialize response".to_owned())
+                        })?;
+                        write_frame(&mut upstream_out, &frame).await.map_err(|error| {
+                            ServeFailure::Io(format!("failed to write MCP client: {error}"))
+                        })?;
+                    },
+                    TransportAction::Present(request) => {
+                        let response = match interaction::resolve(&request, &mut presenter) {
+                            Ok(response) => response,
+                            Err(error) => {
+                                eprintln!("aos mcp serve: local interaction denied: {error}");
+                                interaction::cancelled_response(&request).ok_or_else(|| {
+                                    ServeFailure::Io(
+                                        "elicitation request did not carry a response id".to_owned(),
+                                    )
+                                })?
+                            },
+                        };
+                        let frame = json_frame(&response).ok_or_else(|| {
+                            ServeFailure::Io("failed to encode local interaction".to_owned())
+                        })?;
+                        write_frame(&mut upstream_out, &frame).await.map_err(|error| {
+                            ServeFailure::Io(format!(
+                                "failed to answer local interaction: {error}"
+                            ))
+                        })?;
+                    },
+                    TransportAction::Cancel(request) => {
+                        let response = interaction::cancelled_response(&request).ok_or_else(|| {
+                            ServeFailure::Io(
+                                "elicitation request did not carry a response id".to_owned(),
+                            )
+                        })?;
+                        let frame = json_frame(&response).ok_or_else(|| {
+                            ServeFailure::Io("failed to encode cancelled interaction".to_owned())
+                        })?;
+                        write_frame(&mut upstream_out, &frame).await.map_err(|error| {
+                            ServeFailure::Io(format!(
+                                "failed to answer local interaction: {error}"
+                            ))
+                        })?;
+                    },
                 }
-                let forwarded = message
-                    .as_ref()
-                    .and_then(|value| serde_json::to_string(value).ok())
-                    .unwrap_or(line);
-                write_frame(&mut upstream_out, &forwarded)
-                    .await
-                    .map_err(|error| format!("failed to write MCP client: {error}"))?;
+                transport_frame.clear();
+            },
+            interrupt = next_interrupt(interrupt_rx.as_mut()), if interrupt_rx.is_some() => {
+                let Some(signal) = interrupt else {
+                    interrupt_rx = None;
+                    continue;
+                };
+                return Err(terminate(
+                    child,
+                    downstream_in.take(),
+                    ServeFailure::Interrupted(signal),
+                )
+                .await);
             },
         }
     }
 
     drop(downstream_in);
-    let status = child
-        .wait()
-        .await
-        .map_err(|error| format!("failed waiting for bundled MCP transport: {error}"))?;
+    let status = child.wait().await.map_err(|error| {
+        ServeFailure::Io(format!("failed waiting for bundled MCP transport: {error}"))
+    })?;
     if status.success() {
         Ok(())
     } else {
-        Err(format!("bundled MCP transport exited with {status}"))
+        Err(ServeFailure::Exit(status))
     }
 }
 
 async fn write_frame(
     output: &mut (impl tokio::io::AsyncWrite + Unpin),
-    frame: &str,
+    frame: &[u8],
 ) -> std::io::Result<()> {
-    output.write_all(frame.as_bytes()).await?;
-    output.write_all(b"\n").await?;
+    output.write_all(frame).await?;
     output.flush().await
 }
 
+async fn read_frame(
+    reader: &mut (impl tokio::io::AsyncBufRead + Unpin),
+    frame: &mut Vec<u8>,
+) -> std::io::Result<usize> {
+    frame.clear();
+    reader.read_until(b'\n', frame).await
+}
+
+async fn next_interrupt(
+    receiver: Option<&mut UnboundedReceiver<InterruptSignal>>,
+) -> Option<InterruptSignal> {
+    match receiver {
+        Some(receiver) => receiver.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+async fn terminate(
+    mut child: tokio::process::Child,
+    child_stdin: Option<tokio::process::ChildStdin>,
+    failure: ServeFailure,
+) -> ServeFailure {
+    drop(child_stdin);
+    if let Err(error) = child.start_kill() {
+        return ServeFailure::Io(format!(
+            "failed to terminate bundled MCP transport after failure: {error}"
+        ));
+    }
+    if let Err(error) = child.wait().await {
+        return ServeFailure::Io(format!(
+            "failed waiting for terminated bundled MCP transport: {error}"
+        ));
+    }
+    failure
+}
+
+fn transport_exit_code(status: ExitStatus) -> ExitCode {
+    if status.success() {
+        return ExitCode::SUCCESS;
+    }
+    if let Some(code) = status.code() {
+        return ExitCode::from(code.clamp(1, i32::from(u8::MAX)) as u8);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt as _;
+        status
+            .signal()
+            .map(|signal| ExitCode::from(u8::try_from(128 + signal).unwrap_or(u8::MAX)))
+            .unwrap_or(ExitCode::FAILURE)
+    }
+    #[cfg(not(unix))]
+    ExitCode::FAILURE
+}
+
+fn json_frame(value: &Value) -> Option<Vec<u8>> {
+    let mut frame = serde_json::to_vec(value).ok()?;
+    frame.push(b'\n');
+    Some(frame)
+}
+
 fn prepare_client_message(
-    line: &str,
+    frame: &[u8],
     mode: InteractionMode,
     client_supports_form: &mut bool,
-) -> String {
-    let Ok(mut value) = serde_json::from_str::<Value>(line) else {
-        return line.to_owned();
-    };
+) -> Option<Vec<u8>> {
+    let text = std::str::from_utf8(frame).ok()?;
+    let mut value = serde_json::from_str::<Value>(text).ok()?;
     if value.get("method").and_then(Value::as_str) != Some("initialize") {
-        return line.to_owned();
+        return None;
     }
     *client_supports_form = supports_form_elicitation(&value);
     if matches!(mode, InteractionMode::Auto | InteractionMode::Native)
@@ -217,7 +463,41 @@ fn prepare_client_message(
     {
         advertise_form_elicitation(&mut value);
     }
-    serde_json::to_string(&value).unwrap_or_else(|_| line.to_owned())
+    Some(serde_json::to_vec(&value).unwrap_or_else(|_| frame.to_vec()))
+}
+
+enum TransportAction {
+    Forward,
+    Rewrite(Value),
+    Present(Value),
+    Cancel(Value),
+}
+
+fn transport_action(
+    frame: &[u8],
+    mode: InteractionMode,
+    client_supports_form: bool,
+) -> TransportAction {
+    let Ok(text) = std::str::from_utf8(frame) else {
+        return TransportAction::Forward;
+    };
+    let Ok(message) = serde_json::from_str::<Value>(text) else {
+        return TransportAction::Forward;
+    };
+    let handling = elicitation_handling(&message, mode, client_supports_form);
+    match handling {
+        ElicitationHandling::Forward => {
+            if message.pointer("/result/protocolVersion").is_some()
+                && message.pointer("/result/capabilities").is_some()
+            {
+                TransportAction::Rewrite(message)
+            } else {
+                TransportAction::Forward
+            }
+        }
+        ElicitationHandling::Present => TransportAction::Present(message),
+        ElicitationHandling::Cancel => TransportAction::Cancel(message),
+    }
 }
 
 fn supports_form_elicitation(initialize: &Value) -> bool {
@@ -328,11 +608,12 @@ mod tests {
     fn auto_advertises_form_only_when_client_cannot_present_it() {
         let mut supported = false;
         let forwarded = prepare_client_message(
-            &initialize(json!({ "roots": {} })),
+            initialize(json!({ "roots": {} })).as_bytes(),
             InteractionMode::Auto,
             &mut supported,
-        );
-        let forwarded: Value = serde_json::from_str(&forwarded).expect("json");
+        )
+        .expect("initialize is transformed");
+        let forwarded: Value = serde_json::from_slice(&forwarded).expect("json");
         assert!(!supported);
         assert!(
             forwarded
@@ -342,11 +623,12 @@ mod tests {
 
         let mut supported = false;
         let forwarded = prepare_client_message(
-            &initialize(json!({ "elicitation": { "form": {} } })),
+            initialize(json!({ "elicitation": { "form": {} } })).as_bytes(),
             InteractionMode::Auto,
             &mut supported,
-        );
-        let forwarded: Value = serde_json::from_str(&forwarded).expect("json");
+        )
+        .expect("initialize is transformed");
+        let forwarded: Value = serde_json::from_slice(&forwarded).expect("json");
         assert!(supported);
         assert!(
             forwarded
@@ -359,8 +641,10 @@ mod tests {
     fn client_and_deny_modes_never_invent_capabilities() {
         for mode in [InteractionMode::Client, InteractionMode::Deny] {
             let mut supported = false;
-            let forwarded = prepare_client_message(&initialize(json!({})), mode, &mut supported);
-            let forwarded: Value = serde_json::from_str(&forwarded).expect("json");
+            let forwarded =
+                prepare_client_message(initialize(json!({})).as_bytes(), mode, &mut supported)
+                    .expect("initialize is transformed");
+            let forwarded: Value = serde_json::from_slice(&forwarded).expect("json");
             assert!(
                 forwarded
                     .pointer("/params/capabilities/elicitation/form")
@@ -379,8 +663,10 @@ mod tests {
         })
         .to_string();
         let mut supported = false;
-        let forwarded = prepare_client_message(&malformed, InteractionMode::Auto, &mut supported);
-        let forwarded: Value = serde_json::from_str(&forwarded).expect("json");
+        let forwarded =
+            prepare_client_message(malformed.as_bytes(), InteractionMode::Auto, &mut supported)
+                .expect("initialize is transformed");
+        let forwarded: Value = serde_json::from_slice(&forwarded).expect("json");
         assert_eq!(forwarded["params"]["capabilities"], "not-an-object");
         assert!(!supported);
     }

--- a/crates/unicity-aos-bootstrap/src/mcp/mod.rs
+++ b/crates/unicity-aos-bootstrap/src/mcp/mod.rs
@@ -463,7 +463,7 @@ fn prepare_client_message(
     {
         advertise_form_elicitation(&mut value);
     }
-    Some(serde_json::to_vec(&value).unwrap_or_else(|_| frame.to_vec()))
+    Some(json_frame(&value).unwrap_or_else(|| frame.to_vec()))
 }
 
 enum TransportAction {

--- a/crates/unicity-aos-bootstrap/tests/mcp_serve.rs
+++ b/crates/unicity-aos-bootstrap/tests/mcp_serve.rs
@@ -1,0 +1,289 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Write as _;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+struct Fixture {
+    root: PathBuf,
+    runtime: PathBuf,
+    args: PathBuf,
+    home: PathBuf,
+}
+
+impl Fixture {
+    fn new(name: &str) -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "aos-mcp-serve-{name}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).expect("create fixture");
+        let fixture = Self {
+            root: root.clone(),
+            runtime: root.join("fake-runtime"),
+            args: root.join("runtime-args"),
+            home: root.join("runtime-home"),
+        };
+        fs::create_dir_all(&fixture.home).expect("create runtime home");
+        fixture
+    }
+
+    fn install_runtime(&self, body: &str) {
+        fs::write(&self.runtime, body).expect("write fake runtime");
+        let mut permissions = fs::metadata(&self.runtime)
+            .expect("runtime metadata")
+            .permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&self.runtime, permissions).expect("make runtime executable");
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_aos"));
+        command
+            .env("AOS_HOME", &self.root)
+            .env("UNICITY_AOS_RUNTIME_BIN", &self.runtime)
+            .env("AOS_TEST_ARGS", &self.args)
+            .env("AOS_TEST_HOME", self.root.join("home-marker"))
+            .env("AOS_TEST_WORKSPACE", self.root.join("workspace-marker"))
+            .env("AOS_TEST_PWD", self.root.join("pwd-marker"));
+        command
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+const RECORDING_RUNTIME: &str = r#"#!/bin/sh
+for arg in "$@"; do
+    printf '<%s>\n' "$arg"
+done > "$AOS_TEST_ARGS"
+printf '%s\n' "$ASTRID_HOME" > "$AOS_TEST_HOME"
+printf '%s\n' "$ASTRID_WORKSPACE_STATE_DIR" > "$AOS_TEST_WORKSPACE"
+printf '%s\n' "$PWD" > "$AOS_TEST_PWD"
+exit "${AOS_TEST_EXIT:-0}"
+"#;
+
+#[test]
+fn serve_forwards_host_arguments_exactly_and_separates_home_from_workspace() {
+    let fixture = Fixture::new("argv");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    let workspace = fixture.root.join("project wörkspace ✨");
+    fs::create_dir_all(&workspace).expect("create Unicode workspace");
+
+    let output = fixture
+        .command()
+        .args([
+            "--principal",
+            "grok-code",
+            "mcp",
+            "serve",
+            "--interaction",
+            "native",
+            "--workspace",
+            workspace.to_str().expect("Unicode path"),
+            "--request-timeout",
+            "1d5m",
+        ])
+        .output()
+        .expect("run MCP bridge");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let expected = format!(
+        "<--principal>\n<grok-code>\n<mcp>\n<serve>\n<--workspace>\n<{}>\n<--request-timeout>\n<1d5m>\n",
+        workspace.display()
+    );
+    assert_eq!(
+        fs::read_to_string(&fixture.args).expect("read runtime argv"),
+        expected
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("home-marker")).expect("read runtime home"),
+        format!("{}\n", fixture.root.join("runtime").display())
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("workspace-marker")).expect("read state dir"),
+        ".aos\n"
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("pwd-marker")).expect("read runtime cwd"),
+        format!("{}\n", std::env::current_dir().expect("test cwd").display())
+    );
+}
+
+#[test]
+fn serve_rejects_flags_without_values_before_starting_the_runtime() {
+    let fixture = Fixture::new("invalid-argv");
+    fixture.install_runtime(RECORDING_RUNTIME);
+
+    for arguments in [
+        vec!["mcp", "serve", "--workspace"],
+        vec!["mcp", "serve", "--request-timeout"],
+    ] {
+        let output = fixture
+            .command()
+            .args(&arguments)
+            .output()
+            .expect("run invalid MCP bridge");
+        assert_eq!(output.status.code(), Some(2));
+        assert!(
+            !fixture.args.exists(),
+            "invalid argv must not reach runtime"
+        );
+    }
+}
+
+#[test]
+fn serve_preserves_raw_frames_and_keeps_stderr_isolated() {
+    let fixture = Fixture::new("bytes");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+cat > "$AOS_TEST_PAYLOAD"
+cat "$AOS_TEST_PAYLOAD"
+echo 'runtime diagnostics only' >&2
+"#,
+    );
+    let payload_path = fixture.root.join("payload");
+    let payload = b"\xff non-JSON frame\n   {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}   \n";
+
+    let mut child = fixture
+        .command()
+        .env("AOS_TEST_PAYLOAD", &payload_path)
+        .args(["mcp", "serve"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start MCP bridge");
+    child
+        .stdin
+        .take()
+        .expect("bridge stdin")
+        .write_all(payload)
+        .expect("write raw frames");
+    let output = child.wait_with_output().expect("relay raw frames");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout, payload);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "runtime diagnostics only\n"
+    );
+    assert_eq!(
+        fs::read(&payload_path).expect("read runtime input"),
+        payload
+    );
+}
+
+#[test]
+fn serve_preserves_child_numeric_and_signal_termination() {
+    let fixture = Fixture::new("child-exit");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}'
+exit "${AOS_TEST_EXIT:-0}"
+"#,
+    );
+
+    let output = fixture
+        .command()
+        .env("AOS_TEST_EXIT", "23")
+        .args(["mcp", "serve"])
+        .output()
+        .expect("run bridge with failing runtime");
+    assert_eq!(output.status.code(), Some(23));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("exited with"));
+
+    let signal_fixture = Fixture::new("child-signal");
+    signal_fixture.install_runtime(
+        r#"#!/bin/sh
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}'
+kill -TERM "$$"
+"#,
+    );
+    let output = signal_fixture
+        .command()
+        .args(["mcp", "serve"])
+        .output()
+        .expect("run bridge with signalled runtime");
+    assert_eq!(output.status.code(), Some(143));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("exited with"));
+}
+
+#[test]
+fn parent_termination_kills_and_reaps_the_runtime_child() {
+    let fixture = Fixture::new("parent-interrupt");
+    let pid_path = fixture.root.join("runtime-pid");
+    fixture.install_runtime(&format!(
+        "#!/bin/sh\nprintf '%s\\n' \"$$\" > '{}'\nexec sleep 30\n",
+        shell_literal_path(&pid_path)
+    ));
+
+    let bridge = fixture
+        .command()
+        .args(["mcp", "serve"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start MCP bridge");
+    let runtime_pid = wait_for_runtime_pid(&pid_path);
+    let bridge_pid = bridge.id().to_string();
+
+    let termination = Command::new("kill")
+        .args(["-TERM", &bridge_pid])
+        .status()
+        .expect("signal bridge process");
+    assert!(termination.success(), "send SIGTERM to bridge");
+    let output = bridge
+        .wait_with_output()
+        .expect("wait for interrupted bridge");
+    assert_eq!(output.status.code(), Some(143));
+    assert!(
+        !process_exists(&runtime_pid),
+        "runtime child must not orphan"
+    );
+}
+
+fn wait_for_runtime_pid(path: &Path) -> String {
+    for _ in 0..1_000 {
+        if let Ok(pid) = fs::read_to_string(path) {
+            let pid = pid.trim();
+            if !pid.is_empty() {
+                return pid.to_owned();
+            }
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    panic!("runtime child did not publish its pid");
+}
+
+fn process_exists(pid: &str) -> bool {
+    Command::new("kill")
+        .args(["-0", pid])
+        .output()
+        .expect("probe runtime child")
+        .status
+        .success()
+}
+
+fn shell_literal_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\'', "'\\''")
+}

--- a/crates/unicity-aos-bootstrap/tests/mcp_serve.rs
+++ b/crates/unicity-aos-bootstrap/tests/mcp_serve.rs
@@ -194,6 +194,84 @@ echo 'runtime diagnostics only' >&2
 }
 
 #[test]
+fn serve_preserves_unchanged_initialize_request_bytes() {
+    let fixture = Fixture::new("unchanged-initialize-request");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+cat > "$AOS_TEST_PAYLOAD"
+cat "$AOS_TEST_PAYLOAD"
+"#,
+    );
+    let payload_path = fixture.root.join("payload");
+    let payload = b"  {\"method\":\"initialize\",\"params\":{\"clientInfo\":{\"version\":\"1\",\"name\":\"test\"},\"capabilities\":{\"elicitation\":{\"form\":{}}},\"protocolVersion\":\"2025-11-25\"},\"id\":1,\"jsonrpc\":\"2.0\"}  \n";
+
+    let mut child = fixture
+        .command()
+        .env("AOS_TEST_PAYLOAD", &payload_path)
+        .args(["mcp", "serve", "--interaction", "client"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start MCP bridge");
+    child
+        .stdin
+        .take()
+        .expect("bridge stdin")
+        .write_all(payload)
+        .expect("write initialize frame");
+    let output = child.wait_with_output().expect("relay initialize frame");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout, payload);
+    assert_eq!(
+        fs::read(&payload_path).expect("read runtime input"),
+        payload
+    );
+}
+
+#[test]
+fn serve_preserves_unchanged_initialize_response_bytes() {
+    let fixture = Fixture::new("unchanged-initialize-response");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+IFS= read -r line || exit 91
+printf '%s\n' '  {"result":{"capabilities":{"roots":{}},"protocolVersion":"2025-11-25"},"id":1,"jsonrpc":"2.0"}  '
+"#,
+    );
+    let request = br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}
+"#;
+    let expected_response = b"  {\"result\":{\"capabilities\":{\"roots\":{}},\"protocolVersion\":\"2025-11-25\"},\"id\":1,\"jsonrpc\":\"2.0\"}  \n";
+
+    let mut child = fixture
+        .command()
+        .args(["mcp", "serve", "--interaction", "client"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start MCP bridge");
+    child
+        .stdin
+        .take()
+        .expect("bridge stdin")
+        .write_all(request)
+        .expect("write initialize request");
+    let output = child.wait_with_output().expect("relay initialize response");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout, expected_response);
+}
+
+#[test]
 fn serve_newline_frames_transformed_initialize_for_line_reading_runtime() {
     let fixture = Fixture::new("transformed-newline");
     fixture.install_runtime(

--- a/crates/unicity-aos-bootstrap/tests/mcp_serve.rs
+++ b/crates/unicity-aos-bootstrap/tests/mcp_serve.rs
@@ -1,11 +1,12 @@
 #![cfg(unix)]
 
 use std::fs;
-use std::io::Write as _;
+use std::io::{BufRead as _, BufReader, Write as _};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 struct Fixture {
     root: PathBuf,
@@ -193,6 +194,79 @@ echo 'runtime diagnostics only' >&2
 }
 
 #[test]
+fn serve_newline_frames_transformed_initialize_for_line_reading_runtime() {
+    let fixture = Fixture::new("transformed-newline");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+IFS= read -r line || exit 91
+printf '%s\n' "$line" > "$AOS_TEST_FRAME"
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{}}'
+"#,
+    );
+    let frame_path = fixture.root.join("transformed-frame");
+    let mut child = fixture
+        .command()
+        .env("AOS_TEST_FRAME", &frame_path)
+        .args(["mcp", "serve"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start MCP bridge");
+    let mut stdin = child.stdin.take().expect("bridge stdin");
+    let stdout = child.stdout.take().expect("bridge stdout");
+    let (sender, receiver) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let result = BufReader::new(stdout)
+            .read_line(&mut line)
+            .map(|bytes| (bytes, line));
+        let _ = sender.send(result);
+    });
+
+    stdin
+        .write_all(
+            br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{"roots":{}},"clientInfo":{"name":"test","version":"1"}}}
+"#,
+        )
+        .expect("write initialize frame");
+    let response = match receiver.recv_timeout(Duration::from_secs(2)) {
+        Ok(Ok((bytes, line))) => {
+            assert!(bytes > 0, "line-reading runtime returned an empty frame");
+            line
+        }
+        Ok(Err(error)) => panic!("read transformed response: {error}"),
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            drop(stdin);
+            let _ = wait_for_child(&mut child, Duration::from_secs(2));
+            panic!("line-reading runtime did not receive transformed initialize frame");
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            drop(stdin);
+            let _ = wait_for_child(&mut child, Duration::from_secs(2));
+            panic!("line-reading runtime probe disconnected before receiving a frame");
+        }
+    };
+    drop(stdin);
+    let status = wait_for_child(&mut child, Duration::from_secs(2));
+    assert!(
+        status.success(),
+        "bridge failed after forwarding transformed initialize: {status}"
+    );
+    let transformed = fs::read_to_string(&frame_path).expect("read transformed frame");
+    let transformed: serde_json::Value =
+        serde_json::from_str(transformed.trim()).expect("transformed initialize JSON");
+    assert_eq!(transformed["method"], "initialize");
+    assert!(
+        transformed
+            .pointer("/params/capabilities/elicitation/form")
+            .is_some(),
+        "initialize must be transformed before forwarding"
+    );
+    assert_eq!(response, "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n");
+}
+
+#[test]
 fn serve_preserves_child_numeric_and_signal_termination() {
     let fixture = Fixture::new("child-exit");
     fixture.install_runtime(
@@ -282,6 +356,21 @@ fn process_exists(pid: &str) -> bool {
         .expect("probe runtime child")
         .status
         .success()
+}
+
+fn wait_for_child(child: &mut Child, timeout: Duration) -> ExitStatus {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait().expect("probe bridge process") {
+            Some(status) => return status,
+            None if Instant::now() >= deadline => {
+                child.kill().expect("terminate stalled bridge process");
+                let _ = child.wait();
+                panic!("bridge process did not exit within {timeout:?}");
+            }
+            None => std::thread::sleep(Duration::from_millis(10)),
+        }
+    }
 }
 
 fn shell_literal_path(path: &Path) -> String {


### PR DESCRIPTION
Closes #114

## Summary

- Forward `--workspace PATH` and `--request-timeout DURATION` to the immutable bundled runtime without shell re-parsing or mutable-runtime fallback.
- Relay ordinary newline-framed MCP bytes exactly, including initialize-shaped frames that do not undergo an owned mutation.
- Re-encode only actual form-capability advertisement and server-identity branding; those transformed frames keep the newline delimiter so a line-reading runtime cannot deadlock.
- Preserve representable child exits and Unix signals, isolate child stderr, and terminate/reap the runtime child on parent interruption.
- Keep `--interaction` product-local; persistent `mcp attach` remains the Codex default.

## Exact head

- Base: `238b9edcd8f352612ddf929bc149e6d54993ea1c`
- Head: `3b56853a1596edaf49f938422bec1a32b0e8a3df`
- Head parent: `c75526685c23a598c7d541fe4f9f230d08a3205b`
- All three commits are GPG-signed and DCO-compliant.

## Scope

- `changes/114.fixed.md`
- `crates/unicity-aos-bootstrap/src/mcp/mod.rs`
- `crates/unicity-aos-bootstrap/tests/mcp_serve.rs`

No packaging, release metadata, Distro Apply, runtime layout, versions, tags, WIT, Astrid, Oracle, or live installation state changes.

## Verification

- `cargo test -p unicity-aos-bootstrap --test mcp_serve` — 8 passed
- `cargo test -p unicity-aos-bootstrap mcp::tests` — 8 passed
- `cargo clippy -p unicity-aos-bootstrap --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Regressions cover a line-reading runtime that fails to respond when a transformed initialize frame lacks a newline, plus byte-equality for unchanged initialize requests and branding-inapplicable initialize responses.

## Claim limits

- Byte-exact relay applies to unchanged frames, including initialize requests/responses whose owned fields do not change.
- The two product-owned initialize transformations are deliberately re-encoded and must keep newline framing.
- Parent-interrupt proof covers Unix SIGHUP/SIGINT/SIGTERM through a shared handler; the automated parent-interrupt case is SIGTERM. Windows retains the existing Tokio lifecycle.
- Hosted exact-head CI and independent review remain required before landing.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: GLM 5.3; GPT-5.6 Luna

## Checklist

- [x] I understand every change in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
