### PR TITLE
fix(release): require all 22 capsule artifacts

### DIFF
--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -15,6 +15,34 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from capsule_release import ContractError, CapsuleSpec, source_contract, validate_artifacts
 
 
+EXPECTED_CAPSULE_ASSETS = frozenset(
+    {
+        "aos-cli.capsule",
+        "aos-mcp.capsule",
+        "aos-registry.capsule",
+        "aos-openai-compat.capsule",
+        "aos-react.capsule",
+        "aos-session.capsule",
+        "aos-identity.capsule",
+        "aos-users.capsule",
+        "aos-router.capsule",
+        "aos-prompt-builder.capsule",
+        "aos-context-engine.capsule",
+        "aos-hook-bridge.capsule",
+        "aos-hook-adapter-oracle.capsule",
+        "aos-meta-harness.capsule",
+        "aos-shell.capsule",
+        "aos-http.capsule",
+        "aos-fs.capsule",
+        "aos-system.capsule",
+        "aos-forge.capsule",
+        "aos-skills.capsule",
+        "aos-agents.capsule",
+        "aos-memory.capsule",
+    }
+)
+
+
 def add_bytes(
     archive: tarfile.TarFile,
     name: str,
@@ -88,14 +116,13 @@ class CapsuleReleaseTests(unittest.TestCase):
         self.assertEqual(len(self.specs), 22)
         self.assertEqual(len({spec.asset for spec in self.specs}), 22)
         assets = {spec.asset for spec in self.specs}
-        self.assertIn("aos-forge.capsule", assets)
-        self.assertNotIn("aos-telegram.capsule", assets)
+        self.assertEqual(assets, EXPECTED_CAPSULE_ASSETS)
         distro = Path(__file__).resolve().parent.parent / "distros/community/unicity-ce/Distro.toml"
         text = distro.read_text(encoding="utf-8")
         self.assertNotIn("@unicity-aos/", text)
         self.assertEqual(text.count('source = "capsules/'), 22)
-        for spec in self.specs:
-            self.assertIn(f'source = "capsules/{spec.asset}"', text)
+        for asset in EXPECTED_CAPSULE_ASSETS:
+            self.assertIn(f'source = "capsules/{asset}"', text)
 
     def test_accepts_exact_safe_artifact_set(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -21,6 +21,32 @@ import release_publication
 
 VERSION = "2026.9.0"
 SOURCE_COMMIT = "a" * 40
+EXPECTED_CAPSULE_ASSETS = frozenset(
+    {
+        "aos-cli.capsule",
+        "aos-mcp.capsule",
+        "aos-registry.capsule",
+        "aos-openai-compat.capsule",
+        "aos-react.capsule",
+        "aos-session.capsule",
+        "aos-identity.capsule",
+        "aos-users.capsule",
+        "aos-router.capsule",
+        "aos-prompt-builder.capsule",
+        "aos-context-engine.capsule",
+        "aos-hook-bridge.capsule",
+        "aos-hook-adapter-oracle.capsule",
+        "aos-meta-harness.capsule",
+        "aos-shell.capsule",
+        "aos-http.capsule",
+        "aos-fs.capsule",
+        "aos-system.capsule",
+        "aos-forge.capsule",
+        "aos-skills.capsule",
+        "aos-agents.capsule",
+        "aos-memory.capsule",
+    }
+)
 
 
 def add_file(archive: tarfile.TarFile, name: str, value: bytes) -> None:
@@ -113,7 +139,31 @@ class ReleasePublicationTests(unittest.TestCase):
             artifacts, compatibility = self.fixture(Path(temp))
             payloads = self.validate(artifacts, compatibility)
             self.assertIn(f"unicity-aos-{VERSION}-release.toml", payloads)
-            self.assertEqual(len([name for name in payloads if name.endswith(".capsule")]), 22)
+            capsules = {name for name in payloads if name.endswith(".capsule")}
+            self.assertEqual(capsules, EXPECTED_CAPSULE_ASSETS)
+            self.assertTrue(
+                {
+                    "aos-mcp.capsule",
+                    "aos-hook-adapter-oracle.capsule",
+                    "aos-meta-harness.capsule",
+                }
+                <= capsules
+            )
+
+    def test_rejects_missing_named_capsule_or_bundle(self) -> None:
+        for asset in EXPECTED_CAPSULE_ASSETS:
+            with self.subTest(asset=asset):
+                with tempfile.TemporaryDirectory() as temp:
+                    artifacts, compatibility = self.fixture(Path(temp))
+                    (artifacts / asset).unlink()
+                    with self.assertRaisesRegex(ValueError, "asset set differs"):
+                        self.validate(artifacts, compatibility)
+
+                with tempfile.TemporaryDirectory() as temp:
+                    artifacts, compatibility = self.fixture(Path(temp))
+                    (artifacts / f"{asset}.sigstore.json").unlink()
+                    with self.assertRaisesRegex(ValueError, "asset set differs"):
+                        self.validate(artifacts, compatibility)
 
     def test_rejects_missing_asset(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary

Make the release contract require the complete 22-capsule Community Edition set, including `aos-mcp`, `aos-hook-adapter-oracle`, and `aos-meta-harness`.

## Changes

- assert the exact 22-capsule set against the source contract and Distro
- assert the exact set in the publication payload
- add mutation coverage proving every missing capsule or Sigstore bundle fails closed

## Exact head

- Base: `341d90443ca1871ed01ec5116851d706e6db336b`
- Head: `c2bb9f97338a3ea196e8a5b694429a1dd782498e`
- Tree: `b1bd0fe6d5ac4820aa4e19bc38b6d9d40288d5f0`

## Verification

- `python3 scripts/test_capsule_release.py` — 16/16 pass
- `python3 scripts/test_release_publication.py` — 7/7 pass
- `git diff --check`
- GPG signature and DCO verified

## Scope

Tests only. No capsule bytes, Distro contents, runtime packaging, version metadata, workflow, tag, publication, or live installation changes.

## AI / tool disclosure

Codex was used to implement and verify this test-only release guard.