### PR TITLE
fix(release): fail closed when stable archives lack Distro.sig

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,6 +401,36 @@ jobs:
         run: |
           python3 scripts/capsule_release.py --artifacts capsule-artifacts
           cp capsule-artifacts/*.capsule artifacts/
+      - name: Sign the selected Distro in each product archive
+        if: needs.classify.outputs.nightly == 'false'
+        env:
+          AOS_DISTRO_ED25519_SEED: ${{ secrets.AOS_DISTRO_ED25519_SEED }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          assets=(artifacts/unicity-aos-*.tar.gz)
+          if (( ${#assets[@]} == 0 )); then
+            echo "no product archives found to sign" >&2
+            exit 1
+          fi
+          for asset in "${assets[@]}"; do
+            if tar -tzf "$asset" | grep -q '/Distro.sig$'; then
+              continue
+            fi
+            signed="$RUNNER_TEMP/$(basename "$asset")"
+            scripts/package-release.sh --sign-release-archive "$asset" "$signed"
+            mv "$signed" "$asset"
+          done
+          signed_archives=0
+          for asset in "${assets[@]}"; do
+            if tar -tzf "$asset" | grep -q '/Distro.sig$'; then
+              signed_archives=$((signed_archives + 1))
+            fi
+          done
+          if (( signed_archives == 0 )); then
+            echo "no product archives contain Distro.sig after signing" >&2
+            exit 1
+          fi
       - name: Generate checksums
         run: |
           cd artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,11 @@
 
 ### Fixed
 
+- Stable `github-release` signing discovers product archives by filename
+  `unicity-aos-*.tar.gz` and refuses to publish when none are signed. The
+  download-artifact pattern `aos-*-*-*` is unchanged because it names GitHub
+  artifacts, not archive files.
+
 - Build Linux product binaries on a pinned glibc 2.31 baseline and reject AOS
   or bundled Astrid executables that require glibc newer than 2.34, restoring
   support for RHEL, Oracle Linux, Rocky Linux, and AlmaLinux 9. Closes #58.

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -23,6 +23,9 @@ session = "^1.0"
 spark = "^1.0"
 tool = "^1.0"
 
+[distro.signing]
+pubkey = "ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA="
+
 [variables]
 openai_api_key = { secret = true, description = "API key for OpenAI-compatible LLM provider" }
 openai_base_url = { description = "API base URL", default = "https://api.openai.com" }

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -2,8 +2,172 @@
 set -euo pipefail
 
 if [[ $# -ne 6 ]]; then
-  echo "usage: $0 <target> <aos-binary> <runtime-archive> <runtime-blake3> <capsule-artifacts> <output-dir>" >&2
+  if [[ "${1:-}" != "--sign-release-archive" || $# -ne 3 ]]; then
+    echo "usage: $0 <target> <aos-binary> <runtime-archive> <runtime-blake3> <capsule-artifacts> <output-dir>" >&2
+    echo "usage: $0 --sign-release-archive <aos-archive> <signed-output-archive>" >&2
+    exit 2
+  fi
+fi
+if [[ $# -eq 3 && "${1:-}" != "--sign-release-archive" ]]; then
   exit 2
+fi
+if ! command -v b3sum >/dev/null 2>&1; then
+  echo "required command not found: b3sum" >&2
+  exit 1
+fi
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+extract_safe_tar() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import pathlib
+import sys
+import tarfile
+
+archive, destination, expected_root = sys.argv[1:]
+with tarfile.open(archive, "r:gz") as members:
+    records = members.getmembers()
+    for member in records:
+        name = pathlib.PurePosixPath(member.name)
+        if name.is_absolute() or ".." in name.parts:
+            raise SystemExit(f"unsafe archive path: {member.name}")
+        if not (member.isfile() or member.isdir()):
+            raise SystemExit(f"unsafe archive member type: {member.name}")
+        if expected_root and name.parts and name.parts[0] != expected_root:
+            raise SystemExit(f"archive root does not match {expected_root}: {member.name}")
+    if expected_root and not any(record.name.startswith(expected_root + "/") for record in records):
+        raise SystemExit(f"archive has no {expected_root} payload")
+    members.extractall(destination, filter="data")
+PY
+}
+
+decode_distro_seed() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+encoded = os.environ.get("AOS_DISTRO_ED25519_SEED", "")
+if len(encoded) != 64 or any(byte not in "0123456789abcdef" for byte in encoded):
+    raise SystemExit("AOS_DISTRO_ED25519_SEED must contain 64 lowercase hexadecimal characters")
+with open(sys.argv[1], "wb") as seed:
+    seed.write(bytes.fromhex(encoded))
+PY
+  chmod 0600 "$1"
+}
+
+destroy_distro_seed() {
+  if command -v shred >/dev/null 2>&1; then
+    shred -u "$1"
+  else
+    python3 - "$1" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+with open(path, "rb+") as seed:
+    size = seed.seek(0, os.SEEK_END)
+    seed.seek(0)
+    seed.write(b"\0" * size)
+    seed.flush()
+    os.fsync(seed.fileno())
+os.unlink(path)
+PY
+  fi
+}
+
+sign_staged_distro() {
+  local staged=$1
+  local seed_file=$2
+  local shuttle="$SIGNING_WORK/aos-distro.shuttle"
+  local mirror="$SIGNING_WORK/aos-distro-signed"
+  local seal_log="$SIGNING_WORK/seal.log"
+  rm -rf "$mirror"
+  mkdir -p "$mirror"
+  "$staged/runtime/bin/astrid" distro seal \
+    "$staged/Distro.toml" \
+    --output "$shuttle" \
+    --key "$seed_file" 2> "$seal_log"
+  sealer_pubkey_equals_manifest "$staged" "$seal_log"
+  extract_safe_tar "$shuttle" "$mirror" ""
+  cmp "$staged/Distro.toml" "$mirror/Distro.toml"
+  install -m 0600 "$mirror/Distro.lock" "$staged/Distro.lock"
+  install -m 0600 "$mirror/Distro.sig" "$staged/Distro.sig"
+}
+
+sealer_pubkey_equals_manifest() {
+  local staged=$1
+  local seal_log=$2
+  local declared sealed
+  declared=$(python3 - "$staged/Distro.toml" <<'PY'
+import pathlib
+import sys
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 and older
+    import tomli as tomllib
+
+pubkey = tomllib.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))["distro"]["signing"][
+    "pubkey"
+]
+if not isinstance(pubkey, str) or not pubkey.startswith("ed25519:"):
+    raise SystemExit(f"{sys.argv[1]}: [distro.signing] pubkey must be an ed25519 wire key")
+print(pubkey)
+PY
+  )
+  sealed=$(sed -n 's/.*signed by \(ed25519:[A-Za-z0-9+/=_-]*\).*/\1/p' "$seal_log" | tail -n 1)
+  if [[ -z "$sealed" ]]; then
+    echo "release sealer did not attest its signing public key; refusing to publish" >&2
+    exit 1
+  fi
+  if [[ "$sealed" != "$declared" ]]; then
+    echo "sealer public key does not match [distro.signing].pubkey; refusing to publish" >&2
+    exit 1
+  fi
+}
+
+record_signed_distro_inventory() {
+  local manifest=$1
+  local lock_digest signature_digest
+  lock_digest=$(b3sum -- "$(dirname "$manifest")/Distro.lock" | awk '{print $1}')
+  signature_digest=$(b3sum -- "$(dirname "$manifest")/Distro.sig" | awk '{print $1}')
+  python3 - "$manifest" "$lock_digest" "$signature_digest" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["release_files"]["Distro.lock"] = {"blake3": sys.argv[2], "mode": 384}
+manifest["release_files"]["Distro.sig"] = {"blake3": sys.argv[3], "mode": 384}
+path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+if [[ "${1:-}" == "--sign-release-archive" ]]; then
+  archive=$2
+  signed_output=$3
+  [[ -f "$archive" && ! -L "$archive" ]] || {
+    echo "AOS archive is missing or not a regular file: $archive" >&2
+    exit 1
+  }
+  work=$(mktemp -d)
+  signing_seed="$work/aos-distro-seed"
+  trap '[[ -z "$signing_seed" ]] || destroy_distro_seed "$signing_seed"; rm -rf "$work"' EXIT
+  decode_distro_seed "$signing_seed"
+  extract_safe_tar "$archive" "$work/extracted" ""
+  archive_root=$(find "$work/extracted" -mindepth 1 -maxdepth 1 -type d -print -quit)
+  [[ -n "$archive_root" ]] || { echo "AOS archive has no product bundle root" >&2; exit 1; }
+  SIGNING_WORK="$work/signing"
+  mkdir -p "$SIGNING_WORK"
+  sign_staged_distro "$archive_root" "$signing_seed"
+  record_signed_distro_inventory "$archive_root/release-manifest.json"
+  mkdir -p "$(dirname "$signed_output")"
+  COPYFILE_DISABLE=1 tar -czf "$work/signed.tar.gz" -C "$work/extracted" "$(basename "$archive_root")"
+  mv "$work/signed.tar.gz" "$signed_output"
+  destroy_distro_seed "$signing_seed"
+  signing_seed=
+  echo "$signed_output"
+  exit
 fi
 
 target=$1
@@ -13,7 +177,6 @@ runtime_blake3=$4
 capsule_artifacts=$5
 output_dir=$6
 
-repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 toml_value() {
   python3 - "$1" "$2" "$3" <<'PY'
 import pathlib
@@ -32,6 +195,7 @@ PY
 }
 
 product_version=$(toml_value "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" package version)
+distro_product_version=$(toml_value "$repo_root/distros/community/unicity-ce/Distro.toml" distro version)
 runtime_version=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime version)
 runtime_tag=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime tag)
 runtime_repository=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime repository)
