### PR TITLE
fix(install): launch Astrid from immutable release runtime/bin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@
   validation when a runtime update adds or removes a verb before AOS classifies
   it as inherited, product-owned, or shared. Runtime verbs remain direct
   `aos <verb>` commands without a nested runtime namespace.
+- Launch bundled Astrid executables from the immutable versioned release
+  runtime/bin, keep `ASTRID_HOME` at the durable runtime home, and bind
+  `ASTRID_RUN_DIR` to the AOS-owned run root without copying shipped binaries
+  into mutable runtime state.
 
 - Keep agent Skills out of `Capsule.toml` and the generic capsule release
   contract. Host plugins may vendor trigger Skills, the AOS Skills service

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -1,9 +1,10 @@
 //! Product-owned runtime layout and launcher for Unicity AOS.
 //!
 //! Astrid Runtime keeps its standalone `ASTRID_HOME` and `.astrid` compatibility
-//! contract. AOS instead owns `~/.aos` and passes a private runtime home
-//! to the bundled runtime process only; it never changes the caller's process
-//! environment or rewrites a standalone runtime installation.
+//! contract. AOS instead owns `~/.aos`, executes the bundled runtime from the
+//! exact product-versioned release tree, and passes a private runtime home to
+//! the child process only. It never changes the caller's process environment
+//! or rewrites a standalone runtime installation.
 
 use std::ffi::{OsStr, OsString};
 use std::fs;
@@ -108,6 +109,24 @@ impl AosHome {
         self.root.join("runtime")
     }
 
