### PR TITLE
feat(release): validate musl compatibility metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
       - run: python3 scripts/validate-release-contract.py
       - run: python3 scripts/test_validate_release_contract.py
       - run: python3 scripts/test_release_metadata.py
+      - run: python3 scripts/test_musl_release_metadata.py
       - run: python3 scripts/test_nightly_version.py
       - run: python3 scripts/test_channel_transaction.py
       - run: python3 scripts/test_channel_publication.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- A staged, fail-closed Linux musl runtime-compatibility contract and strict
+  metadata schema/validator. The pin keeps the current Astrid 0.10.4 identity
+  with `release-ready = false` and empty musl publication fields. Related #62.
 - An unpublished native Rust semantic catalog capsule that owns the finite v1
   component inventory, complete primitive records, two complete theme packs,
   hostile-value validation, fail-closed token fallback, safe unknown-component

--- a/release/runtime-musl-compatibility.toml
+++ b/release/runtime-musl-compatibility.toml
@@ -1,0 +1,17 @@
+schema-version = 1
+
+# Linux musl runtime provenance is intentionally separate from the legacy
+# four-target runtime compatibility contract. A release-only pin update flips
+# this gate after Astrid publishes and authenticates the matching immutable
+# two-target musl extension.
+[runtime]
+repository = "astrid-runtime/astrid"
+release-ready = false
+version = "0.10.4"
+tag = "v0.10.4"
+release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v0.10.4"
+source-commit = "b6bf5d1d579915eb5d3c944857d84e62a4fcc878"
+legacy-release-metadata-asset = "astrid-0.10.4-release.toml"
+legacy-release-metadata-blake3 = "25f4de92aa2db9db81e84902db479adf8bae68256fe3656db2c1673dfb302c0b"
+musl-release-metadata-asset = ""
+musl-release-metadata-blake3 = ""