@@ -45,6 +209,10 @@ root="unicity-aos-${product_version}-${target}"
 
 if [[ -z "$product_version" || -z "$runtime_version" || -z "$runtime_tag" || -z "$runtime_repository" || -z "$runtime_identity" || -z "$wit_repository" || -z "$wit_commit" || -z "$sdk_rust_version" || -z "$sdk_rust_commit" ]]; then
   echo "release compatibility metadata is incomplete" >&2
+  exit 1
+fi
+if [[ "$product_version" != "$distro_product_version" ]]; then
+  echo "Cargo product version $product_version does not match Distro version $distro_product_version" >&2
   exit 1
 fi
 if [[ ! -x "$aos_binary" ]]; then
@@ -62,7 +230,8 @@ fi
 python3 "$repo_root/scripts/capsule_release.py" --artifacts "$capsule_artifacts"
 
 work=$(mktemp -d)
-trap 'rm -rf "$work"' EXIT
+signing_seed=
+trap '[[ -z "$signing_seed" ]] || destroy_distro_seed "$signing_seed"; rm -rf "$work"' EXIT
 mkdir -p \
   "$work/runtime-extract" \
   "$work/$root/bin" \
@@ -104,17 +273,66 @@ install -m 0644 "$repo_root/release/runtime-compatibility.toml" "$work/$root/run
 install -m 0644 "$repo_root/distros/community/unicity-ce/Distro.toml" "$work/$root/Distro.toml"
 install -m 0644 "$repo_root/README.md" "$work/$root/README.md"
 
