### PR TITLE
fix(runtime): require stopped Astrid volume mode 0600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,8 @@
 
 ### Fixed
 
+- Require stopped AOS runtime homes to contain only a non-empty private `astrid.volume` (Unix mode `0600`).
+
 - Stable `github-release` signing discovers product archives by filename
   `unicity-aos-*.tar.gz` and refuses to publish when none are signed. The
   download-artifact pattern `aos-*-*-*` is unchanged because it names GitHub

--- a/crates/unicity-aos-bootstrap/src/status.rs
+++ b/crates/unicity-aos-bootstrap/src/status.rs
@@ -1,8 +1,12 @@
 //! Native AOS status over the runtime's typed local control operation.
 
+use std::ffi::OsStr;
 use std::fs::{self, OpenOptions};
 use std::io;
 use std::time::Duration;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 use astrid_core::PrincipalId;
 use astrid_core::kernel_api::{DaemonStatus, KernelRequest, KernelResponse};
@@ -106,7 +110,8 @@ pub async fn read_for_principal(
 /// lock.
 ///
 /// This is stricter than a missing socket: a shutdown is complete only after
-/// every transient marker is gone and the runtime lock can be acquired.
+/// every transient marker is gone, the runtime lock can be acquired, and any
+/// materialized runtime state is an exclusive private volume.
 pub fn confirm_stopped(home: &AosHome) -> Result<AosStatus, String> {
     let run_dir = home.runtime_home().join("run");
     for marker in ["system.sock", "system.pid", "system.ready", "system.token"] {
@@ -128,7 +133,10 @@ pub fn confirm_stopped(home: &AosHome) -> Result<AosStatus, String> {
     let lock_path = run_dir.join("system.lock");
     let lock_metadata = match fs::symlink_metadata(&lock_path) {
         Ok(metadata) => metadata,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return AosStatus::stopped(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            validate_stopped_runtime_layout(home)?;
+            return AosStatus::stopped();
+        }
         Err(error) => return Err(format!("could not inspect runtime lock: {error}")),
     };
     if lock_metadata.file_type().is_symlink() || !lock_metadata.is_file() {
@@ -141,6 +149,9 @@ pub fn confirm_stopped(home: &AosHome) -> Result<AosStatus, String> {
         .map_err(|error| format!("could not open runtime lock: {error}"))?;
     match lock.try_lock_exclusive() {
         Ok(()) => {
+            // Hold the singleton lock while inspecting the volume-only layout so
+            // a concurrent runtime cannot change the state between the checks.
+            validate_stopped_runtime_layout(home)?;
             FileExt::unlock(&lock)
                 .map_err(|error| format!("could not release runtime status lock: {error}"))?;
             AosStatus::stopped()
@@ -152,10 +163,72 @@ pub fn confirm_stopped(home: &AosHome) -> Result<AosStatus, String> {
     }
 }
 
+fn validate_stopped_runtime_layout(home: &AosHome) -> Result<(), String> {
+    let runtime = home.runtime_home();
+    let metadata = match fs::symlink_metadata(&runtime) {
+        Ok(metadata) => metadata,
+        // A fresh AOS home has no runtime state yet. Preserve its stopped
+        // projection until the first volume is materialized.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(format!("could not inspect runtime state: {error}")),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err("runtime state must be a real directory".to_owned());
+    }
+
+    let mut unexpected = Vec::new();
+    let mut volume_path = None;
+    for entry in fs::read_dir(&runtime)
+        .map_err(|error| format!("could not inspect stopped runtime state: {error}"))?
+    {
+        let entry =
+            entry.map_err(|error| format!("could not enumerate stopped runtime state: {error}"))?;
+        let name = entry.file_name();
+        if name == OsStr::new("astrid.volume") {
+            volume_path = Some(entry.path());
+        } else {
+            unexpected.push(name.to_string_lossy().into_owned());
+        }
+    }
+    if !unexpected.is_empty() {
+        unexpected.sort();
+        return Err(format!(
+            "stopped runtime contains unexpected state: {}",
+            unexpected.join(", ")
+        ));
+    }
+
+    let Some(volume_path) = volume_path else {
+        // An empty runtime directory is the other valid pre-first-volume state.
+        return Ok(());
+    };
+    let volume_metadata = fs::symlink_metadata(&volume_path)
+        .map_err(|error| format!("could not inspect astrid.volume: {error}"))?;
+    if volume_metadata.file_type().is_symlink() {
+        return Err("astrid.volume must not be a symlink".to_owned());
+    }
+    if !volume_metadata.is_file() {
+        return Err("astrid.volume must be a regular file".to_owned());
+    }
+    if volume_metadata.len() == 0 {
+        return Err("astrid.volume must not be empty".to_owned());
+    }
+    #[cfg(unix)]
+    {
+        let mode = volume_metadata.permissions().mode() & 0o7777;
+        if mode != 0o600 {
+            return Err(format!(
+                "astrid.volume must use private mode 0600 (found {mode:04o})"
+            ));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use astrid_core::kernel_api::DaemonStatus;
@@ -172,6 +245,22 @@ mod tests {
                 .expect("clock after epoch")
                 .as_nanos()
         ))
+    }
+
+    fn write_private_volume(runtime: &Path) -> PathBuf {
+        let volume = runtime.join("astrid.volume");
+        fs::write(&volume, b"volume-state").expect("create runtime volume");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+
+            let mut permissions = fs::metadata(&volume)
+                .expect("inspect runtime volume")
+                .permissions();
+            permissions.set_mode(0o600);
+            fs::set_permissions(&volume, permissions).expect("make runtime volume private");
+        }
+        volume
     }
 
     #[test]
@@ -211,11 +300,12 @@ mod tests {
     }
 
     #[test]
-    fn reports_a_typed_stopped_state_when_the_runtime_lock_is_available() {
+    fn reports_a_typed_stopped_state_for_an_exclusive_private_volume() {
         let root = temporary_status_home("stopped");
         let home = AosHome::from_root(&root);
-        fs::create_dir_all(home.runtime_home().join("run")).expect("create runtime run dir");
-        fs::write(home.runtime_home().join("run/system.lock"), []).expect("create runtime lock");
+        let runtime = home.runtime_home();
+        fs::create_dir_all(&runtime).expect("create runtime home");
+        write_private_volume(&runtime);
 
         let status = confirm_stopped(&home).expect("read stopped status");
         assert_eq!(status.state, "stopped");
@@ -223,6 +313,20 @@ mod tests {
         assert_eq!(status.runtime_version, "0.10.4");
 
         fs::remove_dir_all(root).expect("remove stopped status fixture");
+    }
+
+    #[test]
+    fn allows_a_missing_or_empty_runtime_before_the_first_volume() {
+        let missing_root = temporary_status_home("missing-runtime");
+        let missing_home = AosHome::from_root(&missing_root);
+        confirm_stopped(&missing_home).expect("missing runtime is stopped before first volume");
+        drop(fs::remove_dir_all(&missing_root));
+
+        let empty_root = temporary_status_home("empty-runtime");
+        let empty_home = AosHome::from_root(&empty_root);
+        fs::create_dir_all(empty_home.runtime_home()).expect("create empty runtime home");
+        confirm_stopped(&empty_home).expect("empty runtime is stopped before first volume");
+        fs::remove_dir_all(empty_root).expect("remove empty runtime fixture");
     }
 
     #[test]
@@ -246,5 +350,122 @@ mod tests {
 
         fs2::FileExt::unlock(&lock).expect("release runtime lock");
         fs::remove_dir_all(root).expect("remove running status fixture");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stopped_runtime_volume_must_use_private_0600_mode() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = temporary_status_home("volume-mode");
+        let home = AosHome::from_root(&root);
+        let runtime = home.runtime_home();
+        fs::create_dir_all(&runtime).expect("create runtime home");
+        let volume = write_private_volume(&runtime);
+        let mut permissions = fs::metadata(&volume)
+            .expect("inspect runtime volume")
+            .permissions();
+        permissions.set_mode(0o644);
+        fs::set_permissions(&volume, permissions).expect("make runtime volume world-readable");
+
+        let error = confirm_stopped(&home).expect_err("0644 volume must fail");
+        assert!(
+            error.contains("private"),
+            "mode error lacked private: {error}"
+        );
+        assert!(error.contains("0600"), "mode error lacked 0600: {error}");
+
+        fs::remove_dir_all(root).expect("remove volume mode fixture");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stopped_runtime_volume_must_reject_special_mode_bits() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = temporary_status_home("volume-special-mode");
+        let home = AosHome::from_root(&root);
+        let runtime = home.runtime_home();
+        fs::create_dir_all(&runtime).expect("create runtime home");
+        let volume = write_private_volume(&runtime);
+        let mut permissions = fs::metadata(&volume)
+            .expect("inspect runtime volume")
+            .permissions();
+        permissions.set_mode(0o1600);
+        fs::set_permissions(&volume, permissions).expect("set sticky private volume mode");
+
+        let error = confirm_stopped(&home).expect_err("sticky 0600 volume must fail");
+        assert!(
+            error.contains("private"),
+            "mode error lacked private: {error}"
+        );
+        assert!(error.contains("0600"), "mode error lacked 0600: {error}");
+        assert!(
+            error.contains("1600"),
+            "mode error lacked special bits: {error}"
+        );
+
+        fs::remove_dir_all(root).expect("remove special mode fixture");
+    }
+
+    #[test]
+    fn stopped_runtime_volume_must_not_be_empty() {
+        let root = temporary_status_home("volume-empty");
+        let home = AosHome::from_root(&root);
+        let runtime = home.runtime_home();
+        fs::create_dir_all(&runtime).expect("create runtime home");
+        fs::write(runtime.join("astrid.volume"), []).expect("create empty volume");
+
+        let error = confirm_stopped(&home).expect_err("empty volume must fail");
+        assert!(error.contains("astrid.volume must not be empty"));
+
+        fs::remove_dir_all(root).expect("remove empty volume fixture");
+    }
+
+    #[test]
+    fn stopped_runtime_volume_must_be_a_regular_file() {
+        let root = temporary_status_home("volume-directory");
+        let home = AosHome::from_root(&root);
+        let runtime = home.runtime_home();
+        fs::create_dir_all(runtime.join("astrid.volume")).expect("create volume directory");
+
+        let error = confirm_stopped(&home).expect_err("volume directory must fail");
+        assert!(error.contains("astrid.volume must be a regular file"));
+
+        fs::remove_dir_all(root).expect("remove volume directory fixture");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stopped_runtime_volume_must_not_be_a_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let root = temporary_status_home("volume-symlink");
+        let home = AosHome::from_root(&root);
+        let runtime = home.runtime_home();
+        fs::create_dir_all(&runtime).expect("create runtime home");
+        let target = root.join("volume-target");
+        fs::write(&target, b"volume-state").expect("create volume target");
+        symlink(&target, runtime.join("astrid.volume")).expect("create volume symlink");
+
+        let error = confirm_stopped(&home).expect_err("volume symlink must fail");
+        assert!(error.contains("astrid.volume must not be a symlink"));
+
+        fs::remove_dir_all(root).expect("remove volume symlink fixture");
+    }
+
+    #[test]
+    fn stopped_runtime_must_contain_only_the_volume() {
+        let root = temporary_status_home("stopped-layout");
+        let home = AosHome::from_root(&root);
+        let runtime = home.runtime_home();
+        fs::create_dir_all(&runtime).expect("create runtime home");
+        write_private_volume(&runtime);
+        fs::create_dir_all(runtime.join("run")).expect("create residual run directory");
+
+        let error = confirm_stopped(&home).expect_err("residual runtime state must fail");
+        assert!(error.contains("unexpected state: run"));
+
+        fs::remove_dir_all(root).expect("remove layout fixture");
     }
 }

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -342,9 +342,21 @@ exit 1
         .expect("create runtime run directory");
     fs::write(&ready_marker, []).expect("create runtime ready marker");
     let marker_to_remove = ready_marker.clone();
+    let run_dir = fixture.home.join("runtime/run");
+    let volume = fixture.home.join("runtime/astrid.volume");
     let shutdown = std::thread::spawn(move || {
         std::thread::sleep(Duration::from_millis(200));
+
+        // The runtime must finish materializing its private volume before the
+        // readiness marker is removed, so AOS cannot report a partial stop.
+        fs::write(&volume, b"volume-state").expect("create private runtime volume");
+        let mut permissions = fs::metadata(&volume)
+            .expect("inspect private runtime volume")
+            .permissions();
+        permissions.set_mode(0o600);
+        fs::set_permissions(&volume, permissions).expect("make runtime volume private");
         fs::remove_file(marker_to_remove).expect("remove runtime ready marker");
+        fs::remove_dir_all(run_dir).expect("remove runtime run directory");
     });
 
     let output = fixture
@@ -360,6 +372,24 @@ exit 1
         "<--future-runtime-global>\n<future-value>\n<stop>\n"
     );
     assert!(!ready_marker.exists());
+    let runtime = fixture.home.join("runtime");
+    let entries: Vec<_> = fs::read_dir(&runtime)
+        .expect("read stopped runtime state")
+        .map(|entry| {
+            entry
+                .expect("read stopped runtime entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    assert_eq!(entries, vec!["astrid.volume"]);
+    let volume = runtime.join("astrid.volume");
+    let metadata = fs::symlink_metadata(&volume).expect("inspect stopped runtime volume");
+    assert!(metadata.is_file());
+    assert!(!metadata.file_type().is_symlink());
+    assert!(metadata.len() > 0);
+    assert_eq!(metadata.permissions().mode() & 0o7777, 0o600);
     assert!(output.stderr.is_empty());
     assert_eq!(
         String::from_utf8(output.stdout).expect("utf8 stop output"),


### PR DESCRIPTION
## Summary

Require a stopped AOS runtime home to be volume-only: exclusive nonempty
regular `astrid.volume` with Unix mode `0600`, including special bits
(`mode & 07777`). Leftover `runtime/run` and other sidecars, plus empty,
directory, symlink, world-readable, or setuid/setgid/sticky volumes, are
not a stopped runtime.

A missing or empty runtime directory remains stopped before the first
volume is materialized. Existing lock and coordination-marker fail-closed
behavior is unchanged.

Restacked onto landed main after #124.

## Changes

- `confirm_stopped` validates exclusive private volume layout after markers
  are gone and the singleton lock can be acquired
- reject leftover `run/`, empty/`0644`/special-bit/directory/symlink volumes
- preserve pre-first-volume missing/empty runtime as stopped
- update the inherited-stop CLI fixture so post-stop state is one private
  volume and no leftover `runtime/run`

## Exact head

- Base: `a00a868b3f0b56c6e4cacaae0ecf459fcda901fc`
- Head: `7c7a6a0efb7586655b5842398913d82f62212a44`
- Unique commit: `fix(status): require a private volume-only stopped runtime`

## Scope

- `CHANGELOG.md`
- `crates/unicity-aos-bootstrap/src/status.rs`
- `crates/unicity-aos-bootstrap/tests/cli_boundary.rs`

No Distro Apply, runtime pin, installer/harness, `runtime/bin` allowlist,
`ASTRID_RUN_DIR`, `package-release.sh`, `release.yml`, version bump, or live
installation state changes.

## Verification

- GPG: good signature from Joshua J. Bouw `<jjb@unicity-labs.com>`
- DCO: `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`
- `cargo fmt --all -- --check`
- `cargo clippy -p unicity-aos-bootstrap --locked --all-targets -- -D warnings`
- `cargo test --locked -p unicity-aos-bootstrap` (MCP newline-frame test
  flaked once under parallel load, passed on isolated suite rerun; unrelated
  to this volume-layout change)

## Residuals and claim limits

- Product version remains 2026.9.0.
- Packaged runtime pin remains Astrid 0.10.4 / `b6bf5d1d`.
- This does not implement Distro Apply, schema-v2, run-root override, capsule
  sealing, or a newer runtime pin.
- This PR does not reopen or land closed #117.

## AI / tool disclosure

Codex was used to restack this change onto current `main` and to tighten the
Unix mode comparison to include special bits.