+    /// The transient AOS process-coordination root reserved for the runtime.
+    #[must_use]
+    pub fn run_root(&self) -> PathBuf {
+        self.root.join("run")
+    }
+
+    /// The immutable assets installed for this exact AOS product version.
+    #[must_use]
+    pub fn release_dir(&self) -> PathBuf {
+        self.root.join("releases").join(PRODUCT_VERSION)
+    }
+
+    /// The release-owned directory containing the bundled Astrid executables.
+    #[must_use]
+    pub fn release_runtime_bin_dir(&self) -> PathBuf {
+        self.release_dir().join("runtime").join("bin")
+    }
+
     /// The receipt written only after a successful standalone-runtime import.
     #[must_use]
     pub fn migration_receipt(&self) -> PathBuf {
@@ -141,11 +160,7 @@ impl AosHome {
         let configured = get("UNICITY_AOS_CAPSULE_DIR");
         let path = match configured {
             Some(path) => Self::validated_environment_root(path, "UNICITY_AOS_CAPSULE_DIR")?,
-            None => self
-                .root
-                .join("releases")
-                .join(PRODUCT_VERSION)
-                .join("capsules"),
+            None => self.release_dir().join("capsules"),
         };
         validate_capsule_dir(&path, &capsule_assets_from_manifest()?)
     }
@@ -259,7 +274,7 @@ impl AosHome {
         {
             return path;
         }
-        self.runtime_home().join("bin").join(runtime_binary_name())
+        self.release_runtime_bin_dir().join(runtime_binary_name())
     }
 
     /// Import a standalone Astrid Runtime home into this product installation.
@@ -283,7 +298,7 @@ impl AosHome {
         migration::imported_legacy_distros(self)
     }
 
-    /// Create the product and bundled-runtime state directories.
+    /// Create the mutable product and bundled-runtime state directories.
     ///
     /// This intentionally creates neither a standalone Astrid home nor a
     /// project `.astrid` directory.
@@ -292,8 +307,7 @@ impl AosHome {
     /// Returns an error when the directories cannot be created.
     pub fn ensure_layout(&self) -> io::Result<()> {
         create_private_dir(&self.root)?;
-        create_private_dir(&self.runtime_home())?;
-        create_private_dir(&self.runtime_home().join("bin"))
+        create_private_dir(&self.runtime_home())
     }
 
     /// Build a command for the bundled runtime with a process-local home.
@@ -302,7 +316,7 @@ impl AosHome {
     /// therefore can bundle the neutral runtime without changing the host
     /// shell, another AOS install, or a standalone Astrid Runtime installation.
     /// # Errors
-    /// Returns an error when the private runtime bin or inherited host PATH
+    /// Returns an error when the release runtime bin or inherited host PATH
     /// cannot be represented safely as a child PATH.
     pub fn runtime_command(&self) -> io::Result<Command> {
         self.runtime_command_with_args(std::iter::empty::<&OsStr>())
@@ -314,7 +328,7 @@ impl AosHome {
     /// argument boundaries and leaves the runtime in charge of its established
     /// local socket, credentials, and operator protocol.
     /// # Errors
-    /// Returns an error when the private runtime bin or inherited host PATH
+    /// Returns an error when the release runtime bin or inherited host PATH
     /// cannot be represented safely as a child PATH.
     pub fn runtime_command_with_args<I, S>(&self, args: I) -> io::Result<Command>
     where
@@ -330,20 +344,30 @@ impl AosHome {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        let runtime_bin = executable.parent().ok_or_else(|| {
+        let executable_parent = executable.parent().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "bundled executable must have a parent directory",
             )
         })?;
+        // An explicit absolute package override points at a complete runtime
+        // bundle, so keep its sibling tools ahead of the host PATH as well.
+        let path_prefix = match std::env::var_os("UNICITY_AOS_RUNTIME_BIN").map(PathBuf::from) {
+            Some(path) if path.is_absolute() => path
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| executable_parent.to_path_buf()),
+            _ => self.release_runtime_bin_dir(),
+        };
         let mut command = Command::new(executable);
         command
             .env("ASTRID_HOME", self.runtime_home())
             .env("ASTRID_WORKSPACE_STATE_DIR", AOS_WORKSPACE_STATE_DIR)
             .env("ASTRID_ENFORCED_DISTRO", self.unicity_ce_manifest_path())
+            .env("ASTRID_RUN_DIR", self.run_root())
             .env(
                 "PATH",
-                Self::runtime_child_path(runtime_bin, std::env::var_os("PATH"))?,
+                Self::runtime_child_path(&path_prefix, std::env::var_os("PATH"))?,
             );
         command.args(args);
         Ok(command)
@@ -808,23 +832,59 @@ mod tests {
     }
 
     #[test]
-    fn runtime_is_scoped_beneath_the_product_home() {
+    fn runtime_executes_from_the_exact_product_release() {
         let home = AosHome::from_root("/tmp/unicity-aos-test");
         assert_eq!(home.root(), PathBuf::from("/tmp/unicity-aos-test"));
         assert_eq!(
             home.runtime_home(),
             PathBuf::from("/tmp/unicity-aos-test/runtime")
         );
+        assert_eq!(home.run_root(), PathBuf::from("/tmp/unicity-aos-test/run"));
+        assert_ne!(home.run_root(), home.runtime_home());
+        assert!(!home.run_root().starts_with(home.runtime_home()));
+        assert!(!home.runtime_home().starts_with(home.run_root()));
+        assert_eq!(
+            home.release_dir(),
+            PathBuf::from(format!(
+                "/tmp/unicity-aos-test/releases/{}",
+                env!("CARGO_PKG_VERSION")
+            ))
+        );
         assert_eq!(
             home.runtime_binary(),
-            home.runtime_home().join("bin").join(runtime_binary_name())
+            home.release_runtime_bin_dir().join(runtime_binary_name())
         );
         assert_eq!(
             home.runtime_daemon_binary(),
-            home.runtime_home()
-                .join("bin")
+            home.release_runtime_bin_dir()
                 .join(runtime_daemon_binary_name())
         );
+    }
+
+    #[test]
+    fn mutable_runtime_copy_cannot_substitute_for_a_missing_release_binary() {
+        let fixture = temporary_home();
+        let home = AosHome::from_root(&fixture);
+        let mutable_binary = home.runtime_home().join("bin").join(runtime_binary_name());
+        fs::create_dir_all(mutable_binary.parent().expect("mutable binary parent"))
+            .expect("create mutable runtime bin");
+        fs::write(&mutable_binary, b"mutable compatibility copy")
+            .expect("write mutable compatibility copy");
+
+        let error = home
+            .ensure_runtime_available()
+            .expect_err("mutable compatibility copy must not satisfy release lookup");
+
+        assert_eq!(error.kind(), ErrorKind::NotFound);
+        assert!(
+            error.to_string().contains(
+                home.release_runtime_bin_dir()
+                    .join(runtime_binary_name())
+                    .to_string_lossy()
+                    .as_ref()
+            )
+        );
+        fs::remove_dir_all(fixture).expect("remove mutable runtime fixture");
     }
 
     #[test]
@@ -832,7 +892,7 @@ mod tests {
         let home = AosHome::from_root("/tmp/unicity-aos-test");
         assert_eq!(
             home.runtime_binary_with(|_| Some(OsString::from("runtime/astrid"))),
-            home.runtime_home().join("bin").join(runtime_binary_name())
+            home.release_runtime_bin_dir().join(runtime_binary_name())
         );
         assert_eq!(
             home.runtime_binary_with(|_| Some(OsString::from("/opt/aos/runtime/bin/astrid"))),
@@ -855,10 +915,14 @@ mod tests {
 
         assert_eq!(env_value("ASTRID_HOME"), "/tmp/unicity-aos-test/runtime");
         assert_eq!(env_value("ASTRID_WORKSPACE_STATE_DIR"), ".aos");
+        assert_eq!(env_value("ASTRID_RUN_DIR"), "/tmp/unicity-aos-test/run");
         let path_entries: Vec<_> = std::env::split_paths(env_value("PATH")).collect();
         assert_eq!(
             path_entries.first(),
-            Some(&PathBuf::from("/tmp/unicity-aos-test/runtime/bin"))
+            Some(&PathBuf::from(format!(
+                "/tmp/unicity-aos-test/releases/{}/runtime/bin",
+                env!("CARGO_PKG_VERSION")
+            )))
         );
         assert_eq!(std::env::var_os("PATH"), caller_path);
     }
@@ -896,7 +960,7 @@ mod tests {
         let fixture = temporary_home();
         let home = AosHome::from_root(&fixture);
         install_capsule_fixtures(home.root());
-        let runtime_bin = home.runtime_home().join("bin");
+        let runtime_bin = home.release_runtime_bin_dir();
         fs::create_dir_all(&runtime_bin).expect("create runtime bin");
         fs::write(home.runtime_daemon_binary(), b"daemon").expect("write daemon fixture");
         #[cfg(unix)]
@@ -932,6 +996,7 @@ mod tests {
         };
         assert_eq!(env_value("ASTRID_HOME"), home.runtime_home());
         assert_eq!(env_value("ASTRID_WORKSPACE_STATE_DIR"), ".aos");
+        assert_eq!(env_value("ASTRID_RUN_DIR"), home.run_root());
         assert_eq!(env_value("ASTRID_DAEMON_LOG_TARGET"), "stderr");
         assert_eq!(
             env_value("ASTRID_ENFORCED_DISTRO"),
@@ -946,7 +1011,7 @@ mod tests {
         let fixture = temporary_home();
         let home = AosHome::from_root(&fixture);
         install_capsule_fixtures(home.root());
-        let runtime_bin = home.runtime_home().join("bin");
+        let runtime_bin = home.release_runtime_bin_dir();
         fs::create_dir_all(&runtime_bin).expect("create runtime bin");
         fs::write(home.runtime_daemon_binary(), b"daemon").expect("write daemon fixture");
 
@@ -1009,13 +1074,16 @@ mod tests {
         let home = AosHome::from_root("/tmp/unicity-aos-test");
         let host_entries = [PathBuf::from("/usr/local/bin"), PathBuf::from("/usr/bin")];
         let host_path = std::env::join_paths(&host_entries).expect("build host PATH");
-        let runtime_bin = home.runtime_home().join("bin");
+        let runtime_bin = home.release_runtime_bin_dir();
         let child_path =
             AosHome::runtime_child_path(&runtime_bin, Some(host_path)).expect("build child PATH");
         assert_eq!(
             std::env::split_paths(&child_path).collect::<Vec<_>>(),
             [
-                PathBuf::from("/tmp/unicity-aos-test/runtime/bin"),
+                PathBuf::from(format!(
+                    "/tmp/unicity-aos-test/releases/{}/runtime/bin",
+                    env!("CARGO_PKG_VERSION")
+                )),
                 PathBuf::from("/usr/local/bin"),
                 PathBuf::from("/usr/bin"),
             ]
@@ -1025,7 +1093,10 @@ mod tests {
             AosHome::runtime_child_path(&runtime_bin, None).expect("build private-only child PATH");
         assert_eq!(
             std::env::split_paths(&child_path).collect::<Vec<_>>(),
-            [PathBuf::from("/tmp/unicity-aos-test/runtime/bin")]
+            [PathBuf::from(format!(
+                "/tmp/unicity-aos-test/releases/{}/runtime/bin",
+                env!("CARGO_PKG_VERSION")
+            ))]
         );
     }
 
@@ -1084,7 +1155,6 @@ mod tests {
         for directory in [
             &root,
             &home.runtime_home(),
-            &home.runtime_home().join("bin"),
             &root.join("distributions"),
             &root.join("distributions/unicity-ce"),
         ] {

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -920,6 +920,7 @@ fn set_runtime_environment(home: &AosHome) {
     unsafe {
         std::env::set_var("ASTRID_HOME", home.runtime_home());
         std::env::set_var("ASTRID_WORKSPACE_STATE_DIR", AOS_WORKSPACE_STATE_DIR);
+        std::env::set_var("ASTRID_RUN_DIR", home.run_root());
     }
 }
 fn offer_first_run_migration() -> Option<ExitCode> {

--- a/crates/unicity-aos-bootstrap/src/migration.rs
+++ b/crates/unicity-aos-bootstrap/src/migration.rs
@@ -225,6 +225,7 @@ impl MigrationLock {
 pub(crate) fn migrate_runtime(home: &AosHome, source: &Path) -> io::Result<MigrationOutcome> {
     let source = checked_root(source, "legacy runtime home")?;
     let target = checked_target_path(&home.runtime_home())?;
+    let release_runtime_bin = home.release_runtime_bin_dir();
     if source == target || source.starts_with(&target) || target.starts_with(&source) {
         return invalid("legacy runtime home and product runtime home must not overlap");
     }
@@ -238,14 +239,14 @@ pub(crate) fn migrate_runtime(home: &AosHome, source: &Path) -> io::Result<Migra
     if receipt_path.is_file() {
         let receipt: Receipt = read_receipt(&receipt_path)?;
         if receipt.source == source {
-            validate_completed_target(&target, &receipt)?;
+            validate_completed_target(&target, &release_runtime_bin, &receipt)?;
             remove_backup(&target_backup(&target))?;
             return Ok(MigrationOutcome::AlreadyMigrated);
         }
         return invalid("an existing migration receipt belongs to a different source");
     }
 
-    validate_target(&target)?;
+    validate_target(&target, &release_runtime_bin)?;
     validate_source_layout(&source)?;
     let staging = home.root().join(STAGING_DIR);
     if staging.exists() {
@@ -256,7 +257,7 @@ pub(crate) fn migrate_runtime(home: &AosHome, source: &Path) -> io::Result<Migra
 
     let result = (|| {
         create_private_dir(&staging)?;
-        let mut entries = copy_product_binaries(&target, &staging)?;
+        let mut entries = Vec::new();
         copy_etc_state(&source, &staging, &mut entries)?;
         for name in PERSISTENT_TOP_LEVEL {
             copy_if_present(
@@ -610,7 +611,8 @@ fn checked_root(path: &Path, description: &str) -> io::Result<PathBuf> {
     path.canonicalize()
 }
 
-fn validate_target(target: &Path) -> io::Result<()> {
+fn validate_target(target: &Path, release_runtime_bin: &Path) -> io::Result<()> {
+    validate_release_runtime_bin(release_runtime_bin)?;
     let target_metadata = fs::symlink_metadata(target).map_err(|_| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -621,36 +623,19 @@ fn validate_target(target: &Path) -> io::Result<()> {
         return invalid("bundled product runtime must be a real directory");
     }
     let bin = target.join("bin");
-    let bin_metadata = fs::symlink_metadata(&bin).map_err(|_| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "bundled product runtime executable set is not installed",
-        )
-    })?;
-    if bin_metadata.file_type().is_symlink() || !bin_metadata.is_dir() {
-        return invalid("bundled product runtime bin must be a real directory");
-    }
-    let expected: HashSet<_> = RUNTIME_EXECUTABLE_NAMES.iter().copied().collect();
-    let mut actual = HashSet::new();
-    for entry in fs::read_dir(&bin)? {
-        let entry = entry?;
-        let name = entry.file_name().into_string().map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "product runtime bin contains a non-UTF-8 entry",
-            )
-        })?;
-        let metadata = fs::symlink_metadata(entry.path())?;
-        if !expected.contains(name.as_str())
-            || metadata.file_type().is_symlink()
-            || !metadata.is_file()
-            || !actual.insert(name)
-        {
-            return invalid("product runtime home contains data; migration refuses to merge state");
+    match fs::symlink_metadata(&bin) {
+        Ok(bin_metadata) => {
+            if bin_metadata.file_type().is_symlink() || !bin_metadata.is_dir() {
+                return invalid("bundled product runtime bin must be a real directory");
+            }
+            if fs::read_dir(&bin)?.next().transpose()?.is_some() {
+                return invalid(
+                    "product runtime home contains data; migration refuses to merge state",
+                );
+            }
         }
-    }
-    if actual.len() != expected.len() {
-        return invalid("bundled product runtime executable set is incomplete");
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
     }
     for entry in fs::read_dir(target)? {
         let entry = entry?;
@@ -663,7 +648,12 @@ fn validate_target(target: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn validate_completed_target(target: &Path, receipt: &Receipt) -> io::Result<()> {
+fn validate_completed_target(
+    target: &Path,
+    release_runtime_bin: &Path,
+    _receipt: &Receipt,
+) -> io::Result<()> {
+    validate_release_runtime_bin(release_runtime_bin)?;
     let target_metadata = fs::symlink_metadata(target).map_err(|_| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -674,29 +664,65 @@ fn validate_completed_target(target: &Path, receipt: &Receipt) -> io::Result<()>
         return invalid("completed product runtime must be a real directory");
     }
     let bin = target.join("bin");
-    let bin_metadata = fs::symlink_metadata(&bin).map_err(|_| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "completed product runtime executable set is not installed",
-        )
-    })?;
-    if bin_metadata.file_type().is_symlink() || !bin_metadata.is_dir() {
-        return invalid("completed product runtime bin must be a real directory");
-    }
-    for name in RUNTIME_EXECUTABLE_NAMES {
-        let relative = PathBuf::from("bin").join(name);
-        if !receipt.entries.iter().any(|entry| entry.path == relative) {
-            return invalid("migration receipt omits a bundled runtime executable");
+    match fs::symlink_metadata(&bin) {
+        Ok(bin_metadata) => {
+            if bin_metadata.file_type().is_symlink() || !bin_metadata.is_dir() {
+                return invalid("completed product runtime bin must be a real directory");
+            }
+            for entry in fs::read_dir(&bin)? {
+                let entry = entry?;
+                let name = entry.file_name();
+                if RUNTIME_EXECUTABLE_NAMES
+                    .iter()
+                    .any(|runtime| name == OsStr::new(runtime))
+                {
+                    return invalid(
+                        "completed product runtime contains a shipped executable in mutable state",
+                    );
+                }
+            }
         }
-        let metadata = fs::symlink_metadata(bin.join(name)).map_err(|_| {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    Ok(())
+}
+
+fn validate_release_runtime_bin(release_runtime_bin: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(release_runtime_bin).map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "completed product runtime executable set is incomplete",
+                "bundled product release runtime executable set is not installed",
+            )
+        } else {
+            error
+        }
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return invalid("bundled product release runtime bin must be a real directory");
+    }
+    let expected: HashSet<_> = RUNTIME_EXECUTABLE_NAMES.iter().copied().collect();
+    let mut actual = HashSet::new();
+    for entry in fs::read_dir(release_runtime_bin)? {
+        let entry = entry?;
+        let name = entry.file_name().into_string().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "product release runtime bin contains a non-UTF-8 entry",
             )
         })?;
-        if metadata.file_type().is_symlink() || !metadata.is_file() {
-            return invalid("completed product runtime executable must be a regular file");
+        let metadata = fs::symlink_metadata(entry.path())?;
+        if !expected.contains(name.as_str())
+            || metadata.file_type().is_symlink()
+            || !metadata.is_file()
+            || !actual.insert(name)
+        {
+            return invalid("product release runtime contains unexpected data");
         }
+    }
+    if actual.len() != expected.len() {
+        return invalid("bundled product release runtime executable set is incomplete");
     }
     Ok(())
 }
@@ -751,18 +777,6 @@ fn copy_etc_state(source_root: &Path, staging: &Path, entries: &mut Vec<Entry>) 
         copy_tree(&entry.path(), &staging.join(&relative), &relative, entries)?;
     }
     Ok(())
-}
-
-fn copy_product_binaries(target: &Path, staging: &Path) -> io::Result<Vec<Entry>> {
-    RUNTIME_EXECUTABLE_NAMES
-        .iter()
-        .map(|name| {
-            let source = target.join("bin").join(name);
-            let relative = PathBuf::from("bin").join(name);
-            let destination = staging.join(&relative);
-            copy_executable(&source, &destination, &relative)
-        })
-        .collect()
 }
 
 fn copy_if_present(
@@ -900,25 +914,6 @@ fn set_private_copied_file_permissions(path: &Path, source: &fs::Metadata) -> io
 #[cfg(not(unix))]
 fn set_private_copied_file_permissions(_path: &Path, _source: &fs::Metadata) -> io::Result<()> {
     Ok(())
-}
-
-fn copy_executable(source: &Path, destination: &Path, relative: &Path) -> io::Result<Entry> {
-    let metadata = fs::symlink_metadata(source)?;
-    if metadata.file_type().is_symlink() || !metadata.is_file() {
-        return invalid("bundled runtime executable must be a regular file");
-    }
-    if let Some(parent) = destination.parent() {
-        create_private_dir(parent)?;
-    }
-    let bytes = fs::copy(source, destination)?;
-    fs::set_permissions(destination, metadata.permissions())?;
-    File::open(destination)?.sync_all()?;
-    sync_parent(destination)?;
-    Ok(Entry {
-        path: relative.to_path_buf(),
-        bytes,
-        digest: blake3_file(destination)?,
-    })
 }
 
 fn replace_target(target: &Path, staging: &Path) -> io::Result<PathBuf> {
@@ -1213,17 +1208,20 @@ mod tests {
     }
 
     fn install_product_runtime(product: &AosHome) {
-        install_runtime_at(&product.runtime_home());
+        fs::create_dir_all(product.runtime_home()).expect("create product runtime home");
+        install_runtime_at(&product.release_runtime_bin_dir());
     }
 
-    fn install_runtime_at(runtime: &Path) {
+    fn install_runtime_at(runtime_bin: &Path) {
         for name in crate::RUNTIME_EXECUTABLE_NAMES {
-            let relative = format!("bin/{name}");
-            write(runtime, &relative, format!("bundled-{name}").as_bytes());
+            fs::create_dir_all(runtime_bin).expect("create bundled release runtime bin");
+            let path = runtime_bin.join(name);
+            fs::write(&path, format!("bundled-{name}").as_bytes())
+                .expect("write bundled executable");
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                fs::set_permissions(runtime.join(relative), fs::Permissions::from_mode(0o755))
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
                     .expect("make bundled executable executable");
             }
         }
@@ -1398,16 +1396,13 @@ mod tests {
             fs::read(runtime.join("config.toml")).unwrap(),
             b"[security]\nstrict = true\n"
         );
-        assert_eq!(
-            fs::read(runtime.join("bin/astrid")).unwrap(),
-            b"bundled-astrid"
-        );
         for name in crate::RUNTIME_EXECUTABLE_NAMES {
             assert_eq!(
-                fs::read(runtime.join("bin").join(name)).unwrap(),
+                fs::read(product.release_runtime_bin_dir().join(name)).unwrap(),
                 format!("bundled-{name}").as_bytes(),
-                "the supported product installer executable set must survive migration"
+                "the immutable product executable set must survive migration"
             );
+            assert!(!runtime.join("bin").join(name).exists());
         }
         assert!(!runtime.join("run").exists());
         assert_eq!(fs::read(runtime.join("log/daemon.log")).unwrap(), b"log");
@@ -1857,7 +1852,7 @@ mod tests {
             );
         }
         for name in crate::RUNTIME_EXECUTABLE_NAMES {
-            let path = runtime.join("bin").join(name);
+            let path = product.release_runtime_bin_dir().join(name);
             assert_eq!(
                 fs::read(&path).unwrap(),
                 format!("bundled-{name}").as_bytes()
@@ -1866,6 +1861,7 @@ mod tests {
                 fs::metadata(path).unwrap().permissions().mode() & 0o777,
                 0o755
             );
+            assert!(!runtime.join("bin").join(name).exists());
         }
         for directory in ["etc", "home", "keys", "secrets", "var", "wit", "log"] {
             assert_eq!(
@@ -2186,13 +2182,17 @@ mod tests {
         install_product_runtime(&product);
         migrate_runtime(&product, &source).expect("migration succeeds");
 
-        write(&product.runtime_home(), "bin/astrid", b"tamperd-binary");
+        write(
+            &product.release_runtime_bin_dir(),
+            "astrid",
+            b"tamperd-binary",
+        );
         assert_eq!(
             migrate_runtime(&product, &source)
                 .expect("a later product update may replace its runtime executable"),
             MigrationOutcome::AlreadyMigrated
         );
-        fs::remove_file(product.runtime_home().join("bin/astrid"))
+        fs::remove_file(product.release_runtime_bin_dir().join("astrid"))
             .expect("remove runtime executable");
         let error = migrate_runtime(&product, &source)
             .expect_err("an incomplete completed runtime must not be accepted");
@@ -2212,7 +2212,7 @@ mod tests {
             .expect_err("the product runtime cannot be imported through a path alias");
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
         assert_eq!(
-            fs::read(source.join("bin/astrid")).unwrap(),
+            fs::read(product.release_runtime_bin_dir().join("astrid")).unwrap(),
             b"bundled-astrid"
         );
         assert!(!product.migration_receipt().exists());
@@ -2255,7 +2255,7 @@ mod tests {
         assert!(!product.root().join(".runtime-import").exists());
         assert!(!product.migration_receipt().exists());
         assert_eq!(
-            fs::read(product.runtime_home().join("bin/astrid")).unwrap(),
+            fs::read(product.release_runtime_bin_dir().join("astrid")).unwrap(),
             b"bundled-astrid"
         );
         drop(held);
@@ -2350,7 +2350,8 @@ mod tests {
         let receipt = product.migration_receipt();
         let staged_receipt = receipt.with_extension("tmp");
         fs::rename(&receipt, &staged_receipt).expect("stage committed receipt");
-        install_runtime_at(&product.root().join("runtime.pre-migration"));
+        fs::create_dir_all(product.root().join("runtime.pre-migration"))
+            .expect("create runtime transaction backup");
         write(&source, "keys/runtime.key", b"current-runtime-key");
         write(&source, "var/new-state", b"current-source-state");
         write(
@@ -2412,10 +2413,7 @@ mod tests {
         )
         .expect("roll back invalid cutover");
 
-        assert_eq!(
-            fs::read(target.join("bin/astrid")).unwrap(),
-            b"bundled-astrid"
-        );
+        assert_eq!(file_snapshot(&target), BTreeMap::new());
         assert!(!backup.exists());
         assert!(!product.migration_receipt().with_extension("tmp").exists());
         fs::remove_dir_all(root).expect("remove fixture root");
@@ -2456,7 +2454,7 @@ mod tests {
         );
         for name in crate::RUNTIME_EXECUTABLE_NAMES {
             assert_eq!(
-                fs::read(product.runtime_home().join("bin").join(name)).unwrap(),
+                fs::read(product.release_runtime_bin_dir().join(name)).unwrap(),
                 format!("bundled-{name}").as_bytes()
             );
         }
@@ -2523,7 +2521,7 @@ mod tests {
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
         assert!(!product.runtime_home().join("keys/runtime.key").exists());
         assert_eq!(
-            fs::read(product.runtime_home().join("bin/astrid")).unwrap(),
+            fs::read(product.release_runtime_bin_dir().join("astrid")).unwrap(),
             b"bundled-astrid"
         );
         fs::remove_dir_all(root).expect("remove fixture root");
@@ -2539,12 +2537,12 @@ mod tests {
         let product = AosHome::from_root(root.join("product"));
         write(&source, "keys/runtime.key", b"runtime-key");
         install_product_runtime(&product);
-        fs::remove_file(product.runtime_home().join("bin/astrid"))
+        fs::remove_file(product.release_runtime_bin_dir().join("astrid"))
             .expect("remove regular executable");
         write(&root, "runtime-target", b"bundled-astrid");
         symlink(
             root.join("runtime-target"),
-            product.runtime_home().join("bin/astrid"),
+            product.release_runtime_bin_dir().join("astrid"),
         )
         .expect("create bundled binary symlink");
 

--- a/install.sh
+++ b/install.sh
@@ -817,7 +817,19 @@ fi
 release_dir="$AOS_HOME/releases/$staged_version"
 release_stage="$AOS_HOME/releases/.${staged_version}.new.$$"
 release_backup="$AOS_HOME/releases/.${staged_version}.rollback.$$"
-for managed in "$AOS_HOME" "$AOS_HOME/libexec" "$AOS_HOME/runtime" "$AOS_HOME/runtime/bin" "$AOS_HOME/releases" "$release_dir" "$release_dir/capsules" "$AOS_HOME/update" "$AOS_HOME/update/channels"; do
+for managed in \
+  "$AOS_HOME" \
+  "$AOS_HOME/libexec" \
+  "$AOS_HOME/runtime" \
+  "$AOS_HOME/runtime/bin" \
+  "$AOS_HOME/run" \
+  "$AOS_HOME/releases" \
+  "$release_dir" \
+  "$release_dir/runtime" \
+  "$release_dir/runtime/bin" \
+  "$release_dir/capsules" \
+  "$AOS_HOME/update" \
+  "$AOS_HOME/update/channels"; do
   [ ! -L "$managed" ] || { echo "refusing symlinked managed path: $managed" >&2; exit 1; }
 done
 if [ -e "$release_dir" ] && [ ! -d "$release_dir" ]; then
@@ -836,6 +848,17 @@ if [ -L "$AOS_BIN_DIR/aos" ] || { [ -e "$AOS_BIN_DIR/aos" ] && [ ! -f "$AOS_BIN_
   echo "refusing non-regular install destination: $AOS_BIN_DIR/aos" >&2
   exit 1
 fi
+for name in astrid astrid-daemon astrid-build astrid-emit; do
+  legacy="$AOS_HOME/runtime/bin/$name"
+  [ ! -L "$legacy" ] || {
+    echo "refusing symlinked legacy runtime executable: $legacy" >&2
+    exit 1
+  }
+  [ ! -e "$legacy" ] || [ -f "$legacy" ] || {
+    echo "refusing non-regular legacy runtime executable: $legacy" >&2
+    exit 1
+  }
+done
 
 if [ -x "$AOS_BIN_DIR/aos" ] && [ "$ASSUME_YES" -ne 1 ]; then
   answer=
@@ -853,8 +876,8 @@ if [ -x "$AOS_BIN_DIR/aos" ]; then
   "$AOS_BIN_DIR/aos" stop >/dev/null 2>&1 || true
 fi
 
-mkdir -p "$AOS_BIN_DIR" "$AOS_HOME/libexec" "$AOS_HOME/runtime/bin" "$AOS_HOME/releases"
-chmod 700 "$AOS_HOME" "$AOS_HOME/libexec" "$AOS_HOME/runtime" "$AOS_HOME/runtime/bin" "$AOS_HOME/releases"
+mkdir -p "$AOS_BIN_DIR" "$AOS_HOME/libexec" "$AOS_HOME/runtime" "$AOS_HOME/run" "$AOS_HOME/releases"
+chmod 700 "$AOS_HOME" "$AOS_HOME/libexec" "$AOS_HOME/runtime" "$AOS_HOME/run" "$AOS_HOME/releases"
 if [ -n "$channel_root" ]; then
   mkdir -p "$channel_root/generations"
   chmod 700 "$AOS_HOME/update" "$AOS_HOME/update/channels" "$channel_root" "$channel_root/generations"
@@ -864,6 +887,13 @@ if [ "$AOS_BIN_DIR" = "$AOS_HOME/bin" ]; then
 fi
 rollback="$work/rollback"
 mkdir "$rollback"
+for name in astrid astrid-daemon astrid-build astrid-emit; do
+  legacy="$AOS_HOME/runtime/bin/$name"
+  if [ -f "$legacy" ]; then
+    cp -p "$legacy" "$rollback/$name"
+  fi
+  : > "$rollback/$name.touched"
+done
 
 install_one() {
   source=$1
@@ -962,13 +992,13 @@ restore() {
 installation_started=1
 if ! install_one "$bundle/bin/aos" "$AOS_BIN_DIR/aos" aos 755; then exit 1; fi
 if ! install_one "$bundle/libexec/install.sh" "$AOS_HOME/libexec/install.sh" installer 600; then exit 1; fi
-for name in astrid astrid-daemon astrid-build astrid-emit; do
-  if ! install_one "$bundle/runtime/bin/$name" "$AOS_HOME/runtime/bin/$name" "$name" 755; then exit 1; fi
-done
 mkdir "$release_stage"
 chmod 700 "$release_stage"
-mkdir "$release_stage/capsules"
-chmod 700 "$release_stage/capsules"
+mkdir "$release_stage/runtime" "$release_stage/runtime/bin" "$release_stage/capsules"
+chmod 700 "$release_stage/runtime" "$release_stage/runtime/bin" "$release_stage/capsules"
+for name in astrid astrid-daemon astrid-build astrid-emit; do
+  install -m 0700 "$bundle/runtime/bin/$name" "$release_stage/runtime/bin/$name"
+done
 install -m 0600 "$bundle/release-manifest.json" "$release_stage/release-manifest.json"
 install -m 0600 "$bundle/Distro.toml" "$release_stage/Distro.toml"
 install -m 0600 "$bundle/capsule-assets.txt" "$release_stage/capsule-assets.txt"
@@ -984,6 +1014,20 @@ if ! mv "$release_stage" "$release_dir"; then
 fi
 release_committed=1
 stage_channel_receipt
+# Older installations may have copied the bundled executables into the mutable
+# runtime home. They are no longer a valid launch location; remove only those
+# known managed files after the new immutable release is committed.
+if [ -d "$AOS_HOME/runtime/bin" ] && [ ! -L "$AOS_HOME/runtime/bin" ]; then
+  for name in astrid astrid-daemon astrid-build astrid-emit; do
+    legacy="$AOS_HOME/runtime/bin/$name"
+    [ ! -L "$legacy" ] || { echo "refusing symlinked legacy runtime executable: $legacy" >&2; exit 1; }
+    [ ! -e "$legacy" ] || [ -f "$legacy" ] || {
+      echo "refusing non-regular legacy runtime executable: $legacy" >&2
+      exit 1
+    }
+    rm -f "$legacy"
+  done
+fi
 installation_started=0
 rm -rf "$release_backup"
 release_install_lock

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -246,8 +246,11 @@ AOS_VERSION=2026.9.0 \
 sh "$repo_root/install.sh" --yes --no-migrate-prompt
 
 test -x "$work/home/.aos/bin/aos"
-test -x "$work/home/.aos/runtime/bin/astrid-daemon"
 release_dir="$work/home/.aos/releases/2026.9.0"
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  test -x "$release_dir/runtime/bin/$binary"
+  test ! -e "$work/home/.aos/runtime/bin/$binary"
+done
 test -f "$release_dir/release-manifest.json"
 test -f "$release_dir/Distro.toml"
 test -f "$release_dir/capsule-assets.txt"
@@ -263,6 +266,7 @@ test -f "$fixture/cosign-called"
 test ! -e "$fixture/path-cosign-called"
 test "$(stat -c '%a' "$work/home/.aos" 2>/dev/null || stat -f '%Lp' "$work/home/.aos")" = 700
 test "$(stat -c '%a' "$release_dir/release-manifest.json" 2>/dev/null || stat -f '%Lp' "$release_dir/release-manifest.json")" = 600
+test "$(stat -c '%a' "$release_dir/runtime/bin/astrid" 2>/dev/null || stat -f '%Lp' "$release_dir/runtime/bin/astrid")" = 700
 test "$(stat -c '%a' "$release_dir/capsules" 2>/dev/null || stat -f '%Lp' "$release_dir/capsules")" = 700
 
 python=${PYTHON3:-python3}
@@ -555,6 +559,25 @@ if PATH="$fake_bin:$PATH" HOME="$managed_symlink_home" AOS_TEST_FIXTURE="$fixtur
 fi
 test ! -e "$work/managed-symlink-executed"
 
+run_symlink_home="$work/run-symlink-home"
+mkdir -p "$run_symlink_home/.aos" "$work/run-symlink-target"
+ln -s "$work/run-symlink-target" "$run_symlink_home/.aos/run"
+if PATH="$fake_bin:$PATH" HOME="$run_symlink_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.9.0 \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a symlinked AOS run root" >&2
+  exit 1
+fi
+
+release_bin_symlink_home="$work/release-bin-symlink-home"
+mkdir -p "$release_bin_symlink_home/.aos/releases/2026.9.0/runtime" "$work/release-bin-symlink-target"
+ln -s "$work/release-bin-symlink-target" \
+  "$release_bin_symlink_home/.aos/releases/2026.9.0/runtime/bin"
+if PATH="$fake_bin:$PATH" HOME="$release_bin_symlink_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.9.0 \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a symlinked release runtime bin directory" >&2
+  exit 1
+fi
+
 directory_home="$work/directory-destination-home"
 mkdir -p "$directory_home/.aos/bin/aos"
 if PATH="$fake_bin:$PATH" HOME="$directory_home" AOS_TEST_FIXTURE="$fixture" AOS_VERSION=2026.9.0 \
@@ -567,11 +590,14 @@ test -d "$directory_home/.aos/bin/aos"
 for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
   case "$binary" in
     aos) destination="$work/home/.aos/bin/aos" ;;
-    *) destination="$work/home/.aos/runtime/bin/$binary" ;;
+    *) destination="$release_dir/runtime/bin/$binary" ;;
   esac
   printf '#!/bin/sh\necho old-%s\n' "$binary" > "$destination"
   chmod 755 "$destination"
 done
+mkdir -p "$work/home/.aos/runtime/bin"
+printf '#!/bin/sh\necho stale-mutable-copy\n' > "$work/home/.aos/runtime/bin/astrid"
+chmod 755 "$work/home/.aos/runtime/bin/astrid"
 printf 'old-release-manifest\n' > "$release_dir/release-manifest.json"
 
 fail_bin="$work/fail-bin"
@@ -603,16 +629,25 @@ fi
 for binary in aos astrid astrid-daemon astrid-build astrid-emit; do
   case "$binary" in
     aos) destination="$work/home/.aos/bin/aos" ;;
-    *) destination="$work/home/.aos/runtime/bin/$binary" ;;
+    *) destination="$release_dir/runtime/bin/$binary" ;;
   esac
   test "$("$destination")" = "old-$binary"
 done
+test -x "$work/home/.aos/runtime/bin/astrid"
+test "$("$work/home/.aos/runtime/bin/astrid")" = stale-mutable-copy
 test "$(cat "$release_dir/release-manifest.json")" = old-release-manifest
 test "$(find "$release_dir/capsules" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 22
 while IFS= read -r capsule; do
   cmp "$work/capsules/$capsule" "$release_dir/capsules/$capsule"
 done < "$release_dir/capsule-assets.txt"
 test "$(cat "$work/home/.astrid/sentinel")" = standalone-runtime-state
+
+PATH="$fake_bin:$PATH" HOME="$work/home" AOS_TEST_FIXTURE="$fixture" \
+  AOS_VERSION=2026.9.0 sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  test ! -e "$work/home/.aos/runtime/bin/$binary"
+  test -x "$release_dir/runtime/bin/$binary"
+done
 
 cat > "$work/aos-mismatch" <<'EOF'
 #!/bin/sh

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -132,8 +132,8 @@ snapshot_shipped_assets() {
   : > "$output"
   printf '%s|bin/aos\n' "$(b3sum -- "$home/bin/aos" | awk '{print $1}')" >> "$output"
   for name in astrid astrid-daemon astrid-build astrid-emit; do
-    printf '%s|runtime/bin/%s\n' \
-      "$(b3sum -- "$home/runtime/bin/$name" | awk '{print $1}')" \
+    printf '%s|releases/2026.9.0/runtime/bin/%s\n' \
+      "$(b3sum -- "$release/runtime/bin/$name" | awk '{print $1}')" \
       "$name" >> "$output"
   done
   while IFS= read -r capsule; do
@@ -161,7 +161,11 @@ mkdir -p "$home" "$fixture" "$fake_bin" "$capsules"
 python3 "$repo_root/scripts/create-astrid-094-fixture.py" "$legacy"
 
 cargo build --locked -p unicity-aos-bootstrap --bin aos
-product_binary=$repo_root/target/debug/aos
+target_dir=$(
+  cargo metadata --locked --no-deps --format-version 1 |
+    python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])'
+)
+product_binary=$target_dir/debug/aos
 test "$($product_binary --version)" = 'Unicity AOS 2026.9.0'
 
 PYTHONPATH="$repo_root/scripts" python3 - "$capsules" <<'PY'
@@ -355,7 +359,10 @@ test "$(find "$legacy/run" -type f | wc -l | tr -d ' ')" -eq 5
 
 install_candidate
 test -x "$aos_home/bin/aos"
-test -x "$aos_home/runtime/bin/astrid-daemon"
+test -x "$aos_home/releases/2026.9.0/runtime/bin/astrid-daemon"
+for name in astrid astrid-daemon astrid-build astrid-emit; do
+  test ! -e "$aos_home/runtime/bin/$name"
+done
 HOME="$home" "$aos_home/bin/aos" migrate runtime --from "$legacy" > "$work/migrate.log"
 grep -F 'imported the standalone runtime; the source was left unchanged' "$work/migrate.log" >/dev/null
 assert_imported_activation_layout "$aos_home/runtime"
@@ -413,7 +420,7 @@ snapshot_shipped_assets "$aos_home" "$shipped_before"
 for name in aos astrid astrid-daemon astrid-build astrid-emit; do
   case "$name" in
     aos) destination=$aos_home/bin/aos ;;
-    *) destination=$aos_home/runtime/bin/$name ;;
+    *) destination=$aos_home/releases/2026.9.0/runtime/bin/$name ;;
   esac
   printf '#!/bin/sh\nexit 0\n' > "$destination"
   chmod 755 "$destination"
@@ -425,9 +432,10 @@ chmod 755 \
   "$aos_home" \
   "$aos_home/bin" \
   "$aos_home/runtime" \
-  "$aos_home/runtime/bin" \
   "$aos_home/releases" \
   "$aos_home/releases/2026.9.0" \
+  "$aos_home/releases/2026.9.0/runtime" \
+  "$aos_home/releases/2026.9.0/runtime/bin" \
   "$aos_home/releases/2026.9.0/capsules"
 
 install_candidate
@@ -438,9 +446,10 @@ for directory in \
   "$aos_home" \
   "$aos_home/bin" \
   "$aos_home/runtime" \
-  "$aos_home/runtime/bin" \
   "$aos_home/releases" \
   "$aos_home/releases/2026.9.0" \
+  "$aos_home/releases/2026.9.0/runtime" \
+  "$aos_home/releases/2026.9.0/runtime/bin" \
   "$aos_home/releases/2026.9.0/capsules"; do
   test "$(mode_of "$directory")" = 700
 done


### PR DESCRIPTION
## Summary

Launch the bundled Astrid executables from the immutable product-versioned release tree instead of copying them into the mutable runtime home.

- Default `runtime_binary()` is `$AOS_HOME/releases/<version>/runtime/bin/astrid`.
- `ASTRID_HOME` remains `$AOS_HOME/runtime`.
- Child `ASTRID_RUN_DIR` is `$AOS_HOME/run` and is not nested under `ASTRID_HOME`.
- `install.sh` copies bundle `runtime/bin` into the versioned release tree and removes stale managed `astrid*` copies from `$AOS_HOME/runtime/bin` only after the new release is committed.
- Runtime import fingerprints bundled executables in the release tree and no longer copies shipped binaries into mutable runtime state.

## Claim Limits

This is the layout/install predecessor only. It does not change Distro Apply, mounted trust, pin provisioning, stopped-volume validation, schema-v2 release metadata, or the HQ sealer. Current packaged Astrid `v0.10.4` may ignore `ASTRID_RUN_DIR`; the environment is bound now so later runtimes can consume it.

Draft PR #112 remains unpublished evidence and is not restacked here.

## Verification

- cargo fmt --all -- --check
- cargo test --locked -p unicity-aos-bootstrap -- --test-threads=1
- cargo clippy --locked -p unicity-aos-bootstrap --all-targets --all-features -- -D warnings
- bash scripts/test-install.sh
- bash scripts/test-upgrade-self-heal.sh
- git diff --check

## AI / Tool Assistance

Implemented and tested with Codex. The final diff, exact ancestry, signature, DCO, and test output were reviewed before publication.