-python3 - "$work/$root/release-manifest.json" "$work/$root/capsule-assets.txt" "$product_version" "$target" "$runtime_repository" "$runtime_version" "$runtime_tag" "$runtime_blake3" "$runtime_identity" "$wit_repository" "$wit_commit" "$sdk_rust_version" "$sdk_rust_commit" <<'PY'
+distro_signing=no
+if [[ -n "${AOS_DISTRO_ED25519_SEED:-}" ]]; then
+  distro_signing=yes
+  SIGNING_WORK="$work/signing"
+  signing_seed="$work/aos-distro-seed"
+  mkdir -p "$SIGNING_WORK"
+  decode_distro_seed "$signing_seed"
+  sign_staged_distro "$work/$root" "$signing_seed"
+  destroy_distro_seed "$signing_seed"
+  signing_seed=
+fi
+
+release_inventory="$work/release-files.tsv"
+: > "$release_inventory"
+record_release_file() {
+  local relative=$1
+  local mode=$2
+  local digest
+  digest=$(b3sum -- "$work/$root/$relative")
+  printf '%s\t%s\t%s\n' "$relative" "$mode" "$(awk '{print $1}' <<<"$digest")" \
+    >> "$release_inventory"
+}
+record_release_file bin/aos 700
+record_release_file libexec/install.sh 600
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  record_release_file "runtime/bin/$binary" 700
+done
+record_release_file capsule-assets.txt 600
+record_release_file Distro.toml 600
+if [[ "$distro_signing" = yes ]]; then
+  record_release_file Distro.lock 600
+  record_release_file Distro.sig 600
+fi
+record_release_file README.md 600
+record_release_file runtime-compatibility.toml 600
+while IFS= read -r capsule; do
+  record_release_file "capsules/$capsule" 600
+done < "$work/$root/capsule-assets.txt"
+
+python3 - "$work/$root/release-manifest.json" "$work/$root/capsule-assets.txt" "$release_inventory" "$product_version" "$target" "$runtime_repository" "$runtime_version" "$runtime_tag" "$runtime_blake3" "$runtime_identity" "$wit_repository" "$wit_commit" "$sdk_rust_version" "$sdk_rust_commit" <<'PY'
 import json
 import pathlib
 import sys
 
