### PR TITLE
fix(runtime): confirm stop after every delegated shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,8 @@
   `aos stop` only after every coordination marker is gone and the singleton
   lock is available; all other inherited runtime failures retain their output
   and exit status.
+- Confirm every delegated runtime shutdown before reporting success, preserving
+  child output and exit status when stopped-state confirmation fails.
 
 ### Fixed
 

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -532,24 +532,33 @@ fn handle_runtime_stop(args: &[OsString]) -> ExitCode {
         }
     };
 
-    if output.status.success() {
+    let expected_disconnect = expected_shutdown_disconnect(&output);
+    let confirmation = wait_for_confirmed_stop(&home);
+    if confirmation.is_ok() && (output.status.success() || expected_disconnect) {
+        if expected_disconnect {
+            if let Err(error) = std::io::stdout().write_all(&output.stdout) {
+                return runtime_output_error(error);
+            }
+            if output.stdout.is_empty() {
+                println!("Unicity AOS stopped.");
+            }
+            return ExitCode::SUCCESS;
+        }
         return emit_runtime_output(&output)
             .map_or_else(runtime_output_error, |()| ExitCode::SUCCESS);
     }
 
-    if expected_shutdown_disconnect(&output) && wait_for_confirmed_stop(&home) {
-        if let Err(error) = std::io::stdout().write_all(&output.stdout) {
-            return runtime_output_error(error);
-        }
-        if output.stdout.is_empty() {
-            println!("Unicity AOS stopped.");
-        }
-        return ExitCode::SUCCESS;
+    let output_result = emit_runtime_output(&output);
+    if let Err(error) = confirmation {
+        eprintln!("aos: shutdown confirmation failed: {error}");
     }
-
-    match emit_runtime_output(&output) {
-        Ok(()) => child_exit_code(output.status),
-        Err(error) => runtime_output_error(error),
+    if let Err(error) = output_result {
+        return runtime_output_error(error);
+    }
+    if output.status.success() {
+        ExitCode::FAILURE
+    } else {
+        child_exit_code(output.status)
     }
 }
 
@@ -562,21 +571,29 @@ fn expected_shutdown_disconnect(output: &std::process::Output) -> bool {
         && stderr.contains("connection closed before astrid.v1.response.shutdown.")
 }
 
-fn wait_for_confirmed_stop(home: &AosHome) -> bool {
+fn wait_for_confirmed_stop(home: &AosHome) -> Result<(), String> {
     const ATTEMPTS: usize = 100;
     const INTERVAL: Duration = Duration::from_millis(50);
 
+    let mut last_failure = "runtime stopped-state confirmation returned no result".to_owned();
     for attempt in 0..ATTEMPTS {
-        if unicity_aos_bootstrap::status::confirm_stopped(home)
-            .is_ok_and(|status| status.state == "stopped")
-        {
-            return true;
+        match unicity_aos_bootstrap::status::confirm_stopped(home) {
+            Ok(status) if status.state == "stopped" => return Ok(()),
+            Ok(status) => {
+                last_failure = format!(
+                    "runtime stopped-state confirmation returned '{}'",
+                    status.state
+                );
+            }
+            Err(error) => last_failure = error,
         }
         if attempt + 1 < ATTEMPTS {
             std::thread::sleep(INTERVAL);
         }
     }
-    false
+    Err(format!(
+        "runtime did not reach a confirmed stopped state within 5 seconds: {last_failure}"
+    ))
 }
 
 fn emit_runtime_output(output: &std::process::Output) -> io::Result<()> {

--- a/crates/unicity-aos-bootstrap/src/status.rs
+++ b/crates/unicity-aos-bootstrap/src/status.rs
@@ -18,6 +18,14 @@ use crate::AosHome;
 
 const STATUS_TIMEOUT: Duration = Duration::from_secs(5);
 const RUNTIME_COMPATIBILITY: &str = include_str!("../../../release/runtime-compatibility.toml");
+const COORDINATION_MARKERS: [&str; 6] = [
+    "system.sock",
+    "system.pid",
+    "system.ready",
+    "system.token",
+    "mcp-gateway.sock",
+    "mcp-gateway.ready",
+];
 
 /// Product status derived from the typed runtime status response.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -114,7 +122,7 @@ pub async fn read_for_principal(
 /// materialized runtime state is an exclusive private volume.
 pub fn confirm_stopped(home: &AosHome) -> Result<AosStatus, String> {
     let run_dir = home.runtime_home().join("run");
-    for marker in ["system.sock", "system.pid", "system.ready", "system.token"] {
+    for marker in COORDINATION_MARKERS {
         match fs::symlink_metadata(run_dir.join(marker)) {
             Ok(_) => {
                 return Err(format!(
@@ -350,6 +358,22 @@ mod tests {
 
         fs2::FileExt::unlock(&lock).expect("release runtime lock");
         fs::remove_dir_all(root).expect("remove running status fixture");
+    }
+
+    #[test]
+    fn mcp_gateway_markers_block_stopped_status() {
+        for marker in ["mcp-gateway.sock", "mcp-gateway.ready"] {
+            let root = temporary_status_home(marker);
+            let home = AosHome::from_root(&root);
+            let run_dir = home.runtime_home().join("run");
+            fs::create_dir_all(&run_dir).expect("create runtime run dir");
+            fs::write(run_dir.join(marker), []).expect("create gateway marker");
+
+            let error = confirm_stopped(&home).expect_err("gateway marker must block stopped");
+            assert!(error.contains(marker), "{marker} was not named in: {error}");
+
+            fs::remove_dir_all(root).expect("remove gateway marker fixture");
+        }
     }
 
     #[cfg(unix)]

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 struct Fixture {
     root: PathBuf,
@@ -394,6 +394,174 @@ exit 1
     assert_eq!(
         String::from_utf8(output.stdout).expect("utf8 stop output"),
         "Unicity AOS stopped.\n"
+    );
+}
+
+#[test]
+fn inherited_exit_zero_stop_waits_for_confirmation() {
+    let fixture = Fixture::new("confirmed-zero-stop");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+echo 'runtime stop complete'
+exit 0
+"#,
+    );
+
+    let ready_marker = fixture.home.join("runtime/run/system.ready");
+    fs::create_dir_all(ready_marker.parent().expect("runtime run directory"))
+        .expect("create runtime run directory");
+    fs::write(&ready_marker, []).expect("create runtime ready marker");
+    let marker_to_remove = ready_marker.clone();
+    let run_dir = fixture.home.join("runtime/run");
+    let volume = fixture.home.join("runtime/astrid.volume");
+    let shutdown = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(200));
+        fs::write(&volume, b"volume-state").expect("create private runtime volume");
+        let mut permissions = fs::metadata(&volume)
+            .expect("inspect private runtime volume")
+            .permissions();
+        permissions.set_mode(0o600);
+        fs::set_permissions(&volume, permissions).expect("make runtime volume private");
+        fs::remove_file(marker_to_remove).expect("remove runtime ready marker");
+        fs::remove_dir_all(run_dir).expect("remove runtime run directory");
+    });
+
+    let output = fixture
+        .command()
+        .arg("stop")
+        .output()
+        .expect("run successful inherited stop");
+    shutdown.join().expect("finish runtime shutdown");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("utf8 stop output"),
+        "runtime stop complete\n"
+    );
+    assert!(output.stderr.is_empty());
+    assert!(!ready_marker.exists());
+    let runtime = fixture.home.join("runtime");
+    let entries: Vec<_> = fs::read_dir(&runtime)
+        .expect("read stopped runtime state")
+        .map(|entry| {
+            entry
+                .expect("read stopped runtime entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    assert_eq!(entries, vec!["astrid.volume"]);
+}
+
+#[test]
+fn inherited_exit_zero_stop_fails_while_the_runtime_token_remains() {
+    let fixture = Fixture::new("unconfirmed-zero-stop");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+echo 'runtime claimed stop complete'
+exit 0
+"#,
+    );
+
+    let token = fixture.home.join("runtime/run/system.token");
+    fs::create_dir_all(token.parent().expect("runtime run directory"))
+        .expect("create runtime run directory");
+    fs::write(&token, b"stale token").expect("create stale runtime token");
+
+    let started = Instant::now();
+    let output = fixture
+        .command()
+        .arg("stop")
+        .output()
+        .expect("run unconfirmed inherited stop");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        started.elapsed() < Duration::from_secs(10),
+        "stop confirmation must remain bounded"
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("utf8 stop output"),
+        "runtime claimed stop complete\n"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stop error");
+    assert!(stderr.contains("aos: shutdown confirmation failed:"));
+    assert!(stderr.contains("system.token"));
+    assert!(token.exists(), "confirmation must not hide a stale marker");
+}
+
+#[test]
+fn inherited_stop_preserves_the_primary_failure_before_confirmation_failure() {
+    let fixture = Fixture::new("primary-and-confirmation-failure");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+echo 'primary runtime stop failure' >&2
+exit 23
+"#,
+    );
+
+    let gateway = fixture.home.join("runtime/run/mcp-gateway.ready");
+    fs::create_dir_all(gateway.parent().expect("runtime run directory"))
+        .expect("create runtime run directory");
+    fs::write(&gateway, b"stale gateway").expect("create stale gateway marker");
+
+    let output = fixture
+        .command()
+        .arg("stop")
+        .output()
+        .expect("run failed inherited stop");
+
+    assert_eq!(output.status.code(), Some(23));
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stop error");
+    let primary = stderr
+        .find("primary runtime stop failure")
+        .expect("primary failure must be retained");
+    let confirmation = stderr
+        .find("aos: shutdown confirmation failed:")
+        .expect("confirmation failure must be reported separately");
+    assert!(primary < confirmation);
+    assert!(stderr.contains("mcp-gateway.ready"));
+    assert!(
+        gateway.exists(),
+        "confirmation must not hide a stale gateway marker"
+    );
+}
+
+#[test]
+fn expected_disconnect_is_not_suppressed_when_confirmation_fails() {
+    let fixture = Fixture::new("disconnect-and-confirmation-failure");
+    fixture.install_runtime(
+        r#"#!/bin/sh
+echo 'error: connection lost waiting on astrid.v1.response.shutdown.test: connection lost: connection closed before astrid.v1.response.shutdown.test' >&2
+exit 1
+"#,
+    );
+
+    let gateway = fixture.home.join("runtime/run/mcp-gateway.sock");
+    fs::create_dir_all(gateway.parent().expect("runtime run directory"))
+        .expect("create runtime run directory");
+    fs::write(&gateway, b"stale gateway endpoint").expect("create stale gateway endpoint");
+
+    let output = fixture
+        .command()
+        .arg("stop")
+        .output()
+        .expect("run disconnected inherited stop");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("utf8 stop error");
+    let disconnect = stderr
+        .find("connection lost waiting on astrid.v1.response.shutdown.test")
+        .expect("disconnect must remain visible when confirmation fails");
+    let confirmation = stderr
+        .find("aos: shutdown confirmation failed:")
+        .expect("confirmation failure must be reported separately");
+    assert!(disconnect < confirmation);
+    assert!(stderr.contains("mcp-gateway.sock"));
+    assert!(
+        gateway.exists(),
+        "confirmation must not hide a stale gateway endpoint"
     );
 }
 


### PR DESCRIPTION
## Summary

Confirm every delegated `aos stop` against the landed volume-only stopped
runtime before reporting success, including child exit 0. Keep the expected
shutdown-disconnect path, preserve nonzero child exits, and report
confirmation failure separately. Treat leftover `mcp-gateway.sock` and
`mcp-gateway.ready` as live coordination markers.

This is a new successor on current `main` after #125. It does not restack
or close existing draft #111.

## Changes

- Wait for `confirm_stopped` after every delegated stop, including exit 0
- On confirmation failure, emit child output, print
  `aos: shutdown confirmation failed: ...`, then fail; preserve nonzero
  child exit when the runtime itself failed
- Add `mcp-gateway.sock` / `mcp-gateway.ready` to coordination markers
- Keep exclusive nonempty `astrid.volume` mode `0600` (`mode & 07777`);
  leftover `runtime/run` still fails; no `runtime/bin` allowlist
- CLI and unit regressions for exit-0 confirmation, stale token,
  mcp-gateway leftovers, and primary-failure-before-confirmation-failure

## Exact head

- Base: `09cfe322fc77ddd4b07da373ff1a66ed75fcbdf6`
- Head: `1a746064a46972990f9ab0563f8e4dc9a3cb3ff3`
- Unique commit: `fix(runtime): confirm stop after every delegated shutdown`

## Scope

- `CHANGELOG.md`
- `crates/unicity-aos-bootstrap/src/main.rs`
- `crates/unicity-aos-bootstrap/src/status.rs`
- `crates/unicity-aos-bootstrap/tests/cli_boundary.rs`

No Distro Apply, trust-pin seeding, schema-v2, `package-release.sh`,
installer, `runtime/bin` allowlist, runtime pin, or live installation
state changes.

## Verification

- GPG: good signature from Joshua J. Bouw `<jjb@unicity-labs.com>`
- DCO: `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`
- `cargo fmt --all -- --check`
- `cargo test -p unicity-aos-bootstrap --offline`

## Residuals and claim limits

- Product version remains 2026.9.0.
- Packaged runtime pin remains Astrid 0.10.4 / `b6bf5d1d`.
- Landed schema-v2 / aos-mcp membership from #125 is unchanged.
- This does not implement Distro Apply or move trust pins.
- Draft #111 remains open and is not the landing vehicle.

## AI / tool disclosure

Codex was used to extract the remaining stop-confirmation behavior onto
current `main` and to add mcp-gateway marker coverage without changing the
landed volume-only stopped-runtime contract.
