### PR TITLE
fix(release): name schema-v2 executables and aos-mcp membership

### DIFF
--- a/changes/schema-v2-exec-membership.fixed.md
+++ b/changes/schema-v2-exec-membership.fixed.md
@@ -1,0 +1,1 @@
+- Added schema-v2 release-manifest executable membership and explicit required `aos-mcp` capsule metadata, with fail-closed validation during native sealer extraction and archive signing.

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -130,6 +130,74 @@ print(value)
 PY
 }
 
+validate_schema_v2_membership() {
+  local manifest=$1
+  local bundle=${2:-}
+  python3 - "$manifest" "$bundle" <<'PY'
+import json
+import os
+import pathlib
+import re
+import stat
+import sys
+
+manifest_path, bundle_arg = sys.argv[1:]
+try:
+    manifest = json.loads(pathlib.Path(manifest_path).read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as error:
+    raise SystemExit(f"release manifest is unreadable: {error}")
+
+expected_executables = [
+    "bin/aos",
+    "runtime/bin/astrid",
+    "runtime/bin/astrid-daemon",
+    "runtime/bin/astrid-build",
+    "runtime/bin/astrid-emit",
+]
+executables = manifest.get("executables")
+if executables != expected_executables:
+    raise SystemExit("release manifest executables membership is missing or non-canonical")
+
+release_files = manifest.get("release_files")
+if not isinstance(release_files, dict):
+    raise SystemExit("release manifest release_files inventory is missing")
+for relative in expected_executables:
+    record = release_files.get(relative)
+    if not isinstance(record, dict) or set(record) != {"blake3", "mode"}:
+        raise SystemExit(f"release manifest executable inventory record is invalid: {relative}")
+    if not isinstance(record["blake3"], str) or re.fullmatch(r"[0-9a-f]{64}", record["blake3"]) is None:
+        raise SystemExit(f"release manifest executable digest is malformed: {relative}")
+    if type(record["mode"]) is not int or record["mode"] != 0o755:
+        raise SystemExit(f"release manifest executable mode is not 0755: {relative}")
+for relative, record in release_files.items():
+    if isinstance(record, dict) and record.get("mode") == 0o755 and relative not in expected_executables:
+        raise SystemExit(f"release manifest has an unlisted executable inventory record: {relative}")
+
+capsules = manifest.get("capsules")
+if not isinstance(capsules, dict):
+    raise SystemExit("release manifest capsules section is missing")
+assets = capsules.get("assets")
+if not isinstance(assets, list) or any(not isinstance(asset, str) for asset in assets):
+    raise SystemExit("release manifest capsule assets are missing or malformed")
+required = capsules.get("required")
+if required != ["aos-mcp.capsule"]:
+    raise SystemExit("release manifest capsules.required must name aos-mcp.capsule")
+if any(asset not in assets for asset in required):
+    raise SystemExit("release manifest capsules.required is not a subset of capsules.assets")
+if "aos-mcp.capsule" not in assets:
+    raise SystemExit("release manifest capsules.assets is missing aos-mcp.capsule")
+
+if bundle_arg:
+    bundle = pathlib.Path(bundle_arg)
+    for relative in expected_executables:
+        path = bundle / relative
+        if path.is_symlink() or not path.is_file():
+            raise SystemExit(f"release manifest executable is missing from archive: {relative}")
+        if stat.S_IMODE(path.stat().st_mode) != 0o755 or not os.access(path, os.X_OK):
+            raise SystemExit(f"release archive executable mode is not 0755: {relative}")
+PY
+}
+
 require_native_release_sealer() {
   local archive=$1
   local output=$2
@@ -153,6 +221,9 @@ require_native_release_sealer() {
   runtime_identity=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime release-workflow-identity)
   mkdir -p "$extracted"
   extract_safe_tar "$archive" "$extracted" "unicity-aos-${product_version}-${expected_target}"
+  validate_schema_v2_membership \
+    "$extracted/unicity-aos-${product_version}-${expected_target}/release-manifest.json" \
+    "$extracted/unicity-aos-${product_version}-${expected_target}"
   python3 - "$extracted" "$product_version" "$expected_target" "$runtime_version" "$runtime_tag" "$runtime_repository" "$runtime_identity" <<'PY'
 import json
 import os
@@ -237,7 +308,8 @@ PY
 require_release_archive_root() {
   local extracted=$1
   local product_version=$2
-  python3 - "$extracted" "$product_version" <<'PY'
+  local bundle
+  bundle=$(python3 - "$extracted" "$product_version" <<'PY'
 import json
 import pathlib
 import sys
@@ -266,6 +338,9 @@ if bundle.name != f"unicity-aos-{product_version}-{target}":
     raise SystemExit("AOS archive root does not match its release-manifest target")
 print(bundle)
 PY
+  )
+  validate_schema_v2_membership "$bundle/release-manifest.json" "$bundle"
+  printf '%s\n' "$bundle"
 }
 
 sealer_pubkey_equals_manifest() {
@@ -503,6 +578,13 @@ manifest = {
     "schema_version": 2,
     "product": {"name": "Unicity AOS Community Edition", "version": product},
     "target": target,
+    "executables": [
+        "bin/aos",
+        "runtime/bin/astrid",
+        "runtime/bin/astrid-daemon",
+        "runtime/bin/astrid-build",
+        "runtime/bin/astrid-emit",
+    ],
     "layout": {
         "release_directory": f"releases/{product}",
         "runtime_executables": "runtime/bin",
@@ -523,7 +605,11 @@ manifest = {
         "sdk_rust_version": sdk_version,
         "sdk_rust_commit": sdk_commit,
     },
-    "capsules": {"count": len(capsules), "assets": capsules},
+    "capsules": {
+        "count": len(capsules),
+        "assets": capsules,
+        "required": ["aos-mcp.capsule"],
+    },
 }
 verifiers = {
     "aarch64-apple-darwin": {
@@ -548,6 +634,8 @@ if target not in verifiers:
 manifest["verifier"] = {"version": "v3.1.1", **verifiers[target]}
 pathlib.Path(path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 PY
+
+validate_schema_v2_membership "$work/$root/release-manifest.json" "$work/$root"
 
 tar -czf "$output_dir/$asset" -C "$work" "$root"
 echo "$output_dir/$asset"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -305,6 +305,14 @@ manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
 product_version, runtime_version, runtime_identity = sys.argv[2:]
 assert manifest["schema_version"] == 2
 assert manifest["product"]["version"] == product_version
+expected_executables = [
+    "bin/aos",
+    "runtime/bin/astrid",
+    "runtime/bin/astrid-daemon",
+    "runtime/bin/astrid-build",
+    "runtime/bin/astrid-emit",
+]
+assert manifest["executables"] == expected_executables
 assert manifest["layout"] == {
     "release_directory": f"releases/{product_version}",
     "runtime_executables": "runtime/bin",
@@ -330,6 +338,7 @@ assert set(manifest["release_files"]) == expected_inventory, (
 assert manifest["release_files"]["bin/aos"]["mode"] == 0o755
 assert manifest["release_files"]["libexec/install.sh"]["mode"] == 0o600
 assert manifest["release_files"]["runtime/bin/astrid-daemon"]["mode"] == 0o755
+assert all(manifest["release_files"][path]["mode"] == 0o755 for path in expected_executables)
 assert manifest["runtime"]["version"] == runtime_version
 assert manifest["runtime"]["digest"] == "blake3:" + "0" * 64
 assert "sha256" not in manifest["runtime"]
@@ -341,6 +350,9 @@ assert manifest["contracts"]["sdk_rust_commit"] == "bbbc61c8821d6c536fb25d2068b6
 assert manifest["capsules"]["count"] == 22
 assert len(manifest["capsules"]["assets"]) == 22
 assert len(set(manifest["capsules"]["assets"])) == 22
+assert manifest["capsules"]["required"] == ["aos-mcp.capsule"]
+assert set(manifest["capsules"]["required"]) <= set(manifest["capsules"]["assets"])
+assert "aos-mcp.capsule" in manifest["capsules"]["assets"]
 assert manifest["verifier"] == {
     "version": "v3.1.1",
     "asset": "cosign-linux-amd64",
@@ -363,6 +375,45 @@ PY
 cp "$fixture_distro" "$bundle_root/Distro.toml"
 fixture_archive="$work/fixture-aos.tar.gz"
 COPYFILE_DISABLE=1 tar -czf "$fixture_archive" -C "$work" "$(basename "$bundle_root")"
+
+membership_mutations="$work/membership-mutations"
+mkdir "$membership_mutations"
+for mutation in missing-executables extra-executable mismatched-executable-mode missing-required missing-aos-mcp; do
+  mutation_dir="$membership_mutations/$mutation"
+  mkdir "$mutation_dir"
+  mutation_root="$mutation_dir/$(basename "$bundle_root")"
+  cp -R "$bundle_root" "$mutation_root"
+  python3 - "$mutation_root/release-manifest.json" "$mutation" <<'PY'
+import json
+import pathlib
+import sys
+
+path, mutation = sys.argv[1:]
+manifest = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+if mutation == "missing-executables":
+    del manifest["executables"]
+elif mutation == "extra-executable":
+    manifest["executables"].append("runtime/bin/not-a-real-executable")
+elif mutation == "mismatched-executable-mode":
+    manifest["release_files"]["runtime/bin/astrid"]["mode"] = 0o600
+elif mutation == "missing-required":
+    assert "aos-mcp.capsule" in manifest["capsules"]["assets"]
+    del manifest["capsules"]["required"]
+elif mutation == "missing-aos-mcp":
+    manifest["capsules"]["assets"].remove("aos-mcp.capsule")
+else:
+    raise SystemExit(f"unknown mutation: {mutation}")
+pathlib.Path(path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+  mutation_archive="$mutation_dir/$mutation.tar.gz"
+  COPYFILE_DISABLE=1 tar -czf "$mutation_archive" -C "$mutation_dir" "$(basename "$mutation_root")"
+  if bash "$repo_root/scripts/package-release.sh" \
+    --extract-release-sealer "$mutation_archive" "$mutation_dir/native-sealer" >/dev/null 2>&1; then
+    echo "release sealer extraction accepted the $mutation manifest mutation" >&2
+    exit 1
+  fi
+done
+
 fixture_signed="$work/fixture-aos-signed.tar.gz"
 native_sealer="$work/native-distro-sealer"
 bash "$repo_root/scripts/package-release.sh" \


### PR DESCRIPTION
## Summary

Make schema-v2 archive metadata name product and runtime executables as a first-class membership set, and require `aos-mcp.capsule` explicitly rather than only as one of 22 assets.

- `release-manifest.json` keeps `schema_version` 2 and adds exact `executables`: `bin/aos`, `runtime/bin/astrid`, `runtime/bin/astrid-daemon`, `runtime/bin/astrid-build`, `runtime/bin/astrid-emit`.
- Each named executable must exist in `release_files` with mode 0755; extra 0755 inventory is refused.
- `capsules.required` is exactly `["aos-mcp.capsule"]` and must be a subset of `capsules.assets`.
- Native sealer extraction and archive signing fail closed if that membership is missing or mutated.
- Unsigned packaging still refuses production Distro.lock/sig. Fixture rehearsal still uses a disposable QA trust identity with unchanged fail-closed pubkey verification.

## Exact head

- Base: `12e244412f1e663e057e81e679135eb0caaf85c1`
- Head: `2850e7370c9fea6e35b97a4ff6cf9ad4dbd91d8f`
- Tree: `397ce52d31d0191d68b64bf3bcddecb4ba6e8809`

## Scope

- `scripts/package-release.sh`
- `scripts/test-package-release.sh`
- `changes/schema-v2-exec-membership.fixed.md`

No Distro Apply, Distro.toml signing pubkey, musl, installer/runtime-bin, tag, release dispatch, or live installation state changes. GitHub release.toml/channel metadata remains schema-version 1.

## Verification

- GPG: good signature from Joshua J. Bouw `<jjb@unicity-labs.com>`
- DCO: `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`
- `bash scripts/test-package-release.sh`
- `bash -n scripts/package-release.sh scripts/test-package-release.sh`
- `git diff --check`

Harness mutations cover missing/extra executables, mismatched executable mode, missing `capsules.required` while `aos-mcp.capsule` remains in assets, and missing `aos-mcp.capsule` from assets.

## Residuals and claim limits

- This does not publish a signed Distro or enable Distro Apply.
- Hosted stable sealing remains fail-closed on Astrid `0.10.4`.
- This does not change production Distro.signing identity.
- This does not certify runtime activation or a 2026.9 tag.

## AI / Tool Assistance

Implemented and tested with Codex. The final diff, exact ancestry, signature, DCO, and test output were reviewed before publication.