-path, capsule_list, product, target, runtime_repo, runtime, tag, digest, runtime_identity, wit_repo, wit_commit, sdk_version, sdk_commit = sys.argv[1:]
+path, capsule_list, inventory_path, product, target, runtime_repo, runtime, tag, digest, runtime_identity, wit_repo, wit_commit, sdk_version, sdk_commit = sys.argv[1:]
 capsules = pathlib.Path(capsule_list).read_text(encoding="utf-8").splitlines()
+release_files = {}
+for line in pathlib.Path(inventory_path).read_text(encoding="utf-8").splitlines():
+    relative, mode, file_digest = line.split("\t")
+    release_files[relative] = {"blake3": file_digest, "mode": int(mode, 8)}
 manifest = {
     "schema_version": 2,
     "product": {"name": "Unicity AOS Community Edition", "version": product},
     "target": target,
+    "layout": {
+        "release_directory": f"releases/{product}",
+        "runtime_executables": "runtime/bin",
+        "capsule_assets": "capsules",
+    },
+    "release_files": release_files,
     "runtime": {
         "repository": runtime_repo,
         "version": runtime,
@@ -131,6 +349,27 @@ manifest = {
     },
     "capsules": {"count": len(capsules), "assets": capsules},
 }
+verifiers = {
+    "aarch64-apple-darwin": {
+        "asset": "cosign-darwin-arm64",
+        "sha256": "94b42a9e697be95675f6160ab031a9a5f1ec1e646d6f648d7b2f5cd59ececbc5",
+    },
+    "x86_64-apple-darwin": {
+        "asset": "cosign-darwin-amd64",
+        "sha256": "14d2678dfbfde18798151e86fbd91ebdadbb7424b18412a42a155dd8a2df4c7a",
+    },
+    "aarch64-unknown-linux-gnu": {
+        "asset": "cosign-linux-arm64",
+        "sha256": "2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11",
+    },
+    "x86_64-unknown-linux-gnu": {
+        "asset": "cosign-linux-amd64",
+        "sha256": "ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc",
+    },
+}
+if target not in verifiers:
+    raise SystemExit(f"release target has no pinned Sigstore verifier: {target}")
+manifest["verifier"] = {"version": "v3.1.1", **verifiers[target]}
 pathlib.Path(path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 PY
 

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -295,10 +295,10 @@ record_release_file() {
   printf '%s\t%s\t%s\n' "$relative" "$mode" "$(awk '{print $1}' <<<"$digest")" \
     >> "$release_inventory"
 }
-record_release_file bin/aos 700
+record_release_file bin/aos 755
 record_release_file libexec/install.sh 600
 for binary in astrid astrid-daemon astrid-build astrid-emit; do
-  record_release_file "runtime/bin/$binary" 700
+  record_release_file "runtime/bin/$binary" 755
 done
 record_release_file capsule-assets.txt 600
 record_release_file Distro.toml 600

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -20,6 +20,82 @@ with (root / "release/runtime-compatibility.toml").open("rb") as file:
 print(product, runtime["version"], runtime["release-workflow-identity"])
 PY
 )
+
+# Release artifacts are downloaded by artifact name but signed by their
+# product archive filename. Keep the workflow's discovery and fail-closed
+# guards exercised here so either naming contract cannot silently drift.
+sign_step=$(python3 - "$repo_root/.github/workflows/release.yml" <<'PY'
+import pathlib
+import sys
+
+lines = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+start = next(
+    index
+    for index, line in enumerate(lines)
+    if line.strip() == "- name: Sign the selected Distro in each product archive"
+)
+end = next(
+    index
+    for index in range(start + 1, len(lines))
+    if lines[index].startswith("      - name: ")
+)
+print("\n".join(lines[start:end]))
+PY
+)
+if grep -Fq -- 'artifacts/aos-*-*-*.tar.gz' <<<"$sign_step"; then
+  echo "release signing loop still uses artifact names instead of product archive names" >&2
+  exit 1
+fi
+grep -Fq -- 'assets=(artifacts/unicity-aos-*.tar.gz)' <<<"$sign_step"
+grep -Fq -- 'no product archives found to sign' <<<"$sign_step"
+grep -Fq -- 'no product archives contain Distro.sig after signing' <<<"$sign_step"
+grep -Fq -- 'pattern: aos-*-*-*' "$repo_root/.github/workflows/release.yml"
+
+assert_signed_product_archives() {
+  local artifacts_dir=$1
+  local signed_archives=0
+  local -a assets
+
+  shopt -s nullglob
+  assets=("$artifacts_dir"/unicity-aos-*.tar.gz)
+  (( ${#assets[@]} > 0 )) || return 1
+  for asset in "${assets[@]}"; do
+    if tar -tzf "$asset" 2>/dev/null | grep -q '/Distro.sig$'; then
+      signed_archives=$((signed_archives + 1))
+    fi
+  done
+  (( signed_archives > 0 ))
+}
+
+glob_work="$work/signing-glob"
+mkdir -p "$glob_work/product" "$glob_work/signed" "$glob_work/empty" "$glob_work/wrong"
+product_archive="$glob_work/product/unicity-aos-${product_version}-${target}.tar.gz"
+printf 'product archive fixture\n' > "$product_archive"
+shopt -s nullglob
+old_assets=("$glob_work/product"/aos-*-*-*.tar.gz)
+test "${#old_assets[@]}" -eq 0
+new_assets=("$glob_work/product"/unicity-aos-*.tar.gz)
+test "${#new_assets[@]}" -eq 1
+test "$(basename "${new_assets[0]}")" = "unicity-aos-${product_version}-${target}.tar.gz"
+
+printf 'fixture signature\n' > "$glob_work/signed/Distro.sig"
+mkdir "$glob_work/signed/unicity-aos-${product_version}-${target}"
+mv "$glob_work/signed/Distro.sig" \
+  "$glob_work/signed/unicity-aos-${product_version}-${target}/Distro.sig"
+COPYFILE_DISABLE=1 tar -czf \
+  "$glob_work/signed/unicity-aos-${product_version}-${target}.tar.gz" \
+  -C "$glob_work/signed" "unicity-aos-${product_version}-${target}"
+assert_signed_product_archives "$glob_work/signed"
+if assert_signed_product_archives "$glob_work/empty"; then
+  echo "release signing guard accepted an empty artifact directory" >&2
+  exit 1
+fi
+printf 'wrong archive name\n' > "$glob_work/wrong/aos-${product_version}-${target}-wrong.tar.gz"
+if assert_signed_product_archives "$glob_work/wrong"; then
+  echo "release signing guard accepted a directory without product archives" >&2
+  exit 1
+fi
+
 runtime_root="$work/astrid-$runtime_version-$target"
 mkdir -p "$runtime_root" "$work/output"
 mkdir -p "$work/capsules"
@@ -37,7 +113,35 @@ for spec in source_contract():
 PY
 
 for binary in astrid astrid-daemon astrid-build astrid-emit; do
-  printf '#!/bin/sh\nexit 0\n' > "$runtime_root/$binary"
+  if [[ "$binary" == astrid ]]; then
+    cat > "$runtime_root/$binary" <<'RUNTIME'
+#!/bin/sh
+set -eu
+if [ "${2:-}" != seal ]; then exit 0; fi
+manifest=$3
+output=
+key=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output=$2; shift 2 ;;
+    --key) key=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$output" ] && [ -f "$key" ]
+stage=$(dirname "$output")/aos-fixture-seal
+rm -rf "$stage"
+mkdir -p "$stage/capsules"
+cp "$manifest" "$stage/Distro.toml"
+cp "$(dirname "$manifest")"/capsules/*.capsule "$stage/capsules/"
+printf 'schema-version = 1\nfixture = true\n' > "$stage/Distro.lock"
+printf 'fixture-signature\n' > "$stage/Distro.sig"
+printf '  signed by ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n' >&2
+COPYFILE_DISABLE=1 tar -czf "$output" -C "$stage" Distro.toml Distro.lock Distro.sig capsules
+RUNTIME
+  else
+    printf '#!/bin/sh\nexit 0\n' > "$runtime_root/$binary"
+  fi
   chmod 755 "$runtime_root/$binary"
 done
 COPYFILE_DISABLE=1 tar -czf "$work/runtime.tar.gz" -C "$work" "$(basename "$runtime_root")"
@@ -69,14 +173,21 @@ tar -tzf "$archive" > "$work/files"
 grep -q '/bin/aos$' "$work/files"
 grep -q '/libexec/install.sh$' "$work/files"
 grep -q '/runtime/bin/astrid-daemon$' "$work/files"
+grep -q '/runtime-compatibility.toml$' "$work/files"
 test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 22
 grep -q '/capsule-assets.txt$' "$work/files"
 grep -q '/Distro.toml$' "$work/files"
 grep -q '/release-manifest.json$' "$work/files"
+if grep -Eq '/Distro\.(lock|sig)$' "$work/files"; then
+  echo "unsigned release packaging emitted a production Distro signature" >&2
+  exit 1
+fi
 
 tar -xzf "$archive" -C "$work"
 manifest=$(find "$work" -path '*/release-manifest.json' -print -quit)
 bundle_root=$(dirname "$manifest")
+test "$(stat -c '%a' "$bundle_root/bin/aos" 2>/dev/null || stat -f '%Lp' "$bundle_root/bin/aos")" = 755
+test "$(stat -c '%a' "$bundle_root/runtime/bin/astrid-daemon" 2>/dev/null || stat -f '%Lp' "$bundle_root/runtime/bin/astrid-daemon")" = 755
 test "$(grep -c '^source = "capsules/aos-.*\.capsule"$' "$bundle_root/Distro.toml")" -eq 22
 if grep -F '@unicity-aos/capsule-' "$bundle_root/Distro.toml" >/dev/null; then
   echo "release archive retained a legacy capsule repository source" >&2
@@ -91,6 +202,30 @@ manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 product_version, runtime_version, runtime_identity = sys.argv[2:]
 assert manifest["schema_version"] == 2
 assert manifest["product"]["version"] == product_version
+assert manifest["layout"] == {
+    "release_directory": f"releases/{product_version}",
+    "runtime_executables": "runtime/bin",
+    "capsule_assets": "capsules",
+}
+expected_inventory = {
+    "Distro.toml",
+    "README.md",
+    "bin/aos",
+    "capsule-assets.txt",
+    "libexec/install.sh",
+    "runtime-compatibility.toml",
+    "runtime/bin/astrid",
+    "runtime/bin/astrid-build",
+    "runtime/bin/astrid-daemon",
+    "runtime/bin/astrid-emit",
+    *(f"capsules/{asset}" for asset in manifest["capsules"]["assets"]),
+}
+assert set(manifest["release_files"]) == expected_inventory, (
+    set(manifest["release_files"]) - expected_inventory,
+    expected_inventory - set(manifest["release_files"]),
+)
+assert manifest["release_files"]["bin/aos"]["mode"] == 0o700
+assert manifest["release_files"]["libexec/install.sh"]["mode"] == 0o600
 assert manifest["runtime"]["version"] == runtime_version
 assert manifest["runtime"]["digest"] == "blake3:" + "0" * 64
 assert "sha256" not in manifest["runtime"]
@@ -102,7 +237,69 @@ assert manifest["contracts"]["sdk_rust_commit"] == "bbbc61c8821d6c536fb25d2068b6
 assert manifest["capsules"]["count"] == 22
 assert len(manifest["capsules"]["assets"]) == 22
 assert len(set(manifest["capsules"]["assets"])) == 22
+assert manifest["verifier"] == {
+    "version": "v3.1.1",
+    "asset": "cosign-linux-amd64",
+    "sha256": "ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc",
+}
 PY
+
+fixture_distro="$work/FixtureDistro.toml"
+python3 - "$bundle_root/Distro.toml" "$fixture_distro" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+official = 'pubkey = "ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA="'
+fixture = 'pubkey = "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="'
+if source.count(official) != 1:
+    raise SystemExit("product Distro does not carry exactly one official signing pin")
+pathlib.Path(sys.argv[2]).write_text(source.replace(official, fixture), encoding="utf-8")
+PY
+cp "$fixture_distro" "$bundle_root/Distro.toml"
+fixture_archive="$work/fixture-aos.tar.gz"
+COPYFILE_DISABLE=1 tar -czf "$fixture_archive" -C "$work" "$(basename "$bundle_root")"
+fixture_signed="$work/fixture-aos-signed.tar.gz"
+AOS_DISTRO_ED25519_SEED="$(python3 -c 'import secrets; print(secrets.token_hex(32))')" \
+  bash "$repo_root/scripts/package-release.sh" \
+  --sign-release-archive "$fixture_archive" "$fixture_signed"
+unset AOS_DISTRO_ED25519_SEED
+tar -tzf "$fixture_signed" > "$work/fixture-files"
+grep -q '/Distro.lock$' "$work/fixture-files"
+grep -q '/Distro.sig$' "$work/fixture-files"
+mkdir "$work/fixture-extract"
+tar -xzf "$fixture_signed" -C "$work/fixture-extract"
+fixture_root="$work/fixture-extract/$(basename "$bundle_root")"
+cmp "$fixture_distro" "$fixture_root/Distro.toml"
+python3 - "$fixture_root/release-manifest.json" <<'PY'
+import json
+import pathlib
+import sys
+
+files = json.loads(pathlib.Path(sys.argv[1]).read_text())["release_files"]
+assert {"Distro.lock", "Distro.sig"} <= files.keys()
+PY
+
+python3 - "$bundle_root/Distro.toml" "$fixture_distro" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+fixture = 'pubkey = "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="'
+mismatch = 'pubkey = "ed25519:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="'
+if source.count(fixture) != 1:
+    raise SystemExit("fixture Distro does not carry exactly one fixture signing pin")
+pathlib.Path(sys.argv[2]).write_text(source.replace(fixture, mismatch), encoding="utf-8")
+PY
+cp "$fixture_distro" "$bundle_root/Distro.toml"
+mismatch_archive="$work/mismatch-aos.tar.gz"
+COPYFILE_DISABLE=1 tar -czf "$mismatch_archive" -C "$work" "$(basename "$bundle_root")"
+if AOS_DISTRO_ED25519_SEED="$(python3 -c 'import secrets; print(secrets.token_hex(32))')" \
+  bash "$repo_root/scripts/package-release.sh" \
+  --sign-release-archive "$mismatch_archive" "$work/mismatch-aos-signed.tar.gz" >/dev/null 2>&1; then
+  echo "release signing accepted a sealer key that differs from Distro.toml" >&2
+  exit 1
+fi
 
 unsafe_root="$work/unsafe-runtime"
 mkdir -p "$unsafe_root/astrid-$runtime_version-$target"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -224,8 +224,9 @@ assert set(manifest["release_files"]) == expected_inventory, (
     set(manifest["release_files"]) - expected_inventory,
     expected_inventory - set(manifest["release_files"]),
 )
-assert manifest["release_files"]["bin/aos"]["mode"] == 0o700
+assert manifest["release_files"]["bin/aos"]["mode"] == 0o755
 assert manifest["release_files"]["libexec/install.sh"]["mode"] == 0o600
+assert manifest["release_files"]["runtime/bin/astrid-daemon"]["mode"] == 0o755
 assert manifest["runtime"]["version"] == runtime_version
 assert manifest["runtime"]["digest"] == "blake3:" + "0" * 64
 assert "sha256" not in manifest["runtime"]


### PR DESCRIPTION
## Summary

Stable `github-release` now discovers product archives by filename `unicity-aos-*.tar.gz` and refuses to publish when none are present or none contain `Distro.sig`. The download-artifact pattern `aos-*-*-*` is unchanged because it names GitHub artifacts, not archive files.

This is the independently landable signing slice from parked Distro Apply work. It restacks onto live `main` after #59 (glibc baseline) and #115 (MCP relay). Linux GNU builds still use the digest-pinned Bullseye image and `$AOS_BINARY`. Nightlies remain unsigned.

Signed `release_files` executable modes now match staged archive members and the untouched installer (`0755` for `bin/aos` and runtime binaries). The selected Distro pin `[distro.signing].pubkey = ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA=` is declared so the sealer can fail closed on a key mismatch. This PR does not add `aos distro apply`, volume-only stop, or a new runtime pin.

## Exact head

- Base: `3962f00014d13c390d2c68e99f841e1061ed5f67`
- Head: `a817cf416c3ef68f13265353fcfc74e9be05ef3c`
- Parent: `cdfef85c03251f2d64ae18c8d54ec63482623e89`
- Merge-base: `3962f00014d13c390d2c68e99f841e1061ed5f67`
- Tree: `409ec9f25a9479a5c67fcab6456b8c1e7c47d595`
- Unique commits: 2
- GPG: good signature from Joshua J. Bouw `<jjb@unicity-labs.com>`, key `7CD32E7697286B11593246B9FA53358CB4127512`
- DCO: `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`

## Scope

- `.github/workflows/release.yml`
- `scripts/package-release.sh`
- `scripts/test-package-release.sh`
- `distros/community/unicity-ce/Distro.toml`
- `CHANGELOG.md`

No Distro Apply, `aos_home.rs`, `status.rs`, `install.sh`, harness, version bump, live home, tag, or publication mutation.

## Verification

- `bash scripts/test-package-release.sh`
- `git diff --check`
- `git verify-commit` (both unique commits)

## Claim limits

- Source and packaging-test evidence only. Not a 2026.9 GO, not Distro Apply, not a hosted-journey proof.
- `github-release` still seals each archive with that archive's bundled `runtime/bin/astrid` on `ubuntu-latest`. Cross-target sealer execution is out of this PR.
- Runtime compatibility remains Astrid `0.10.4` / `b6bf5d1d579915eb5d3c944857d84e62a4fcc878`.
- Production Distro signatures are not committed. Fixture packaging proves orchestration, not production sealing.
- Distro identity remains `2026.1.3`.

## AI / Tool Assistance

Assisted-by: Codex:grok-4.6

A coding agent extracted the fail-closed archive-signing slice onto current `main`. The maintainer owns signing custody and the merge decision.

## Checklist

- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
- [x] Independent review complete
- [ ] Ready to merge
