### PR TITLE
fix(release): seal cross-target archives with native runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,7 @@ jobs:
           import tomllib
           with open("release/runtime-compatibility.toml", "rb") as file:
               metadata = tomllib.load(file)["runtime"]
+          print(f"RUNTIME_VERSION={metadata['version']}")
           print(f"RUNTIME_TAG={metadata['tag']}")
           PY
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -394,6 +395,11 @@ jobs:
           pattern: aos-*-*-*
           merge-multiple: true
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: needs.classify.outputs.nightly == 'false'
+        with:
+          name: aos-x86_64-unknown-linux-gnu
+          path: native-sealer-candidate
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: capsule-artifacts
           name: aos-community-capsules
@@ -401,6 +407,33 @@ jobs:
         run: |
           python3 scripts/capsule_release.py --artifacts capsule-artifacts
           cp capsule-artifacts/*.capsule artifacts/
+      - name: Prepare authenticated native Distro sealer
+        if: needs.classify.outputs.nightly == 'false'
+        run: |
+          set -euo pipefail
+          python3 - "$RUNTIME_VERSION" <<'PY'
+          import sys
+
+          version = tuple(int(part) for part in sys.argv[1].split("."))
+          if version < (2026, 9, 0):
+              raise SystemExit(
+                  "stable Distro sealing requires Astrid 2026.9.0+ with the "
+                  "030f6c43+ local-capsule runtime contract"
+              )
+          PY
+          shopt -s nullglob
+          candidates=(native-sealer-candidate/unicity-aos-*.tar.gz)
+          if (( ${#candidates[@]} != 1 )); then
+            echo "expected exactly one same-run x86_64-unknown-linux-gnu AOS archive" >&2
+            exit 1
+          fi
+          sealer="$RUNNER_TEMP/aos-native-distro-sealer"
+          scripts/package-release.sh \
+            --extract-release-sealer "${candidates[0]}" "$sealer"
+          {
+            echo "AOS_DISTRO_NATIVE_SEALER=$sealer"
+            echo "AOS_DISTRO_NATIVE_SEALER_ARCHIVE=${candidates[0]}"
+          } >> "$GITHUB_ENV"
       - name: Sign the selected Distro in each product archive
         if: needs.classify.outputs.nightly == 'false'
         env:
@@ -413,12 +446,25 @@ jobs:
             echo "no product archives found to sign" >&2
             exit 1
           fi
+          [[ -n "${AOS_DISTRO_NATIVE_SEALER:-}" ]] || {
+            echo "authenticated native Distro sealer is unavailable" >&2
+            exit 1
+          }
+          [[ -n "${AOS_DISTRO_NATIVE_SEALER_ARCHIVE:-}" ]] || {
+            echo "authenticated native Distro sealer archive is unavailable" >&2
+            exit 1
+          }
           for asset in "${assets[@]}"; do
             if tar -tzf "$asset" | grep -q '/Distro.sig$'; then
               continue
             fi
             signed="$RUNNER_TEMP/$(basename "$asset")"
-            scripts/package-release.sh --sign-release-archive "$asset" "$signed"
+            scripts/package-release.sh \
+              --sign-release-archive \
+              "$asset" \
+              "$signed" \
+              "$AOS_DISTRO_NATIVE_SEALER" \
+              "$AOS_DISTRO_NATIVE_SEALER_ARCHIVE"
             mv "$signed" "$asset"
           done
           signed_archives=0

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -457,14 +457,8 @@ install -m 0644 "$repo_root/README.md" "$work/$root/README.md"
 
 distro_signing=no
 if [[ -n "${AOS_DISTRO_ED25519_SEED:-}" ]]; then
-  distro_signing=yes
-  SIGNING_WORK="$work/signing"
-  signing_seed="$work/aos-distro-seed"
-  mkdir -p "$SIGNING_WORK"
-  decode_distro_seed "$signing_seed"
-  sign_staged_distro "$work/$root" "$signing_seed"
-  destroy_distro_seed "$signing_seed"
-  signing_seed=
+  echo "release composer cannot sign Distro without an explicit native sealer; use --sign-release-archive" >&2
+  exit 1
 fi
 
 release_inventory="$work/release-files.tsv"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -2,13 +2,31 @@
 set -euo pipefail
 
 if [[ $# -ne 6 ]]; then
-  if [[ "${1:-}" != "--sign-release-archive" || $# -ne 3 ]]; then
+  case "${1:-}" in
+    --extract-release-sealer)
+      [[ $# -eq 3 ]] || {
+        echo "usage: $0 --extract-release-sealer <native-aos-archive> <output-sealer>" >&2
+        exit 2
+      }
+      ;;
+    --sign-release-archive)
+      [[ $# -eq 5 ]] || {
+        echo "usage: $0 --sign-release-archive <aos-archive> <signed-output-archive> <native-sealer> <native-aos-archive>" >&2
+        exit 2
+      }
+      ;;
+    *)
     echo "usage: $0 <target> <aos-binary> <runtime-archive> <runtime-blake3> <capsule-artifacts> <output-dir>" >&2
-    echo "usage: $0 --sign-release-archive <aos-archive> <signed-output-archive>" >&2
+    echo "usage: $0 --extract-release-sealer <native-aos-archive> <output-sealer>" >&2
+    echo "usage: $0 --sign-release-archive <aos-archive> <signed-output-archive> <native-sealer> <native-aos-archive>" >&2
     exit 2
-  fi
+      ;;
+  esac
 fi
-if [[ $# -eq 3 && "${1:-}" != "--sign-release-archive" ]]; then
+if [[ $# -eq 3 && "${1:-}" != "--extract-release-sealer" ]]; then
+  exit 2
+fi
+if [[ $# -eq 5 && "${1:-}" != "--sign-release-archive" ]]; then
   exit 2
 fi
 if ! command -v b3sum >/dev/null 2>&1; then
@@ -78,12 +96,13 @@ PY
 sign_staged_distro() {
   local staged=$1
   local seed_file=$2
+  local sealer=$3
   local shuttle="$SIGNING_WORK/aos-distro.shuttle"
   local mirror="$SIGNING_WORK/aos-distro-signed"
   local seal_log="$SIGNING_WORK/seal.log"
   rm -rf "$mirror"
   mkdir -p "$mirror"
-  "$staged/runtime/bin/astrid" distro seal \
+  "$sealer" distro seal \
     "$staged/Distro.toml" \
     --output "$shuttle" \
     --key "$seed_file" 2> "$seal_log"
@@ -92,6 +111,161 @@ sign_staged_distro() {
   cmp "$staged/Distro.toml" "$mirror/Distro.toml"
   install -m 0600 "$mirror/Distro.lock" "$staged/Distro.lock"
   install -m 0600 "$mirror/Distro.sig" "$staged/Distro.sig"
+}
+
+toml_value() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import pathlib
+import sys
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 and older
+    import tomli as tomllib
+
+path, section, key = sys.argv[1:]
+value = tomllib.loads(pathlib.Path(path).read_text(encoding="utf-8"))[section][key]
+if not isinstance(value, str) or not value:
+    raise SystemExit(f"{path}: [{section}] {key} must be a non-empty string")
+print(value)
+PY
+}
+
+require_native_release_sealer() {
+  local archive=$1
+  local output=$2
+  local expected_target=x86_64-unknown-linux-gnu
+  local work=$3
+  local extracted="$work/native-sealer-extract"
+  local product_version runtime_version runtime_tag runtime_repository runtime_identity
+
+  [[ -f "$archive" && ! -L "$archive" ]] || {
+    echo "native sealer candidate is missing or not a regular file: $archive" >&2
+    exit 1
+  }
+  [[ ! -e "$output" && ! -L "$output" ]] || {
+    echo "native sealer output already exists: $output" >&2
+    exit 1
+  }
+  product_version=$(toml_value "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" package version)
+  runtime_version=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime version)
+  runtime_tag=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime tag)
+  runtime_repository=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime repository)
+  runtime_identity=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime release-workflow-identity)
+  mkdir -p "$extracted"
+  extract_safe_tar "$archive" "$extracted" "unicity-aos-${product_version}-${expected_target}"
+  python3 - "$extracted" "$product_version" "$expected_target" "$runtime_version" "$runtime_tag" "$runtime_repository" "$runtime_identity" <<'PY'
+import json
+import os
+import pathlib
+import re
+import stat
+import sys
+
+root, product_version, target, runtime_version, runtime_tag, repository, identity = sys.argv[1:]
+root = pathlib.Path(root)
+expected_root = f"unicity-aos-{product_version}-{target}"
+entries = list(root.iterdir())
+if len(entries) != 1 or entries[0].name != expected_root or entries[0].is_symlink() or not entries[0].is_dir():
+    raise SystemExit("native sealer archive does not contain exactly the expected product root")
+bundle = entries[0]
+manifest_path = bundle / "release-manifest.json"
+sealer = bundle / "runtime/bin/astrid"
+if manifest_path.is_symlink() or not manifest_path.is_file():
+    raise SystemExit("native sealer archive is missing a regular release-manifest.json")
+if sealer.is_symlink() or not sealer.is_file() or not os.access(sealer, os.X_OK):
+    raise SystemExit("native sealer archive has no regular executable runtime/bin/astrid")
+try:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as error:
+    raise SystemExit(f"native sealer release manifest is unreadable: {error}")
+if manifest.get("schema_version") != 2:
+    raise SystemExit("native sealer release manifest schema is not supported")
+if manifest.get("target") != target:
+    raise SystemExit("native sealer release manifest target does not match x86_64-unknown-linux-gnu")
+if manifest.get("product", {}).get("version") != product_version:
+    raise SystemExit("native sealer release manifest product version does not match the checkout")
+runtime = manifest.get("runtime")
+if not isinstance(runtime, dict) or runtime != {
+    "repository": repository,
+    "version": runtime_version,
+    "tag": runtime_tag,
+    "asset": f"astrid-{runtime_version}-{target}.tar.gz",
+    "digest": runtime.get("digest") if isinstance(runtime, dict) else None,
+    "release_workflow_identity": identity,
+}:
+    raise SystemExit("native sealer release manifest runtime tuple does not match the checkout")
+digest = runtime["digest"]
+if not isinstance(digest, str) or re.fullmatch(r"blake3:[0-9a-f]{64}", digest) is None:
+    raise SystemExit("native sealer runtime digest is malformed")
+record = manifest.get("release_files", {}).get("runtime/bin/astrid")
+if not isinstance(record, dict) or set(record) != {"blake3", "mode"}:
+    raise SystemExit("native sealer release manifest lacks an exact astrid inventory record")
+if not isinstance(record["blake3"], str) or re.fullmatch(r"[0-9a-f]{64}", record["blake3"]) is None:
+    raise SystemExit("native sealer astrid inventory digest is malformed")
+if record["mode"] != 0o755:
+    raise SystemExit("native sealer astrid inventory mode is not executable")
+if stat.S_IMODE(sealer.stat().st_mode) != 0o755:
+    raise SystemExit("native sealer astrid mode does not match its inventory")
+PY
+  local extracted_sealer="$extracted/unicity-aos-${product_version}-${expected_target}/runtime/bin/astrid"
+  local expected_digest actual_digest version_output
+  expected_digest=$(python3 - "$extracted/unicity-aos-${product_version}-${expected_target}/release-manifest.json" <<'PY'
+import json
+import pathlib
+import sys
+
+print(json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))["release_files"]["runtime/bin/astrid"]["blake3"])
+PY
+  )
+  actual_digest=$(b3sum -- "$extracted_sealer" | awk '{print $1}')
+  [[ "$actual_digest" == "$expected_digest" ]] || {
+    echo "native sealer bytes do not match release-manifest.json" >&2
+    exit 1
+  }
+  version_output=$("$extracted_sealer" --version)
+  python3 - "$runtime_version" "$version_output" <<'PY'
+import re
+import sys
+
+expected, output = sys.argv[1:]
+if re.search(rf"(?<![0-9]){re.escape(expected)}(?![0-9])", output) is None:
+    raise SystemExit("native sealer --version does not match release-manifest.json")
+PY
+  install -m 0755 "$extracted_sealer" "$output"
+}
+
+require_release_archive_root() {
+  local extracted=$1
+  local product_version=$2
+  python3 - "$extracted" "$product_version" <<'PY'
+import json
+import pathlib
+import sys
+
+root, product_version = sys.argv[1:]
+root = pathlib.Path(root)
+entries = list(root.iterdir())
+if len(entries) != 1 or entries[0].is_symlink() or not entries[0].is_dir():
+    raise SystemExit("AOS archive must contain exactly one regular product root")
+bundle = entries[0]
+manifest_path = bundle / "release-manifest.json"
+if manifest_path.is_symlink() or not manifest_path.is_file():
+    raise SystemExit("AOS archive is missing a regular release-manifest.json")
+try:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as error:
+    raise SystemExit(f"AOS archive release manifest is unreadable: {error}")
+if manifest.get("schema_version") != 2:
+    raise SystemExit("AOS archive release manifest schema is not supported")
+target = manifest.get("target")
+if not isinstance(target, str) or not target:
+    raise SystemExit("AOS archive release manifest target is missing")
+if manifest.get("product", {}).get("version") != product_version:
+    raise SystemExit("AOS archive release manifest product version does not match the checkout")
+if bundle.name != f"unicity-aos-{product_version}-{target}":
+    raise SystemExit("AOS archive root does not match its release-manifest target")
+print(bundle)
+PY
 }
 
 sealer_pubkey_equals_manifest() {
@@ -143,9 +317,21 @@ path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 PY
 }
 
+if [[ "${1:-}" == "--extract-release-sealer" ]]; then
+  archive=$2
+  output=$3
+  work=$(mktemp -d)
+  trap 'rm -rf "$work"' EXIT
+  require_native_release_sealer "$archive" "$output" "$work"
+  echo "$output"
+  exit
+fi
+
 if [[ "${1:-}" == "--sign-release-archive" ]]; then
   archive=$2
   signed_output=$3
+  native_sealer=$4
+  native_sealer_archive=$5
   [[ -f "$archive" && ! -L "$archive" ]] || {
     echo "AOS archive is missing or not a regular file: $archive" >&2
     exit 1
@@ -153,13 +339,26 @@ if [[ "${1:-}" == "--sign-release-archive" ]]; then
   work=$(mktemp -d)
   signing_seed="$work/aos-distro-seed"
   trap '[[ -z "$signing_seed" ]] || destroy_distro_seed "$signing_seed"; rm -rf "$work"' EXIT
-  decode_distro_seed "$signing_seed"
+  seed_value=${AOS_DISTRO_ED25519_SEED:-}
+  unset AOS_DISTRO_ED25519_SEED
+  require_native_release_sealer "$native_sealer_archive" "$work/verified-native-sealer" "$work"
+  [[ -f "$native_sealer" && ! -L "$native_sealer" && -x "$native_sealer" ]] || {
+    echo "explicit native sealer is missing or not a regular executable: $native_sealer" >&2
+    exit 1
+  }
+  cmp "$work/verified-native-sealer" "$native_sealer" || {
+    echo "explicit native sealer does not match the authenticated native candidate" >&2
+    exit 1
+  }
   extract_safe_tar "$archive" "$work/extracted" ""
-  archive_root=$(find "$work/extracted" -mindepth 1 -maxdepth 1 -type d -print -quit)
-  [[ -n "$archive_root" ]] || { echo "AOS archive has no product bundle root" >&2; exit 1; }
+  archive_root=$(require_release_archive_root \
+    "$work/extracted" \
+    "$(toml_value "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" package version)")
   SIGNING_WORK="$work/signing"
   mkdir -p "$SIGNING_WORK"
-  sign_staged_distro "$archive_root" "$signing_seed"
+  AOS_DISTRO_ED25519_SEED="$seed_value" decode_distro_seed "$signing_seed"
+  unset seed_value
+  sign_staged_distro "$archive_root" "$signing_seed" "$native_sealer"
   record_signed_distro_inventory "$archive_root/release-manifest.json"
   mkdir -p "$(dirname "$signed_output")"
   COPYFILE_DISABLE=1 tar -czf "$work/signed.tar.gz" -C "$work/extracted" "$(basename "$archive_root")"
@@ -176,23 +375,6 @@ runtime_archive=$3
 runtime_blake3=$4
 capsule_artifacts=$5
 output_dir=$6
-
-toml_value() {
-  python3 - "$1" "$2" "$3" <<'PY'
-import pathlib
-import sys
-try:
-    import tomllib
-except ModuleNotFoundError:  # Python 3.10 and older
-    import tomli as tomllib
-
-path, section, key = sys.argv[1:]
-value = tomllib.loads(pathlib.Path(path).read_text(encoding="utf-8"))[section][key]
-if not isinstance(value, str) or not value:
-    raise SystemExit(f"{path}: [{section}] {key} must be a non-empty string")
-print(value)
-PY
-}
 
 product_version=$(toml_value "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" package version)
 distro_product_version=$(toml_value "$repo_root/distros/community/unicity-ce/Distro.toml" distro version)

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -99,30 +99,35 @@ with tarfile.open(archive_path, "w:gz") as archive:
     for index in range(8192):
         archive.addfile(tarfile.TarInfo(f"bundle/filler-{index:05d}"))
 PY
-if gnu_tar_path=$(command -v gtar 2>/dev/null); then
-  ln -s "$gnu_tar_path" "$gnu_tar_work/bin/tar"
-else
-  cat > "$gnu_tar_work/bin/tar" <<'FAKE_TAR'
+cat > "$gnu_tar_work/bin/tar" <<'FAKE_TAR'
 #!/usr/bin/env python3
 import os
+import stat
 import sys
 
 if len(sys.argv) != 3 or sys.argv[1] != "-tzf":
     raise SystemExit("fake GNU tar only supports -tzf")
-payload = b"bundle/Distro.lock\nbundle/Distro.sig\n" + b"bundle/filler\n" * 8192
-offset = 0
-while offset < len(payload):
+
+prefix = b"bundle/Distro.lock\nbundle/Distro.sig\n"
+filler = b"bundle/filler\n" * 256
+
+try:
+    os.write(1, prefix)
+    if stat.S_ISFIFO(os.fstat(1).st_mode):
+        # Keep the controlled producer alive until grep -q closes its pipe.
+        while True:
+            os.write(1, filler)
+    else:
+        for _ in range(32):
+            os.write(1, filler)
+except BrokenPipeError:
     try:
-        offset += os.write(1, payload[offset:])
-    except BrokenPipeError:
-        try:
-            os.write(2, b"tar: stdout: write error\n")
-        except OSError:
-            pass
-        raise SystemExit(2)
+        os.write(2, b"tar: stdout: write error\n")
+    except OSError:
+        pass
+    raise SystemExit(2)
 FAKE_TAR
-  chmod 755 "$gnu_tar_work/bin/tar"
-fi
+chmod 755 "$gnu_tar_work/bin/tar"
 # Deliberately exercise the pre-fix pipeline with the GNU-like tar command.
 if PATH="$gnu_tar_work/bin:$PATH" bash -c \
   'set -o pipefail; "$2" -tzf "$1" | grep -q "/Distro.lock$"' \

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -49,7 +49,14 @@ fi
 grep -Fq -- 'assets=(artifacts/unicity-aos-*.tar.gz)' <<<"$sign_step"
 grep -Fq -- 'no product archives found to sign' <<<"$sign_step"
 grep -Fq -- 'no product archives contain Distro.sig after signing' <<<"$sign_step"
+native_sealer_ref="\"\$AOS_DISTRO_NATIVE_SEALER\""
+native_sealer_archive_ref="\"\$AOS_DISTRO_NATIVE_SEALER_ARCHIVE\""
+grep -Fq -- "$native_sealer_ref" <<<"$sign_step"
+grep -Fq -- "$native_sealer_archive_ref" <<<"$sign_step"
 grep -Fq -- 'pattern: aos-*-*-*' "$repo_root/.github/workflows/release.yml"
+grep -Fq -- 'name: aos-x86_64-unknown-linux-gnu' "$repo_root/.github/workflows/release.yml"
+grep -Fq -- '--extract-release-sealer' "$repo_root/.github/workflows/release.yml"
+grep -Fq -- 'stable Distro sealing requires Astrid 2026.9.0+' "$repo_root/.github/workflows/release.yml"
 
 assert_signed_product_archives() {
   local artifacts_dir=$1
@@ -117,6 +124,13 @@ for binary in astrid astrid-daemon astrid-build astrid-emit; do
     cat > "$runtime_root/$binary" <<'RUNTIME'
 #!/bin/sh
 set -eu
+if [ -n "${AOS_DISTRO_ED25519_SEED:-}" ]; then
+  exit 96
+fi
+if [ "${1:-}" = --version ]; then
+  echo "astrid __RUNTIME_VERSION__"
+  exit 0
+fi
 if [ "${2:-}" != seal ]; then exit 0; fi
 manifest=$3
 output=
@@ -144,6 +158,8 @@ RUNTIME
   fi
   chmod 755 "$runtime_root/$binary"
 done
+sed -i.bak "s/__RUNTIME_VERSION__/$runtime_version/" "$runtime_root/astrid"
+rm "$runtime_root/astrid.bak"
 COPYFILE_DISABLE=1 tar -czf "$work/runtime.tar.gz" -C "$work" "$(basename "$runtime_root")"
 printf '#!/bin/sh\nexit 0\n' > "$work/aos"
 chmod 755 "$work/aos"
@@ -261,9 +277,12 @@ cp "$fixture_distro" "$bundle_root/Distro.toml"
 fixture_archive="$work/fixture-aos.tar.gz"
 COPYFILE_DISABLE=1 tar -czf "$fixture_archive" -C "$work" "$(basename "$bundle_root")"
 fixture_signed="$work/fixture-aos-signed.tar.gz"
+native_sealer="$work/native-distro-sealer"
+bash "$repo_root/scripts/package-release.sh" \
+  --extract-release-sealer "$fixture_archive" "$native_sealer"
 AOS_DISTRO_ED25519_SEED="$(python3 -c 'import secrets; print(secrets.token_hex(32))')" \
   bash "$repo_root/scripts/package-release.sh" \
-  --sign-release-archive "$fixture_archive" "$fixture_signed"
+  --sign-release-archive "$fixture_archive" "$fixture_signed" "$native_sealer" "$fixture_archive"
 unset AOS_DISTRO_ED25519_SEED
 tar -tzf "$fixture_signed" > "$work/fixture-files"
 grep -q '/Distro.lock$' "$work/fixture-files"
@@ -297,8 +316,132 @@ mismatch_archive="$work/mismatch-aos.tar.gz"
 COPYFILE_DISABLE=1 tar -czf "$mismatch_archive" -C "$work" "$(basename "$bundle_root")"
 if AOS_DISTRO_ED25519_SEED="$(python3 -c 'import secrets; print(secrets.token_hex(32))')" \
   bash "$repo_root/scripts/package-release.sh" \
-  --sign-release-archive "$mismatch_archive" "$work/mismatch-aos-signed.tar.gz" >/dev/null 2>&1; then
+  --sign-release-archive "$mismatch_archive" "$work/mismatch-aos-signed.tar.gz" "$native_sealer" "$fixture_archive" >/dev/null 2>&1; then
   echo "release signing accepted a sealer key that differs from Distro.toml" >&2
+  exit 1
+fi
+
+multi_target_root="$work/multi-target-archives"
+mkdir "$multi_target_root"
+targets=(
+  x86_64-unknown-linux-gnu
+  aarch64-unknown-linux-gnu
+  x86_64-apple-darwin
+  aarch64-apple-darwin
+)
+for archive_target in "${targets[@]}"; do
+  target_root="$multi_target_root/unicity-aos-${product_version}-${archive_target}"
+  cp -R "$bundle_root" "$target_root"
+  cp "$fixture_root/Distro.toml" "$target_root/Distro.toml"
+  rm -f "$target_root/Distro.lock" "$target_root/Distro.sig"
+  cat > "$target_root/runtime/bin/astrid" <<'SENTINEL'
+#!/bin/sh
+touch "${AOS_TEST_SENTINEL:?}"
+exit 97
+SENTINEL
+  chmod 755 "$target_root/runtime/bin/astrid"
+  sentinel_digest=$(b3sum -- "$target_root/runtime/bin/astrid" | awk '{print $1}')
+  python3 - "$target_root/release-manifest.json" "$archive_target" "$runtime_version" "$sentinel_digest" <<'PY'
+import json
+import pathlib
+import sys
+
+path, target, runtime_version, digest = sys.argv[1:]
+manifest = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+manifest["target"] = target
+manifest["runtime"]["asset"] = f"astrid-{runtime_version}-{target}.tar.gz"
+manifest["release_files"]["runtime/bin/astrid"] = {"blake3": digest, "mode": 0o755}
+pathlib.Path(path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+  COPYFILE_DISABLE=1 tar -czf \
+    "$multi_target_root/unicity-aos-${product_version}-${archive_target}.tar.gz" \
+    -C "$multi_target_root" "$(basename "$target_root")"
+  rm -rf "$target_root"
+done
+
+sentinel="$work/embedded-target-sealer-invoked"
+for unsigned_archive in "$multi_target_root"/*.tar.gz; do
+  signed_archive="$work/signed-$(basename "$unsigned_archive")"
+  AOS_TEST_SENTINEL="$sentinel" \
+    AOS_DISTRO_ED25519_SEED="$(python3 -c 'import secrets; print(secrets.token_hex(32))')" \
+    bash "$repo_root/scripts/package-release.sh" \
+    --sign-release-archive "$unsigned_archive" "$signed_archive" "$native_sealer" "$fixture_archive" >/dev/null
+  test ! -e "$sentinel"
+  tar -tzf "$signed_archive" | grep -q '/Distro.lock$'
+  tar -tzf "$signed_archive" | grep -q '/Distro.sig$'
+  mkdir "$work/signed-$(basename "$unsigned_archive" .tar.gz)"
+  tar -xzf "$signed_archive" -C "$work/signed-$(basename "$unsigned_archive" .tar.gz)"
+  signed_root=$(find "$work/signed-$(basename "$unsigned_archive" .tar.gz)" -mindepth 1 -maxdepth 1 -type d -print -quit)
+  cmp "$fixture_root/Distro.toml" "$signed_root/Distro.toml"
+done
+
+wrong_target_source="$work/wrong-target-sealer-source.tar.gz"
+wrong_target_root="$work/unicity-aos-${product_version}-x86_64-unknown-linux-gnu-wrong-target"
+cp -R "$fixture_root" "$wrong_target_root"
+python3 - "$wrong_target_root/release-manifest.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["target"] = "aarch64-unknown-linux-gnu"
+path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+COPYFILE_DISABLE=1 tar -czf "$wrong_target_source" -C "$work" "$(basename "$wrong_target_root")"
+if bash "$repo_root/scripts/package-release.sh" \
+  --extract-release-sealer "$wrong_target_source" "$work/wrong-target-sealer" >/dev/null 2>&1; then
+  echo "release sealer extraction accepted a source archive with the wrong target" >&2
+  exit 1
+fi
+
+wrong_digest_source="$work/wrong-digest-sealer-source.tar.gz"
+wrong_digest_root="$work/unicity-aos-${product_version}-x86_64-unknown-linux-gnu-wrong-digest"
+cp -R "$fixture_root" "$wrong_digest_root"
+python3 - "$wrong_digest_root/release-manifest.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["release_files"]["runtime/bin/astrid"]["blake3"] = "f" * 64
+path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+COPYFILE_DISABLE=1 tar -czf "$wrong_digest_source" -C "$work" "$(basename "$wrong_digest_root")"
+if bash "$repo_root/scripts/package-release.sh" \
+  --extract-release-sealer "$wrong_digest_source" "$work/wrong-digest-sealer" >/dev/null 2>&1; then
+  echo "release sealer extraction accepted bytes that differ from the manifest" >&2
+  exit 1
+fi
+
+wrong_version_source="$work/wrong-version-sealer-source.tar.gz"
+wrong_version_root="$work/unicity-aos-${product_version}-x86_64-unknown-linux-gnu-wrong-version"
+cp -R "$fixture_root" "$wrong_version_root"
+sed -i.bak "s/astrid $runtime_version/astrid 9.9.9/" "$wrong_version_root/runtime/bin/astrid"
+rm "$wrong_version_root/runtime/bin/astrid.bak"
+wrong_version_digest=$(b3sum -- "$wrong_version_root/runtime/bin/astrid" | awk '{print $1}')
+python3 - "$wrong_version_root/release-manifest.json" "$wrong_version_digest" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["release_files"]["runtime/bin/astrid"]["blake3"] = sys.argv[2]
+path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+COPYFILE_DISABLE=1 tar -czf "$wrong_version_source" -C "$work" "$(basename "$wrong_version_root")"
+if bash "$repo_root/scripts/package-release.sh" \
+  --extract-release-sealer "$wrong_version_source" "$work/wrong-version-sealer" >/dev/null 2>&1; then
+  echo "release sealer extraction accepted a binary with the wrong version" >&2
+  exit 1
+fi
+
+if AOS_DISTRO_ED25519_SEED="$(python3 -c 'import secrets; print(secrets.token_hex(32))')" \
+  bash "$repo_root/scripts/package-release.sh" \
+  --sign-release-archive "$fixture_archive" "$work/missing-sealer-signed.tar.gz" "$work/missing-sealer" "$fixture_archive" >/dev/null 2>&1; then
+  echo "release signing accepted a missing explicit native sealer" >&2
   exit 1
 fi
 

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -58,21 +58,81 @@ grep -Fq -- 'name: aos-x86_64-unknown-linux-gnu' "$repo_root/.github/workflows/r
 grep -Fq -- '--extract-release-sealer' "$repo_root/.github/workflows/release.yml"
 grep -Fq -- 'stable Distro sealing requires Astrid 2026.9.0+' "$repo_root/.github/workflows/release.yml"
 
+write_tar_listing() {
+  local archive=$1
+  local listing=$2
+  tar -tzf "$archive" > "$listing"
+}
+
 assert_signed_product_archives() {
   local artifacts_dir=$1
   local signed_archives=0
   local -a assets
+  local asset listing
 
   shopt -s nullglob
   assets=("$artifacts_dir"/unicity-aos-*.tar.gz)
   (( ${#assets[@]} > 0 )) || return 1
   for asset in "${assets[@]}"; do
-    if tar -tzf "$asset" 2>/dev/null | grep -q '/Distro.sig$'; then
-      signed_archives=$((signed_archives + 1))
+    listing=$(mktemp "$work/tar-listing.XXXXXX")
+    if write_tar_listing "$asset" "$listing" 2>/dev/null; then
+      if grep -q '/Distro.sig$' "$listing"; then
+        signed_archives=$((signed_archives + 1))
+      fi
     fi
+    rm -f "$listing"
   done
   (( signed_archives > 0 ))
 }
+
+gnu_tar_work="$work/gnu-tar-regression"
+mkdir -p "$gnu_tar_work/bin"
+gnu_tar_archive="$gnu_tar_work/archive.tar.gz"
+python3 - "$gnu_tar_archive" <<'PY'
+import sys
+import tarfile
+
+archive_path = sys.argv[1]
+with tarfile.open(archive_path, "w:gz") as archive:
+    for name in ("bundle/Distro.lock", "bundle/Distro.sig"):
+        archive.addfile(tarfile.TarInfo(name))
+    for index in range(8192):
+        archive.addfile(tarfile.TarInfo(f"bundle/filler-{index:05d}"))
+PY
+if gnu_tar_path=$(command -v gtar 2>/dev/null); then
+  ln -s "$gnu_tar_path" "$gnu_tar_work/bin/tar"
+else
+  cat > "$gnu_tar_work/bin/tar" <<'FAKE_TAR'
+#!/usr/bin/env python3
+import os
+import sys
+
+if len(sys.argv) != 3 or sys.argv[1] != "-tzf":
+    raise SystemExit("fake GNU tar only supports -tzf")
+payload = b"bundle/Distro.lock\nbundle/Distro.sig\n" + b"bundle/filler\n" * 8192
+offset = 0
+while offset < len(payload):
+    try:
+        offset += os.write(1, payload[offset:])
+    except BrokenPipeError:
+        try:
+            os.write(2, b"tar: stdout: write error\n")
+        except OSError:
+            pass
+        raise SystemExit(2)
+FAKE_TAR
+  chmod 755 "$gnu_tar_work/bin/tar"
+fi
+# Deliberately exercise the pre-fix pipeline with the GNU-like tar command.
+if PATH="$gnu_tar_work/bin:$PATH" bash -c \
+  'set -o pipefail; "$2" -tzf "$1" | grep -q "/Distro.lock$"' \
+  _ "$gnu_tar_archive" tar >/dev/null 2>"$gnu_tar_work/pipeline.err"; then
+  echo "GNU tar regression pipeline unexpectedly ignored SIGPIPE" >&2
+  exit 1
+fi
+gnu_tar_listing="$gnu_tar_work/listing"
+PATH="$gnu_tar_work/bin:$PATH" write_tar_listing "$gnu_tar_archive" "$gnu_tar_listing"
+grep -q '/Distro.lock$' "$gnu_tar_listing"
 
 glob_work="$work/signing-glob"
 mkdir -p "$glob_work/product" "$glob_work/signed" "$glob_work/empty" "$glob_work/wrong"
@@ -125,6 +185,9 @@ for binary in astrid astrid-daemon astrid-build astrid-emit; do
 #!/bin/sh
 set -eu
 if [ -n "${AOS_DISTRO_ED25519_SEED:-}" ]; then
+  if [ -n "${AOS_TEST_SENTINEL:-}" ]; then
+    touch "$AOS_TEST_SENTINEL"
+  fi
   exit 96
 fi
 if [ "${1:-}" = --version ]; then
@@ -182,6 +245,25 @@ bash "$repo_root/scripts/package-release.sh" \
   0000000000000000000000000000000000000000000000000000000000000000 \
   "$work/capsules" \
   "$work/output"
+
+compose_sentinel="$work/compose-embedded-runtime-invoked"
+compose_seed_error="$work/compose-seed.error"
+if AOS_TEST_SENTINEL="$compose_sentinel" \
+  AOS_DISTRO_ED25519_SEED="$(python3 -c 'import secrets; print(secrets.token_hex(32))')" \
+  bash "$repo_root/scripts/package-release.sh" \
+  "$target" \
+  "$work/aos" \
+  "$work/runtime.tar.gz" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$work/capsules" \
+  "$work/output" >/dev/null 2>"$compose_seed_error"; then
+  echo "release composer accepted a seed without an explicit native sealer" >&2
+  exit 1
+fi
+test ! -e "$compose_sentinel"
+grep -Fq -- \
+  'release composer cannot sign Distro without an explicit native sealer; use --sign-release-archive' \
+  "$compose_seed_error"
 
 archive="$work/output/unicity-aos-$product_version-$target.tar.gz"
 test -f "$archive"
@@ -367,8 +449,10 @@ for unsigned_archive in "$multi_target_root"/*.tar.gz; do
     bash "$repo_root/scripts/package-release.sh" \
     --sign-release-archive "$unsigned_archive" "$signed_archive" "$native_sealer" "$fixture_archive" >/dev/null
   test ! -e "$sentinel"
-  tar -tzf "$signed_archive" | grep -q '/Distro.lock$'
-  tar -tzf "$signed_archive" | grep -q '/Distro.sig$'
+  signed_listing="$work/$(basename "$signed_archive").files"
+  write_tar_listing "$signed_archive" "$signed_listing"
+  grep -q '/Distro.lock$' "$signed_listing"
+  grep -q '/Distro.sig$' "$signed_listing"
   mkdir "$work/signed-$(basename "$unsigned_archive" .tar.gz)"
   tar -xzf "$signed_archive" -C "$work/signed-$(basename "$unsigned_archive" .tar.gz)"
   signed_root=$(find "$work/signed-$(basename "$unsigned_archive" .tar.gz)" -mindepth 1 -maxdepth 1 -type d -print -quit)


### PR DESCRIPTION
Related #117

## Summary

Protected Ubuntu stable sealing authenticates the same-run
`x86_64-unknown-linux-gnu` runtime and uses that explicit native sealer for
every target archive. Target-embedded binaries are never executed. The Distro
seed is unavailable before that authentication. Stable sealing fails closed
until a later Astrid 2026.9 GNU pin supports local Distro sources.

## Changes

- extract and authenticate one same-run `x86_64-unknown-linux-gnu` sealer
- pass that explicit sealer into `--sign-release-archive` for every target
- refuse signing when the sealer, sealer archive, or seed is missing
- fail closed on current Astrid `0.10.4` until the 2026.9 local-source pin
- refuse compose-time Distro seed signing without that explicit sealer
- package tests consume complete tar listings before matching Distro.sig

## Exact head

- Base: `bd805df2bb3ace21e246ff9729e47482c07f2bb6`
- Head: `52c06229e1b48298ae97316162ad630a3270d572`
- Tree: `ba8cba9c6196e7736f4b7f82fd136abfd61f0744`

## Scope

- `.github/workflows/release.yml`
- `scripts/package-release.sh`
- `scripts/test-package-release.sh`

No Distro Apply, Distro.toml, musl selection, installer, version bump, tag,
release dispatch, secret, or live installation state changes. Historical
musl-metadata #119 remains on `main` and is not restacked here.

## Verification

- GPG: good signature from Joshua J. Bouw `<jjb@unicity-labs.com>`
- DCO: `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`
- `bash scripts/test-package-release.sh`
- `python3 scripts/validate-release-contract.py`
- `python3 scripts/test_validate_release_contract.py`
- `bash -n scripts/package-release.sh scripts/test-package-release.sh`
- `actionlint .github/workflows/release.yml`
- `shellcheck` of the touched shell scripts
- `git diff --check`

Regressions cover embedded exit-97 sealers, wrong source target/digest/version,
missing explicit sealer, pubkey mismatch, and package-test tar listing
consumption.

## Residuals and claim limits

- Product version remains 2026.1.3. GNU runtime identity remains Astrid 0.10.4.
- This PR does not publish a signed Distro or enable Distro Apply.
- Hosted stable sealing remains fail-closed on the current runtime pin.
- This PR does not close #117.

## AI / tool disclosure

Codex was used to reconstruct this change onto current `main`.