--- a/scripts/musl_release_metadata.py
+++ b/scripts/musl_release_metadata.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Validate the immutable Linux musl metadata extension for an AOS release."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import release_metadata
+
+
+KIND = "aos-release-musl-extension"
+MUSL_TARGETS = (
+    "aarch64-unknown-linux-musl",
+    "x86_64-unknown-linux-musl",
+)
+ROOT_KEYS = {
+    "schema-version",
+    "kind",
+    "product",
+    "repository",
+    "version",
+    "tag",
+    "source-commit",
+    "release-workflow-identity",
+    "legacy-release",
+    "runtime-musl",
+    "targets",
+}
+LEGACY_KEYS = {"metadata-asset", "metadata-sha256"}
+RUNTIME_KEYS = {
+    "repository",
+    "version",
+    "tag",
+    "source-commit",
+    "release-workflow-identity",
+    "legacy-release-metadata-asset",
+    "legacy-release-metadata-blake3",
+    "musl-release-metadata-asset",
+    "musl-release-metadata-blake3",
+}
+TARGET_KEYS = {"asset", "sha256", "blake3", "sigstore-bundle", "size"}
+
+
+def validate_runtime_pin(value: Any, *, require_ready: bool) -> dict[str, Any]:
+    """Validate a staged musl runtime pin and return its runtime table."""
+    root = release_metadata.exact_keys(
+        value, {"schema-version", "runtime"}, "musl runtime compatibility"
+    )
+    release_metadata.require(
+        type(root["schema-version"]) is int and root["schema-version"] == 1,
+        "musl runtime compatibility schema-version must be integer 1",
+    )
+    runtime = release_metadata.exact_keys(
+        root["runtime"],
+        RUNTIME_KEYS | {"release-ready"},
+        "musl runtime compatibility.runtime",
+    )
+    release_ready = runtime["release-ready"]
+    release_metadata.require(
+        type(release_ready) is bool,
+        "musl runtime compatibility release-ready must be a boolean",
+    )
+    if require_ready:
+        release_metadata.require(
+            release_ready,
+            "musl runtime compatibility release-ready gate is false",
+        )
+
+    repository = release_metadata.string(
+        runtime["repository"], "musl runtime repository"
+    )
+    release_metadata.require(
+        repository == "astrid-runtime/astrid",
+        "musl runtime repository must be astrid-runtime/astrid",
+    )
+    version = release_metadata.string(runtime["version"], "musl runtime version")
+    release_metadata.require(
+        release_metadata.SEMVER.fullmatch(version) is not None,
+        "musl runtime version must be canonical semver",
+    )
+    tag = release_metadata.string(runtime["tag"], "musl runtime tag")
+    release_metadata.require(tag == f"v{version}", "musl runtime tag/version mismatch")
+    source_commit = release_metadata.string(
+        runtime["source-commit"], "musl runtime source-commit"
+    )
+    release_metadata.require(
+        release_metadata.COMMIT.fullmatch(source_commit) is not None,
+        "musl runtime source commit is malformed",
+    )
+    identity = release_metadata.string(
+        runtime["release-workflow-identity"],
+        "musl runtime release-workflow-identity",
+    )
+    expected_identity = (
+        "https://github.com/astrid-runtime/astrid/.github/workflows/"
+        f"release.yml@refs/tags/v{version}"
+    )
+    release_metadata.require(
+        identity == expected_identity,
+        "musl runtime workflow identity is not the exact tag identity",
+    )
+
+    legacy_asset = release_metadata.string(
+        runtime["legacy-release-metadata-asset"],
+        "musl runtime legacy metadata asset",
+    )
+    release_metadata.require(
+        legacy_asset == f"astrid-{version}-release.toml",
+        "musl runtime legacy metadata asset is not canonical",
+    )
+    legacy_blake3 = release_metadata.string(
+        runtime["legacy-release-metadata-blake3"],
+        "musl runtime legacy metadata BLAKE3",
+    )
+    release_metadata.require(
+        release_metadata.HEX_64.fullmatch(legacy_blake3) is not None,
+        "musl runtime legacy metadata BLAKE3 is malformed",
+    )
+
+    musl_asset = runtime["musl-release-metadata-asset"]
+    musl_blake3 = runtime["musl-release-metadata-blake3"]
+    if release_ready:
+        musl_asset = release_metadata.string(
+            musl_asset, "musl runtime extension metadata asset"
+        )
+        release_metadata.require(
+            musl_asset == f"astrid-{version}-musl-release.toml",
+            "musl runtime extension metadata asset is not canonical",
+        )
+        musl_blake3 = release_metadata.string(
+            musl_blake3, "musl runtime extension metadata BLAKE3"
+        )
+        release_metadata.require(
+            release_metadata.HEX_64.fullmatch(musl_blake3) is not None,
+            "musl runtime extension metadata BLAKE3 is malformed",
+        )
+    else:
+        release_metadata.require(
+            musl_asset == musl_blake3 == "",
+            "unready musl runtime extension fields must remain empty",
+        )
+    return runtime
+
+
+def validate_target_table(
+    value: Any, *, version: str, context: str
+) -> dict[str, dict[str, Any]]:
+    """Validate the fixed two-target musl archive table."""
+    table = release_metadata.exact_keys(value, set(MUSL_TARGETS), context)
+    for target in MUSL_TARGETS:
+        item = release_metadata.exact_keys(
+            table[target], TARGET_KEYS, f"{context}.{target}"
+        )
+        asset = release_metadata.string(item["asset"], f"{context}.{target}.asset")
+        expected_asset = f"unicity-aos-{version}-{target}.tar.gz"
+        release_metadata.require(
+            asset == expected_asset,
+            f"{context}.{target}.asset must be {expected_asset}",
+        )
+        sigstore_bundle = release_metadata.string(
+            item["sigstore-bundle"], f"{context}.{target}.sigstore-bundle"
+        )
+        release_metadata.require(
+            sigstore_bundle == f"{asset}.sigstore.json",
+            f"{context}.{target}.sigstore-bundle must name the asset bundle",
+        )
+        for algorithm in ("sha256", "blake3"):
+            digest = release_metadata.string(
+                item[algorithm], f"{context}.{target}.{algorithm}"
+            )
+            release_metadata.require(
+                release_metadata.HEX_64.fullmatch(digest) is not None,
+                f"{context}.{target}.{algorithm} is malformed",
+            )
+        release_metadata.require(
+            type(item["size"]) is int and item["size"] > 0,
+            f"{context}.{target}.size must be positive",
+        )
+    return table
+
+
+def validate_extension(
+    value: Any,
+    *,
+    legacy: dict[str, Any] | None = None,
+    legacy_bytes: bytes | None = None,
+) -> dict[str, Any]:
+    """Validate an extension, optionally binding it to a legacy release."""
+    release_metadata.require(
+        (legacy is None) == (legacy_bytes is None),
+        "legacy release binding requires both metadata and its bytes",
+    )
+    root = release_metadata.exact_keys(value, ROOT_KEYS, "musl release metadata")
+    release_metadata.require(
+        type(root["schema-version"]) is int and root["schema-version"] == 1,
+        "musl release metadata schema-version must be integer 1",
+    )
+    kind = release_metadata.string(root["kind"], "musl release metadata kind")
+    release_metadata.require(kind == KIND, f"musl release metadata kind must be {KIND}")
+    product = release_metadata.string(
+        root["product"], "musl release metadata product"
+    )
+    release_metadata.require(
+        product == release_metadata.PRODUCT,
+        f"musl release metadata product must be {release_metadata.PRODUCT}",
+    )
+    repository = release_metadata.string(
+        root["repository"], "musl release metadata repository"
+    )
+    release_metadata.require(
+        repository == release_metadata.REPOSITORY,
+        f"musl release metadata repository must be {release_metadata.REPOSITORY}",
+    )
+    version = release_metadata.string(
+        root["version"], "musl release metadata version"
+    )
+    release_metadata.require(
+        release_metadata.VERSION.fullmatch(version) is not None,
+        "musl release metadata version must be calendar semver",
+    )
+    tag = release_metadata.string(root["tag"], "musl release metadata tag")
+    release_metadata.require(
+        tag == version, "musl release metadata tag must equal version"
+    )
+    source_commit = release_metadata.string(
+        root["source-commit"], "musl release metadata source-commit"
+    )
+    release_metadata.require(
+        release_metadata.COMMIT.fullmatch(source_commit) is not None,
+        "musl release metadata source-commit is malformed",
+    )
+    if release_metadata.is_nightly_version(version):
+        release_metadata.require(
+            release_metadata.nightly_source_commit(version) == source_commit,
+            "musl release metadata nightly version must embed its source commit",
+        )
+    identity = release_metadata.string(
+        root["release-workflow-identity"],
+        "musl release metadata release-workflow-identity",
+    )
+    release_metadata.require(
+        identity == release_metadata.release_workflow_identity(version, tag),
+        "musl release metadata workflow identity is not the exact tag identity",
+    )
+
+    legacy_link = release_metadata.exact_keys(
+        root["legacy-release"], LEGACY_KEYS, "musl release metadata.legacy-release"
+    )
+    legacy_asset = release_metadata.string(
+        legacy_link["metadata-asset"],
+        "musl release metadata legacy metadata asset",
+    )
+    release_metadata.require(
+        legacy_asset == f"unicity-aos-{version}-release.toml",
+        "musl release metadata legacy asset is not canonical",
+    )
+    legacy_digest = release_metadata.string(
+        legacy_link["metadata-sha256"],
+        "musl release metadata legacy metadata SHA-256",
+    )
+    release_metadata.require(
+        release_metadata.HEX_64.fullmatch(legacy_digest) is not None,
+        "musl release metadata legacy SHA-256 is malformed",
+    )
+
+    runtime_musl = release_metadata.exact_keys(
+        root["runtime-musl"], RUNTIME_KEYS, "musl release metadata.runtime-musl"
+    )
+    validate_runtime_pin(
+        {"schema-version": 1, "runtime": {**runtime_musl, "release-ready": True}},
+        require_ready=True,
+    )
+    validate_target_table(
+        root["targets"],
+        version=version,
+        context="musl release metadata.targets",
+    )
+
+    if legacy is not None:
+        assert legacy_bytes is not None
+        validated_legacy = release_metadata.validate_release(legacy)
+        for key in (
+            "product",
+            "version",
+            "tag",
+            "source-commit",
+            "release-workflow-identity",
+        ):
+            release_metadata.require(
+                root[key] == validated_legacy[key],
+                f"musl release metadata {key} differs from the legacy release",
+            )
+        release_metadata.require(
+            legacy_digest == hashlib.sha256(legacy_bytes).hexdigest(),
+            "musl release metadata does not bind the authenticated legacy release",
+        )
+    return root
+
+
+def render_extension(value: dict[str, Any]) -> str:
+    """Render an already-valid extension fixture as canonical TOML."""
+    root = validate_extension(value)
+    quote = release_metadata.quoted
+    lines = [
+        "schema-version = 1",
+        f"kind = {quote(root['kind'])}",
+        f"product = {quote(root['product'])}",
+        f"repository = {quote(root['repository'])}",
+        f"version = {quote(root['version'])}",
+        f"tag = {quote(root['tag'])}",
+        f"source-commit = {quote(root['source-commit'])}",
+        f"release-workflow-identity = {quote(root['release-workflow-identity'])}",
+        "",
+        "[legacy-release]",
+        f"metadata-asset = {quote(root['legacy-release']['metadata-asset'])}",
+        f"metadata-sha256 = {quote(root['legacy-release']['metadata-sha256'])}",
+        "",
+        "[runtime-musl]",
+    ]
+    for key in (
+        "repository",
+        "version",
+        "tag",
+        "source-commit",
+        "release-workflow-identity",
+        "legacy-release-metadata-asset",
+        "legacy-release-metadata-blake3",
+        "musl-release-metadata-asset",
+        "musl-release-metadata-blake3",
+    ):
+        lines.append(f"{key} = {quote(root['runtime-musl'][key])}")
+    for target in MUSL_TARGETS:
+        item = root["targets"][target]
+        lines.extend(
+            [
+                "",
+                f"[targets.{target}]",
+                f"asset = {quote(item['asset'])}",
+                f"sha256 = {quote(item['sha256'])}",
+                f"blake3 = {quote(item['blake3'])}",
+                f"sigstore-bundle = {quote(item['sigstore-bundle'])}",
+                f"size = {item['size']}",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command", required=True)
+    validate = commands.add_parser("validate")
+    validate.add_argument("path", type=Path)
+    validate.add_argument(
+        "--legacy-release",
+        type=Path,
+        help="optionally bind the extension to a legacy release metadata file",
+    )
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    extension = release_metadata.load(args.path)
+    if args.legacy_release is None:
+        validate_extension(extension)
+    else:
+        legacy_bytes = args.legacy_release.read_bytes()
+        validate_extension(
+            extension,
+            legacy=release_metadata.load(args.legacy_release),
+            legacy_bytes=legacy_bytes,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (
+        KeyError,
+        OSError,
+        release_metadata.tomllib.TOMLDecodeError,
+        TypeError,
+        ValueError,
+    ) as error:
+        print(f"musl release metadata: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/test_musl_release_metadata.py
+++ b/scripts/test_musl_release_metadata.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Regression tests for the staged Linux musl release metadata contract."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+import musl_release_metadata as MUSL
+import release_metadata
+from test_release_metadata import release_fixture
+
+
+VERSION = "2026.1.3"
+RUNTIME_VERSION = "0.10.4"
+
+
+def runtime_pin_fixture(*, release_ready: bool) -> dict[str, object]:
+    runtime = {
+        "repository": "astrid-runtime/astrid",
+        "release-ready": release_ready,
+        "version": RUNTIME_VERSION,
+        "tag": f"v{RUNTIME_VERSION}",
+        "release-workflow-identity": (
+            "https://github.com/astrid-runtime/astrid/.github/workflows/"
+            f"release.yml@refs/tags/v{RUNTIME_VERSION}"
+        ),
+        "source-commit": "b" * 40,
+        "legacy-release-metadata-asset": f"astrid-{RUNTIME_VERSION}-release.toml",
+        "legacy-release-metadata-blake3": "c" * 64,
+        "musl-release-metadata-asset": (
+            f"astrid-{RUNTIME_VERSION}-musl-release.toml"
+            if release_ready
+            else ""
+        ),
+        "musl-release-metadata-blake3": "d" * 64 if release_ready else "",
+    }
+    return {"schema-version": 1, "runtime": runtime}
+
+
+def extension_fixture() -> tuple[dict[str, object], dict[str, object], bytes]:
+    legacy = release_fixture()
+    legacy_bytes = b"fixture legacy release metadata"
+    targets = {}
+    for index, target in enumerate(MUSL.MUSL_TARGETS, 1):
+        asset = f"unicity-aos-{VERSION}-{target}.tar.gz"
+        targets[target] = {
+            "asset": asset,
+            "sha256": f"{index:064x}",
+            "blake3": f"{index + 10:064x}",
+            "sigstore-bundle": f"{asset}.sigstore.json",
+            "size": index,
+        }
+    runtime = copy.deepcopy(runtime_pin_fixture(release_ready=True)["runtime"])
+    runtime.pop("release-ready")
+    extension = {
+        "schema-version": 1,
+        "kind": MUSL.KIND,
+        "product": release_metadata.PRODUCT,
+        "repository": release_metadata.REPOSITORY,
+        "version": VERSION,
+        "tag": VERSION,
+        "source-commit": legacy["source-commit"],
+        "release-workflow-identity": legacy["release-workflow-identity"],
+        "legacy-release": {
+            "metadata-asset": f"unicity-aos-{VERSION}-release.toml",
+            "metadata-sha256": hashlib.sha256(legacy_bytes).hexdigest(),
+        },
+        "runtime-musl": runtime,
+        "targets": targets,
+    }
+    return extension, legacy, legacy_bytes
+
+
+class RuntimePinTests(unittest.TestCase):
+    def test_unready_pin_is_admitted_but_require_ready_rejects_it(self) -> None:
+        pin = runtime_pin_fixture(release_ready=False)
+        runtime = MUSL.validate_runtime_pin(pin, require_ready=False)
+        self.assertFalse(runtime["release-ready"])
+        with self.assertRaisesRegex(ValueError, "release-ready gate is false"):
+            MUSL.validate_runtime_pin(pin, require_ready=True)
+
+    def test_rejects_unknown_keys(self) -> None:
+        pin = runtime_pin_fixture(release_ready=False)
+        pin["runtime"]["surprise"] = True
+        with self.assertRaisesRegex(ValueError, "unknown keys: surprise"):
+            MUSL.validate_runtime_pin(pin, require_ready=False)
+
+    def test_rejects_tag_version_mismatch(self) -> None:
+        pin = runtime_pin_fixture(release_ready=False)
+        pin["runtime"]["tag"] = "v9.9.9"
+        with self.assertRaisesRegex(ValueError, "tag/version mismatch"):
+            MUSL.validate_runtime_pin(pin, require_ready=False)
+
+    def test_rejects_malformed_digests(self) -> None:
+        pin = runtime_pin_fixture(release_ready=False)
+        pin["runtime"]["legacy-release-metadata-blake3"] = "bad"
+        with self.assertRaisesRegex(ValueError, "legacy metadata BLAKE3"):
+            MUSL.validate_runtime_pin(pin, require_ready=False)
+
+        ready = runtime_pin_fixture(release_ready=True)
+        ready["runtime"]["musl-release-metadata-blake3"] = "bad"
+        with self.assertRaisesRegex(ValueError, "extension metadata BLAKE3"):
+            MUSL.validate_runtime_pin(ready, require_ready=False)
+
+    def test_rejects_non_empty_musl_fields_when_unready(self) -> None:
+        pin = runtime_pin_fixture(release_ready=False)
+        pin["runtime"]["musl-release-metadata-asset"] = "pending.toml"
+        with self.assertRaisesRegex(ValueError, "must remain empty"):
+            MUSL.validate_runtime_pin(pin, require_ready=False)
+
+    def test_rejects_empty_musl_fields_when_ready(self) -> None:
+        pin = runtime_pin_fixture(release_ready=True)
+        pin["runtime"]["musl-release-metadata-asset"] = ""
+        with self.assertRaises(ValueError):
+            MUSL.validate_runtime_pin(pin, require_ready=False)
+
+
+class ExtensionTests(unittest.TestCase):
+    def test_round_trip_binds_exactly_two_targets_to_legacy_release(self) -> None:
+        extension, legacy, legacy_bytes = extension_fixture()
+        MUSL.validate_extension(
+            extension,
+            legacy=legacy,
+            legacy_bytes=legacy_bytes,
+        )
+        self.assertEqual(set(extension["targets"]), set(MUSL.MUSL_TARGETS))
+
+        rendered = MUSL.render_extension(extension)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "extension.toml"
+            path.write_text(rendered, encoding="utf-8")
+            loaded = release_metadata.load(path)
+        MUSL.validate_extension(loaded, legacy=legacy, legacy_bytes=legacy_bytes)
+        self.assertEqual(loaded, extension)
+
+    def test_rejects_missing_unknown_and_duplicate_target_data(self) -> None:
+        extension, _, _ = extension_fixture()
+        missing = copy.deepcopy(extension)
+        missing["targets"].pop(MUSL.MUSL_TARGETS[0])
+        with self.assertRaisesRegex(ValueError, "missing keys"):
+            MUSL.validate_extension(missing)
+
+        unknown = copy.deepcopy(extension)
+        unknown["targets"]["x86_64-unknown-linux-gnu"] = copy.deepcopy(
+            unknown["targets"][MUSL.MUSL_TARGETS[1]]
+        )
+        with self.assertRaisesRegex(ValueError, "unknown keys"):
+            MUSL.validate_extension(unknown)
+
+        duplicate = copy.deepcopy(extension)
+        duplicate["targets"][MUSL.MUSL_TARGETS[0]] = copy.deepcopy(
+            duplicate["targets"][MUSL.MUSL_TARGETS[1]]
+        )
+        with self.assertRaisesRegex(ValueError, "asset must be"):
+            MUSL.validate_extension(duplicate)
+
+    def test_rejects_legacy_identity_mismatch(self) -> None:
+        extension, legacy, legacy_bytes = extension_fixture()
+        mismatched_legacy = copy.deepcopy(legacy)
+        mismatched_legacy["source-commit"] = "c" * 40
+        with self.assertRaisesRegex(ValueError, "source-commit differs"):
+            MUSL.validate_extension(
+                extension,
+                legacy=mismatched_legacy,
+                legacy_bytes=legacy_bytes,
+            )
+
+    def test_rejects_legacy_digest_mismatch(self) -> None:
+        extension, legacy, legacy_bytes = extension_fixture()
+        extension["legacy-release"]["metadata-sha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "bind the authenticated"):
+            MUSL.validate_extension(
+                extension,
+                legacy=legacy,
+                legacy_bytes=legacy_bytes,
+            )
+
+    def test_rejects_runtime_identity_and_unknown_keys(self) -> None:
+        extension, _, _ = extension_fixture()
+        extension["runtime-musl"]["tag"] = "v9.9.9"
+        with self.assertRaisesRegex(ValueError, "tag/version mismatch"):
+            MUSL.validate_extension(extension)
+
+        extension, _, _ = extension_fixture()
+        extension["runtime-musl"]["surprise"] = True
+        with self.assertRaisesRegex(ValueError, "unknown keys"):
+            MUSL.validate_extension(extension)
+
+    def test_checked_in_pin_is_staged_and_fail_closed(self) -> None:
+        path = Path(__file__).resolve().parent.parent / "release/runtime-musl-compatibility.toml"
+        pin = release_metadata.load(path)
+        runtime = MUSL.validate_runtime_pin(pin, require_ready=False)
+        self.assertFalse(runtime["release-ready"])
+        with self.assertRaisesRegex(ValueError, "release-ready gate is false"):
+            MUSL.validate_runtime_pin(pin, require_ready=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_release_contract.py
+++ b/scripts/test_validate_release_contract.py
@@ -10,6 +10,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import musl_release_metadata
+
 
 SCRIPT = Path(__file__).with_name("validate-release-contract.py")
 ROOT = SCRIPT.parent.parent
@@ -149,6 +151,50 @@ class ReleaseReadinessTests(unittest.TestCase):
         else:
             with self.assertRaisesRegex(ValueError, "refusing to publish"):
                 VALIDATOR.main(["--require-release-ready"])
+
+    def test_main_admits_checked_in_false_ready_musl_pin(self) -> None:
+        pin = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-musl-compatibility.toml"
+        )
+        runtime = musl_release_metadata.validate_runtime_pin(
+            pin, require_ready=False
+        )
+        self.assertFalse(runtime["release-ready"])
+        self.assertEqual(VALIDATOR.main([]), 0)
+
+    def test_require_release_ready_follows_the_gnu_gate_only(self) -> None:
+        gnu = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-compatibility.toml"
+        )["runtime"]
+        musl = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-musl-compatibility.toml"
+        )["runtime"]
+        self.assertTrue(gnu["release-ready"])
+        self.assertFalse(musl["release-ready"])
+        self.assertEqual(VALIDATOR.main(["--require-release-ready"]), 0)
+
+    def test_musl_pin_rejects_identity_extra_keys_and_empty_ready_fields(self) -> None:
+        pin = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-musl-compatibility.toml"
+        )
+        pin["runtime"]["tag"] = "v9.9.9"
+        with self.assertRaisesRegex(ValueError, "tag/version mismatch"):
+            musl_release_metadata.validate_runtime_pin(pin, require_ready=False)
+
+        pin = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-musl-compatibility.toml"
+        )
+        pin["runtime"]["surprise"] = True
+        with self.assertRaisesRegex(ValueError, "unknown keys"):
+            musl_release_metadata.validate_runtime_pin(pin, require_ready=False)
+
+        pin = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-musl-compatibility.toml"
+        )
+        pin["runtime"]["release-ready"] = True
+        pin["runtime"]["musl-release-metadata-blake3"] = ""
+        with self.assertRaises(ValueError):
+            musl_release_metadata.validate_runtime_pin(pin, require_ready=False)
 
     def test_cli_matches_the_current_publication_gate(self) -> None:
         staged = subprocess.run(

--- a/scripts/validate-release-contract.py
+++ b/scripts/validate-release-contract.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import musl_release_metadata
+
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -139,9 +141,30 @@ def main(argv: list[str] | None = None) -> int:
     product = strings("crates/unicity-aos-bootstrap/Cargo.toml")
     distro = strings("distros/community/unicity-ce/Distro.toml")
     compatibility = strings("release/runtime-compatibility.toml")
+    compatibility_metadata = readiness_metadata("release/runtime-compatibility.toml")
     validate_release_readiness(
-        readiness_metadata("release/runtime-compatibility.toml"),
+        compatibility_metadata,
         require_release_ready=args.require_release_ready,
+    )
+    musl_runtime = musl_release_metadata.validate_runtime_pin(
+        readiness_metadata("release/runtime-musl-compatibility.toml"),
+        require_ready=False,
+    )
+    gnu_runtime = compatibility_metadata["runtime"]
+    for key in ("repository", "version", "tag", "source-commit"):
+        require(
+            musl_runtime[key] == gnu_runtime[key],
+            f"musl runtime {key} does not match the GNU runtime pin",
+        )
+    require(
+        gnu_runtime["release-metadata-asset"]
+        == musl_runtime["legacy-release-metadata-asset"],
+        "musl runtime legacy metadata asset does not match the GNU runtime pin",
+    )
+    require(
+        gnu_runtime["release-metadata-blake3"]
+        == musl_runtime["legacy-release-metadata-blake3"],
+        "musl runtime legacy metadata BLAKE3 does not match the GNU runtime pin",
     )
 
     product_version = product[("package", "version")]


### PR DESCRIPTION
Related #62

## Summary

Stage a fail-closed Linux musl runtime-compatibility contract and a strict
metadata schema/validator. This does not authenticate musl installs, select
musl at runtime, or publish musl archives.

## Changes

- add a strict musl compatibility/extension metadata validator
- check in `release/runtime-musl-compatibility.toml` with the current Astrid
  0.10.4 identity, `release-ready = false`, and empty musl publication fields
- admit that exact false-ready pin from the existing release-contract gate
- keep GNU install, packaging, and four-target publication behavior unchanged

## Exact head

- Base: `c2c0e2ff8197787f711ac9ee8a46de84adc58a0c`
- Head: `bf02ddcd800e935413c0b7270d8c6675ac3ab740`
- Unique commit: `feat(release): validate musl compatibility metadata`

## Scope

- `.github/workflows/ci.yml`
- `CHANGELOG.md`
- `release/runtime-musl-compatibility.toml`
- `scripts/musl_release_metadata.py`
- `scripts/test_musl_release_metadata.py`
- `scripts/test_validate_release_contract.py`
- `scripts/validate-release-contract.py`

No installer, musl target selection, archive composer, publication inventory,
`package-release.sh`, `release.yml`, Distro Apply, version bump, or live
installation state changes.

## Verification

- GPG: good signature from Joshua J. Bouw `<jjb@unicity-labs.com>`
- DCO: `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`
- `python3 scripts/test_musl_release_metadata.py`
- `python3 scripts/test_validate_release_contract.py`
- `python3 scripts/validate-release-contract.py`
- `python3 scripts/validate-release-contract.py --require-release-ready`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## Residuals and claim limits

- Product version remains 2026.1.3.
- GNU `release/runtime-compatibility.toml` is unchanged.
- Musl publication fields stay empty until a later authenticated extension.
- `--require-release-ready` still follows the GNU publication gate only.
- Historical PRs #68 and #74 are not restacked by this change.
- This PR does not close #62.

## AI / tool disclosure

Codex was used to reconstruct this change onto current `main`.
