### PR TITLE
feat(distro): apply signed Unicity CE with volume-only stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@
   changing runtime state, and proves clean daemon shutdown before publication.
 - Native `aos status` output for authenticated running state and verified
   stopped state without invoking the runtime CLI.
+- A selected `aos distro apply --principal P --yes` path that verifies the
+  bundled Distro.toml, Distro.lock, and Distro.sig with Astrid 0.10.4's signed
+  lock algorithm, seeds the runtime trust pin, confirms a volume-only stop, and
+  records an AOS-owned activation receipt.
 - An opt-in daily nightly train with deterministic run-dated versions, exact
   Astrid compatibility pins, protected publication and promotion, and
   idempotent recovery after interrupted release or pointer updates. It is
@@ -106,9 +110,8 @@
 - Bootstrap the default CE system fleet through Astrid's canonical distro
   installer before the daemon-backed authorization pass, allowing a completely
   fresh AOS home and non-default targets to use the same runtime trust path.
-- Keep the authenticated init operator separate from its target principal,
-  prevent AOS distribution replacement, and fail closed while signed direct
-  update channels remain unpublished.
+- Keep the authenticated init operator separate from its target principal and
+  fail closed while signed direct update channels remain unpublished.
 - Require explicit machine-readable runtime-compatibility and upgrade/self-heal
   approvals before the tag-triggered workflow can package or publish a release,
   backed by a packaged migration/reinstall test over the frozen 2026-07-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,10 @@
 - Native `aos status` output for authenticated running state and verified
   stopped state without invoking the runtime CLI.
 - A selected `aos distro apply --principal P --yes` path that verifies the
-  bundled Distro.toml, Distro.lock, and Distro.sig with Astrid 0.10.4's signed
-  lock algorithm, seeds the runtime trust pin, confirms a volume-only stop, and
-  records an AOS-owned activation receipt.
+  authenticated release inventory and bundled Distro.toml, Distro.lock, and
+  Distro.sig with Astrid 0.10.4's signed lock algorithm, seeds the runtime trust
+  pin, requires an exact non-empty private volume-only stop, and records an
+  AOS-owned activation receipt.
 - An opt-in daily nightly train with deterministic run-dated versions, exact
   Astrid compatibility pins, protected publication and promotion, and
   idempotent recovery after interrupted release or pointer updates. It is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,6 +1873,7 @@ name = "unicity-aos-bootstrap"
 version = "2026.9.0"
 dependencies = [
  "astrid-core",
+ "astrid-crypto",
  "astrid-types 0.10.4",
  "astrid-uplink",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ license = "MIT OR Apache-2.0"
 [workspace.dependencies]
 astrid-sdk = { version = "=0.7.1", features = ["derive"] }
 astrid-core = "=0.10.4"
+astrid-crypto = "=0.10.4"
 astrid-types = { version = "=0.10.4", features = ["clock"] }
 astrid-uplink = "=0.10.4"
 axum = "0.8"

--- a/crates/unicity-aos-bootstrap/Cargo.toml
+++ b/crates/unicity-aos-bootstrap/Cargo.toml
@@ -7,6 +7,7 @@ description = "Product-owned runtime layout and launcher for Unicity AOS."
 
 [dependencies]
 astrid-core.workspace = true
+astrid-crypto.workspace = true
 astrid-types.workspace = true
 astrid-uplink.workspace = true
 axum.workspace = true

--- a/crates/unicity-aos-bootstrap/src/distro_trust.rs
+++ b/crates/unicity-aos-bootstrap/src/distro_trust.rs
@@ -1,0 +1,550 @@
+//! Verification and receipt helpers for the bundled Unicity CE distro.
+//!
+//! The release directory is the package boundary for Distro Apply.  The
+//! manifest, lock, and signature are consumed only from that selected path;
+//! callers cannot substitute another manifest or opt into Astrid's unsigned
+//! trust bypasses.
+
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use astrid_crypto::{PublicKey, Signature};
+use serde::{Deserialize, Serialize};
+use unicity_aos_bootstrap::AosHome;
+
+pub(crate) const SELECTED_DISTRO_ID: &str = "unicity-ce";
+pub(crate) const ASTRID_RUNTIME_VERSION: &str = "0.10.4";
+const SIG_DOMAIN_TAG: &[u8] = b"astrid-distro-lock-sig-v1\x00";
+const RECEIPT_SCHEMA_VERSION: u32 = 1;
+const RECEIPT_KIND: &str = "aos-distro-apply-active-v1";
+
+#[derive(Debug, Clone)]
+pub(crate) struct VerifiedDistro {
+    pub(crate) manifest_path: PathBuf,
+    pub(crate) distro_id: String,
+    pub(crate) distro_version: String,
+    pub(crate) manifest_blake3: String,
+    pub(crate) signing_pubkey: String,
+    pub(crate) lock_blake3: String,
+    pub(crate) signature_blake3: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct DistroLock {
+    schema_version: u32,
+    distro: DistroLockMeta,
+    #[serde(default, rename = "capsule")]
+    capsules: Vec<LockedCapsule>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    manifest_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct DistroLockMeta {
+    id: String,
+    version: String,
+    resolved_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LockedCapsule {
+    name: String,
+    version: String,
+    source: String,
+    hash: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    resolved_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ActiveReceipt {
+    schema: u32,
+    kind: String,
+    active: bool,
+    cutover_complete: bool,
+    distro_id: String,
+    distro_version: String,
+    manifest_blake3: String,
+    signing_pubkey: String,
+    pin_blake3: String,
+    lock_blake3: String,
+    signature_blake3: String,
+    principal: String,
+    astrid_runtime_version: String,
+}
+
+/// Verify the exact release members used by the selected Distro Apply path.
+pub(crate) fn verify_selected_release(home: &AosHome) -> io::Result<VerifiedDistro> {
+    let release_dir = home.release_dir();
+    require_directory(&release_dir, "release directory")?;
+
+    let manifest_path = release_dir.join("Distro.toml");
+    let lock_path = release_dir.join("Distro.lock");
+    let signature_path = release_dir.join("Distro.sig");
+    require_private_release_file(&manifest_path, "bundled Distro.toml")?;
+    require_private_release_file(&lock_path, "bundled Distro.lock")?;
+    require_private_release_file(&signature_path, "bundled Distro.sig")?;
+
+    let manifest_bytes = fs::read(&manifest_path)?;
+    let manifest_text = std::str::from_utf8(&manifest_bytes).map_err(|error| {
+        invalid_data(format!("bundled Distro.toml is not valid UTF-8: {error}"))
+    })?;
+    let manifest: toml::Value = toml::from_str(manifest_text)
+        .map_err(|error| invalid_data(format!("failed to parse bundled Distro.toml: {error}")))?;
+    let schema_version = manifest
+        .get("schema-version")
+        .and_then(toml::Value::as_integer)
+        .and_then(|value| u32::try_from(value).ok())
+        .ok_or_else(|| invalid_data("Distro.toml is missing integer schema-version"))?;
+    let distro = table(&manifest, "distro", "bundled Distro.toml")?;
+    if schema_version != 1 {
+        return Err(invalid_data(format!(
+            "unsupported bundled Distro.toml schema-version {schema_version}"
+        )));
+    }
+    let distro_id = required_string(distro, "id", "Distro.toml [distro]")?;
+    if distro_id != SELECTED_DISTRO_ID {
+        return Err(invalid_data(format!(
+            "bundled distro id must be {SELECTED_DISTRO_ID:?}, got {distro_id:?}"
+        )));
+    }
+    let distro_version = required_string(distro, "version", "Distro.toml [distro]")?;
+    if distro_version != env!("CARGO_PKG_VERSION") {
+        return Err(invalid_data(format!(
+            "bundled distro version {distro_version:?} does not match AOS release {}",
+            env!("CARGO_PKG_VERSION")
+        )));
+    }
+    let astrid_version = required_string(distro, "astrid-version", "Distro.toml [distro]")?;
+    if astrid_version != format!("={ASTRID_RUNTIME_VERSION}") {
+        return Err(invalid_data(format!(
+            "bundled distro requires Astrid {astrid_version:?}, expected ={ASTRID_RUNTIME_VERSION}"
+        )));
+    }
+    let signing = distro
+        .get("signing")
+        .and_then(toml::Value::as_table)
+        .ok_or_else(|| invalid_data("bundled Distro.toml is missing [distro.signing]"))?;
+    let signing_pubkey = required_string(signing, "pubkey", "Distro.toml [distro.signing]")?;
+    let public_key = parse_public_key(&signing_pubkey)?;
+    let canonical_pubkey = format!("ed25519:{}", public_key.to_base64());
+    if signing_pubkey != canonical_pubkey {
+        return Err(invalid_data(
+            "bundled Distro.toml signing pubkey is not canonical ed25519 wire form",
+        ));
+    }
+
+    let lock_bytes = fs::read(&lock_path)?;
+    let lock_text = std::str::from_utf8(&lock_bytes).map_err(|error| {
+        invalid_data(format!("bundled Distro.lock is not valid UTF-8: {error}"))
+    })?;
+    let lock: DistroLock = toml::from_str(lock_text)
+        .map_err(|error| invalid_data(format!("failed to parse bundled Distro.lock: {error}")))?;
+    if lock.schema_version != schema_version {
+        return Err(invalid_data(format!(
+            "Distro.lock schema-version {} does not match Distro.toml {schema_version}",
+            lock.schema_version
+        )));
+    }
+    if lock.distro.id != distro_id || lock.distro.version != distro_version {
+        return Err(invalid_data(
+            "Distro.lock identity does not match bundled Distro.toml",
+        ));
+    }
+    let manifest_blake3 = format!("blake3:{}", blake3::hash(&manifest_bytes).to_hex());
+    if lock.manifest_hash.as_deref() != Some(manifest_blake3.as_str()) {
+        return Err(invalid_data(
+            "Distro.lock manifest-hash does not bind the exact bundled Distro.toml bytes",
+        ));
+    }
+
+    let canonical_lock = serde_json::to_vec(&lock).map_err(|error| {
+        invalid_data(format!(
+            "failed to canonicalize bundled Distro.lock: {error}"
+        ))
+    })?;
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(SIG_DOMAIN_TAG);
+    hasher.update(&canonical_lock);
+    let signing_digest = hasher.finalize();
+    let signature_text = fs::read_to_string(&signature_path)?;
+    let signature = Signature::from_hex(signature_text.trim()).map_err(|error| {
+        invalid_data(format!(
+            "malformed bundled Distro.sig (expected 64-byte hex): {error}"
+        ))
+    })?;
+    public_key
+        .verify(signing_digest.as_bytes(), &signature)
+        .map_err(|_| {
+            invalid_data("bundled Distro.sig does not verify against Distro.lock and pubkey")
+        })?;
+
+    verify_release_inventory(
+        &release_dir,
+        &manifest_bytes,
+        &lock_bytes,
+        signature_text.as_bytes(),
+    )?;
+
+    Ok(VerifiedDistro {
+        manifest_path,
+        distro_id,
+        distro_version,
+        manifest_blake3,
+        signing_pubkey,
+        lock_blake3: format!("blake3:{}", blake3::hash(&lock_bytes).to_hex()),
+        signature_blake3: format!(
+            "blake3:{}",
+            blake3::hash(signature_text.as_bytes()).to_hex()
+        ),
+    })
+}
+
+/// Seed the runtime trust file with the already-verified package key.
+pub(crate) fn seed_runtime_trust(home: &AosHome, signing_pubkey: &str) -> io::Result<()> {
+    let trust_dir = home.runtime_home().join("trust");
+    ensure_private_directory(&trust_dir)?;
+    let trust_path = trust_dir.join(format!("{SELECTED_DISTRO_ID}.pub"));
+    match fs::symlink_metadata(&trust_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => Err(
+            invalid_data("runtime distro trust pin must be a regular file"),
+        ),
+        Ok(_) => {
+            let metadata = fs::metadata(&trust_path)?;
+            require_private_mode(&metadata, "runtime distro trust pin")?;
+            let existing = fs::read_to_string(&trust_path)?;
+            if existing.trim() == signing_pubkey {
+                Ok(())
+            } else {
+                Err(invalid_data(
+                    "runtime distro trust pin does not match bundled Distro.toml",
+                ))
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            write_private_atomic(&trust_path, format!("{signing_pubkey}\n").as_bytes())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Refuse to dispatch when an existing receipt binds another apply.
+pub(crate) fn check_existing_receipt(
+    home: &AosHome,
+    distro: &VerifiedDistro,
+    principal: &str,
+) -> io::Result<()> {
+    let path = receipt_path(home);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(invalid_data(
+            "AOS Distro Apply receipt must be a regular file",
+        ));
+    }
+    require_private_mode(&metadata, "AOS Distro Apply receipt")?;
+    let bytes = fs::read(&path)?;
+    let receipt: ActiveReceipt = serde_json::from_slice(&bytes).map_err(|error| {
+        invalid_data(format!("AOS Distro Apply receipt is invalid JSON: {error}"))
+    })?;
+    if receipt.schema != RECEIPT_SCHEMA_VERSION
+        || receipt.kind != RECEIPT_KIND
+        || !receipt.active
+        || !receipt.cutover_complete
+        || receipt.distro_id != distro.distro_id
+        || receipt.distro_version != distro.distro_version
+        || receipt.manifest_blake3 != distro.manifest_blake3
+        || receipt.signing_pubkey != distro.signing_pubkey
+        || receipt.pin_blake3 != blake3::hash(distro.signing_pubkey.as_bytes()).to_string()
+        || receipt.lock_blake3 != distro.lock_blake3
+        || receipt.signature_blake3 != distro.signature_blake3
+        || receipt.principal != principal
+        || receipt.astrid_runtime_version != ASTRID_RUNTIME_VERSION
+    {
+        return Err(invalid_data(
+            "existing AOS Distro Apply receipt does not match the selected distro, key, or principal",
+        ));
+    }
+    Ok(())
+}
+
+/// Write the success receipt after exact stop confirmation.
+pub(crate) fn write_active_receipt(
+    home: &AosHome,
+    distro: &VerifiedDistro,
+    principal: &str,
+) -> io::Result<()> {
+    let receipts_dir = home.root().join("receipts");
+    ensure_private_directory(&receipts_dir)?;
+    let receipt = ActiveReceipt {
+        schema: RECEIPT_SCHEMA_VERSION,
+        kind: RECEIPT_KIND.to_owned(),
+        active: true,
+        cutover_complete: true,
+        distro_id: distro.distro_id.clone(),
+        distro_version: distro.distro_version.clone(),
+        manifest_blake3: distro.manifest_blake3.clone(),
+        signing_pubkey: distro.signing_pubkey.clone(),
+        pin_blake3: blake3::hash(distro.signing_pubkey.as_bytes()).to_string(),
+        lock_blake3: distro.lock_blake3.clone(),
+        signature_blake3: distro.signature_blake3.clone(),
+        principal: principal.to_owned(),
+        astrid_runtime_version: ASTRID_RUNTIME_VERSION.to_owned(),
+    };
+    let bytes = serde_json::to_vec_pretty(&receipt).map_err(|error| {
+        invalid_data(format!(
+            "failed to encode AOS Distro Apply receipt: {error}"
+        ))
+    })?;
+    let path = receipts_dir.join(format!("{SELECTED_DISTRO_ID}.active.json"));
+    write_private_atomic(&path, &bytes)
+}
+
+fn receipt_path(home: &AosHome) -> PathBuf {
+    home.root()
+        .join("receipts")
+        .join(format!("{SELECTED_DISTRO_ID}.active.json"))
+}
+
+fn verify_release_inventory(
+    release_dir: &Path,
+    manifest_bytes: &[u8],
+    lock_bytes: &[u8],
+    signature_bytes: &[u8],
+) -> io::Result<()> {
+    let path = release_dir.join("release-manifest.json");
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(invalid_data("release-manifest.json must be a regular file"));
+    }
+    require_private_mode(&metadata, "release-manifest.json")?;
+    let bytes = fs::read(&path)?;
+    let manifest: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|error| invalid_data(format!("release-manifest.json is invalid JSON: {error}")))?;
+    let files = manifest
+        .get("release_files")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| invalid_data("release-manifest.json is missing release_files"))?;
+    for (name, contents) in [
+        ("Distro.toml", manifest_bytes),
+        ("Distro.lock", lock_bytes),
+        ("Distro.sig", signature_bytes),
+    ] {
+        let entry = files
+            .get(name)
+            .and_then(serde_json::Value::as_object)
+            .ok_or_else(|| invalid_data(format!("release-manifest.json is missing {name}")))?;
+        let expected = format!("blake3:{}", blake3::hash(contents).to_hex());
+        let declared = entry
+            .get("blake3")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| invalid_data(format!("release-manifest.json has no {name} digest")))?;
+        if declared != expected.strip_prefix("blake3:").unwrap_or(&expected) && declared != expected
+        {
+            return Err(invalid_data(format!(
+                "release-manifest.json digest does not match {name}"
+            )));
+        }
+        if entry.get("mode").and_then(serde_json::Value::as_u64) != Some(0o600) {
+            return Err(invalid_data(format!(
+                "release-manifest.json requires private mode 0600 for {name}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn parse_public_key(wire: &str) -> io::Result<PublicKey> {
+    let encoded = wire.strip_prefix("ed25519:").ok_or_else(|| {
+        invalid_data("bundled Distro.toml signing pubkey must use ed25519:<base64> wire form")
+    })?;
+    PublicKey::from_base64(encoded).map_err(|error| {
+        invalid_data(format!(
+            "invalid bundled Distro.toml signing pubkey: {error}"
+        ))
+    })
+}
+
+fn table<'a>(
+    value: &'a toml::Value,
+    key: &str,
+    context: &str,
+) -> io::Result<&'a toml::map::Map<String, toml::Value>> {
+    value
+        .get(key)
+        .and_then(toml::Value::as_table)
+        .ok_or_else(|| invalid_data(format!("{context} is missing [{key}]")))
+}
+
+fn required_string(
+    table: &toml::map::Map<String, toml::Value>,
+    key: &str,
+    context: &str,
+) -> io::Result<String> {
+    table
+        .get(key)
+        .and_then(toml::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| invalid_data(format!("{context} is missing non-empty {key}")))
+}
+
+fn require_directory(path: &Path, label: &str) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            invalid_data(format!("{label} is missing at {}", path.display()))
+        } else {
+            error
+        }
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(invalid_data(format!(
+            "{label} must be a real directory at {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn require_regular_file(path: &Path, label: &str) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            invalid_data(format!("{label} is missing at {}", path.display()))
+        } else {
+            error
+        }
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(invalid_data(format!(
+            "{label} must be a regular file at {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn require_private_release_file(path: &Path, label: &str) -> io::Result<()> {
+    require_regular_file(path, label)?;
+    let metadata = fs::metadata(path)?;
+    require_private_mode(&metadata, label)
+}
+
+fn require_private_mode(metadata: &fs::Metadata, label: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = metadata.permissions().mode() & 0o7777;
+        if mode != 0o600 {
+            return Err(invalid_data(format!(
+                "{label} must use private mode 0600 (found {mode:o})"
+            )));
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = (metadata, label);
+    Ok(())
+}
+
+fn ensure_private_directory(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(invalid_data(format!(
+                "private directory must be a real directory at {}",
+                path.display()
+            )));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => fs::create_dir_all(path)?,
+        Err(error) => return Err(error),
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(path)?.permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(path, permissions)?;
+    }
+    Ok(())
+}
+
+fn write_private_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| invalid_data("private file has no parent directory"))?;
+    ensure_private_directory(parent)?;
+    if let Ok(metadata) = fs::symlink_metadata(path)
+        && (metadata.file_type().is_symlink() || !metadata.is_file())
+    {
+        return Err(invalid_data(format!(
+            "private file must be a regular file at {}",
+            path.display()
+        )));
+    }
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| invalid_data("private file name is not valid UTF-8"))?;
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let temporary = parent.join(format!(".{name}.tmp-{}-{nonce}", std::process::id()));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = file.metadata()?.permissions();
+        permissions.set_mode(0o600);
+        file.set_permissions(permissions)?;
+    }
+    if let Err(error) = file.write_all(bytes).and_then(|()| file.sync_all()) {
+        drop(file);
+        let _ = fs::remove_file(&temporary);
+        return Err(error);
+    }
+    drop(file);
+    if let Ok(metadata) = fs::symlink_metadata(path)
+        && (metadata.file_type().is_symlink() || !metadata.is_file())
+    {
+        let _ = fs::remove_file(&temporary);
+        return Err(invalid_data(format!(
+            "private file must be a regular file at {}",
+            path.display()
+        )));
+    }
+    if let Err(error) = fs::rename(&temporary, path) {
+        #[cfg(windows)]
+        if error.kind() == io::ErrorKind::AlreadyExists {
+            if let Err(remove_error) = fs::remove_file(path) {
+                let _ = fs::remove_file(&temporary);
+                return Err(remove_error);
+            }
+            if let Err(rename_error) = fs::rename(&temporary, path) {
+                let _ = fs::remove_file(&temporary);
+                return Err(rename_error);
+            }
+            return Ok(());
+        }
+        let _ = fs::remove_file(&temporary);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}

--- a/crates/unicity-aos-bootstrap/src/distro_trust.rs
+++ b/crates/unicity-aos-bootstrap/src/distro_trust.rs
@@ -5,6 +5,7 @@
 //! callers cannot substitute another manifest or opt into Astrid's unsigned
 //! trust bypasses.
 
+use std::ffi::OsStr;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -307,6 +308,35 @@ pub(crate) fn write_active_receipt(
     write_private_atomic(&path, &bytes)
 }
 
+/// Require the materialized runtime state produced by a successful Distro Apply.
+///
+/// Generic stopped-state confirmation preserves an empty or absent runtime home
+/// for a fresh installation.  Distro Apply is stricter: a successful apply must
+/// leave exactly one non-empty private volume before its activation receipt is
+/// written.
+pub(crate) fn require_stopped_volume(home: &AosHome) -> io::Result<()> {
+    let runtime = home.runtime_home();
+    require_directory(&runtime, "stopped runtime state")?;
+    for entry in fs::read_dir(&runtime)? {
+        let entry = entry?;
+        if entry.file_name() != OsStr::new("astrid.volume") {
+            return Err(invalid_data(
+                "stopped runtime state must contain only astrid.volume",
+            ));
+        }
+    }
+
+    let volume = runtime.join("astrid.volume");
+    require_regular_file(&volume, "stopped runtime astrid.volume")?;
+    let metadata = fs::metadata(&volume)?;
+    if metadata.len() == 0 {
+        return Err(invalid_data(
+            "stopped runtime astrid.volume must not be empty",
+        ));
+    }
+    require_private_mode(&metadata, "stopped runtime astrid.volume")
+}
+
 fn receipt_path(home: &AosHome) -> PathBuf {
     home.root()
         .join("receipts")
@@ -320,14 +350,8 @@ fn verify_release_inventory(
     signature_bytes: &[u8],
 ) -> io::Result<()> {
     let path = release_dir.join("release-manifest.json");
-    let metadata = match fs::symlink_metadata(&path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(error),
-    };
-    if metadata.file_type().is_symlink() || !metadata.is_file() {
-        return Err(invalid_data("release-manifest.json must be a regular file"));
-    }
+    require_regular_file(&path, "release-manifest.json")?;
+    let metadata = fs::metadata(&path)?;
     require_private_mode(&metadata, "release-manifest.json")?;
     let bytes = fs::read(&path)?;
     let manifest: serde_json::Value = serde_json::from_slice(&bytes)

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -934,6 +934,10 @@ fn handle_distro_apply(leading_principal: Option<String>, args: DistroApplyArgs)
         eprintln!("aos: Distro Apply shutdown failed: {error}");
         return ExitCode::FAILURE;
     }
+    if let Err(error) = distro_trust::require_stopped_volume(&home) {
+        eprintln!("aos: Distro Apply stopped without a required volume: {error}");
+        return ExitCode::FAILURE;
+    }
     if let Err(error) = distro_trust::write_active_receipt(&home, &verified, principal.as_str()) {
         eprintln!("aos: Distro Apply succeeded but receipt write failed: {error}");
         return ExitCode::FAILURE;

--- a/crates/unicity-aos-bootstrap/src/main.rs
+++ b/crates/unicity-aos-bootstrap/src/main.rs
@@ -15,6 +15,7 @@ use astrid_core::PrincipalId;
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use unicity_aos_bootstrap::{AOS_WORKSPACE_STATE_DIR, AosHome};
 
+mod distro_trust;
 mod hook;
 mod mcp;
 
@@ -54,8 +55,11 @@ enum ProductCommand {
     /// Update AOS and its coordinated runtime executable set.
     #[command(name = "update", alias = "self-update", alias = "self_update")]
     Update(UpdateArgs),
-    /// Distribution state is fixed to Unicity CE in this AOS release.
-    Distro(DistroArgs),
+    /// Apply the signed Unicity CE distribution bundled with this AOS release.
+    Distro {
+        #[command(subcommand)]
+        command: DistroCommand,
+    },
     /// Deliver a host hook through the authenticated AOS event bus.
     Hook(hook::HookArgs),
     /// Expose this AOS installation to an MCP host over stdio.
@@ -94,11 +98,30 @@ enum McpCommand {
     Serve(mcp::ServeArgs),
 }
 
+#[derive(Subcommand)]
+enum DistroCommand {
+    /// Apply the selected bundled Unicity CE distribution.
+    Apply(DistroApplyArgs),
+}
+
 #[derive(Args)]
-struct DistroArgs {
-    /// Runtime distribution arguments retained only to provide a safe refusal.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    arguments: Vec<OsString>,
+struct DistroApplyArgs {
+    /// Authenticated runtime principal for this apply.
+    #[arg(
+        long,
+        value_name = "PRINCIPAL",
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
+    principal: Option<String>,
+    /// Confirm this non-interactive apply.
+    #[arg(short = 'y', long)]
+    yes: bool,
+    /// Keep Astrid's resolver offline.
+    #[arg(long)]
+    offline: bool,
+    /// Variable forwarded to Astrid's distro apply.
+    #[arg(long = "var", value_name = "KEY=VALUE")]
+    vars: Vec<String>,
 }
 
 #[derive(Args)]
@@ -324,7 +347,7 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
             &cli.command,
             Some(
                 ProductCommand::Init(_)
-                    | ProductCommand::Distro(_)
+                    | ProductCommand::Distro { .. }
                     | ProductCommand::Hook(_)
                     | ProductCommand::Mcp { .. }
                     | ProductCommand::Status(_)
@@ -346,7 +369,9 @@ fn handle_product_command(args: &[OsString]) -> Option<ExitCode> {
             command: MigrateCommand::Runtime { from },
         }) => Some(handle_migrate_runtime(&from)),
         Some(ProductCommand::Update(args)) => Some(handle_self_update(&args)),
-        Some(ProductCommand::Distro(args)) => Some(refuse_distro_command(&args.arguments)),
+        Some(ProductCommand::Distro {
+            command: DistroCommand::Apply(args),
+        }) => Some(handle_distro_apply(cli.principal, args)),
         Some(ProductCommand::Hook(args)) => Some(handle_hook(cli.principal, args)),
         Some(ProductCommand::Mcp {
             command: McpCommand::Serve(args),
@@ -780,12 +805,187 @@ fn handle_self_update(args: &UpdateArgs) -> ExitCode {
     command_exit_code(command.status(), "run the installed signed AOS updater")
 }
 
-fn refuse_distro_command(_arguments: &[OsString]) -> ExitCode {
-    eprintln!(
-        "aos: Unicity CE owns the distribution state for this AOS installation; `aos distro` cannot apply or replace it"
-    );
-    eprintln!("AOS does not expose raw distribution mutation beneath another command namespace.");
-    ExitCode::from(2)
+fn distro_principal(
+    leading_principal: Option<String>,
+    command_principal: Option<String>,
+) -> Result<PrincipalId, String> {
+    let principal = match (leading_principal, command_principal) {
+        (Some(_), Some(_)) => {
+            return Err(
+                "'--principal' was provided both before and after `distro apply`; provide it once"
+                    .to_owned(),
+            );
+        }
+        (Some(principal), None) | (None, Some(principal)) => principal,
+        (None, None) => {
+            return Err(
+                "`aos distro apply` requires an explicit '--principal PRINCIPAL'".to_owned(),
+            );
+        }
+    };
+    PrincipalId::new(principal).map_err(|error| format!("invalid distro apply principal: {error}"))
+}
+
+fn handle_distro_apply(leading_principal: Option<String>, args: DistroApplyArgs) -> ExitCode {
+    if !args.yes {
+        eprintln!("aos: `distro apply` requires '--yes' for non-interactive application");
+        return ExitCode::from(2);
+    }
+    let principal = match distro_principal(leading_principal, args.principal) {
+        Ok(principal) => principal,
+        Err(error) => {
+            eprintln!("aos: {error}");
+            return ExitCode::from(2);
+        }
+    };
+    let home = match resolve_home() {
+        Ok(home) => home,
+        Err(code) => return code,
+    };
+    let verified = match distro_trust::verify_selected_release(&home) {
+        Ok(verified) => verified,
+        Err(error) => {
+            eprintln!("aos: bundled Distro Apply verification failed: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if let Err(error) = distro_trust::check_existing_receipt(&home, &verified, principal.as_str()) {
+        eprintln!("aos: refusing Distro Apply before dispatch: {error}");
+        return ExitCode::FAILURE;
+    }
+
+    let start_result = home.run_runtime_with_args([OsStr::new("start")]);
+    let start_status = match start_result {
+        Ok(status) => Some(status),
+        Err(error) => {
+            eprintln!("aos: failed to start bundled runtime for Distro Apply: {error}");
+            None
+        }
+    };
+
+    let mut apply_code = ExitCode::FAILURE;
+    let mut apply_error = None;
+    if let Some(status) = start_status {
+        if !status.success() {
+            apply_code = child_exit_code(status);
+            apply_error = Some(format!(
+                "bundled runtime start exited with {}",
+                status.code().unwrap_or(1)
+            ));
+        } else if let Err(error) = distro_trust::seed_runtime_trust(&home, &verified.signing_pubkey)
+        {
+            apply_error = Some(format!("failed to seed runtime distro trust: {error}"));
+        } else {
+            let mut runtime_args = vec![
+                OsString::from("--principal"),
+                OsString::from(principal.as_str()),
+                OsString::from("distro"),
+                OsString::from("apply"),
+                OsString::from("--yes"),
+                verified.manifest_path.clone().into_os_string(),
+            ];
+            if args.offline {
+                runtime_args.push(OsString::from("--offline"));
+            }
+            for value in args.vars {
+                runtime_args.push(OsString::from("--var"));
+                runtime_args.push(OsString::from(value));
+            }
+            let output_result =
+                home.runtime_command_with_args(&runtime_args)
+                    .and_then(|mut command| {
+                        command.env("ASTRID_ENFORCED_DISTRO", &verified.manifest_path);
+                        command.output()
+                    });
+            match output_result {
+                Ok(output) => {
+                    apply_code = child_exit_code(output.status);
+                    if !output.status.success() {
+                        apply_error = Some(format!(
+                            "bundled Distro Apply exited with {}",
+                            output.status.code().unwrap_or(1)
+                        ));
+                    }
+                    if let Err(error) = emit_runtime_output(&output) {
+                        apply_code = ExitCode::FAILURE;
+                        apply_error = Some(format!(
+                            "failed to write bundled Distro Apply output: {error}"
+                        ));
+                    }
+                }
+                Err(error) => {
+                    apply_error = Some(format!("failed to run bundled Distro Apply: {error}"));
+                }
+            }
+        }
+    } else {
+        apply_error = Some("bundled runtime did not start for Distro Apply".to_owned());
+    }
+
+    let stop_error = stop_after_distro_apply(&home);
+    if let Some(error) = apply_error {
+        eprintln!("aos: Distro Apply failed: {error}");
+        if let Err(stop_error) = stop_error {
+            eprintln!("aos: Distro Apply shutdown failed: {stop_error}");
+        }
+        return apply_code;
+    }
+    if let Err(error) = stop_error {
+        eprintln!("aos: Distro Apply shutdown failed: {error}");
+        return ExitCode::FAILURE;
+    }
+    if let Err(error) = distro_trust::write_active_receipt(&home, &verified, principal.as_str()) {
+        eprintln!("aos: Distro Apply succeeded but receipt write failed: {error}");
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
+}
+
+fn stop_after_distro_apply(home: &AosHome) -> Result<(), String> {
+    let output_result = home
+        .runtime_command_with_args([OsStr::new("stop")])
+        .and_then(|mut command| command.output());
+    let confirmation = wait_for_confirmed_stop(home);
+    let output = match output_result {
+        Ok(output) => output,
+        Err(error) => {
+            if let Err(confirmation_error) = confirmation {
+                return Err(format!(
+                    "failed to run bundled runtime stop: {error}; {confirmation_error}"
+                ));
+            }
+            return Err(format!("failed to run bundled runtime stop: {error}"));
+        }
+    };
+    let expected_disconnect = expected_shutdown_disconnect(&output);
+    if confirmation.is_ok() && (output.status.success() || expected_disconnect) {
+        if expected_disconnect {
+            std::io::stdout()
+                .write_all(&output.stdout)
+                .map_err(|error| format!("failed to write bundled runtime output: {error}"))?;
+            if output.stdout.is_empty() {
+                println!("Unicity AOS stopped.");
+            }
+        } else {
+            emit_runtime_output(&output)
+                .map_err(|error| format!("failed to write bundled runtime output: {error}"))?;
+        }
+        return Ok(());
+    }
+
+    emit_runtime_output(&output)
+        .map_err(|error| format!("failed to write bundled runtime output: {error}"))?;
+    if let Err(error) = confirmation {
+        return Err(format!("shutdown confirmation failed: {error}"));
+    }
+    if output.status.success() {
+        Err("runtime stop exited successfully but stopped-state confirmation failed".to_owned())
+    } else {
+        Err(format!(
+            "bundled runtime stop exited with {}",
+            output.status.code().unwrap_or(1)
+        ))
+    }
 }
 
 fn command_exit_code(status: io::Result<std::process::ExitStatus>, operation: &str) -> ExitCode {
@@ -1043,9 +1243,9 @@ mod tests {
     use std::ffi::OsString;
 
     use super::{
-        DaemonCommand, ProductCli, ProductCommand, child_exit_code, handle_product_command,
-        help_targets_product, is_owned_root, leading_owned_root, runtime_args_for_dispatch,
-        runtime_stop_requested, status_principal,
+        DaemonCommand, DistroCommand, ProductCli, ProductCommand, child_exit_code,
+        distro_principal, handle_product_command, help_targets_product, is_owned_root,
+        leading_owned_root, runtime_args_for_dispatch, runtime_stop_requested, status_principal,
     };
 
     #[test]
@@ -1101,6 +1301,75 @@ mod tests {
             Some(std::path::Path::new("/workspace"))
         );
         assert!(args.verbose);
+    }
+
+    #[test]
+    fn product_cli_parses_only_the_selected_signed_distro_apply_surface() {
+        let cli = ProductCli::try_parse_from([
+            "aos",
+            "--principal",
+            "operator",
+            "distro",
+            "apply",
+            "--yes",
+            "--offline",
+            "--var",
+            "model=fixture",
+        ])
+        .expect("parse signed distro apply");
+        assert_eq!(cli.principal.as_deref(), Some("operator"));
+        let Some(ProductCommand::Distro {
+            command: DistroCommand::Apply(args),
+        }) = cli.command
+        else {
+            panic!("expected distro apply command");
+        };
+        assert!(args.yes);
+        assert!(args.offline);
+        assert_eq!(args.vars, ["model=fixture"]);
+        assert!(
+            ProductCli::try_parse_from([
+                "aos",
+                "distro",
+                "apply",
+                "--principal",
+                "operator",
+                "--yes",
+                "--accept-new-key",
+            ])
+            .is_err()
+        );
+        assert!(
+            ProductCli::try_parse_from([
+                "aos",
+                "distro",
+                "apply",
+                "--principal",
+                "operator",
+                "--yes",
+                "/tmp/other.toml",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn distro_apply_principal_is_explicit_and_validated() {
+        assert_eq!(
+            distro_principal(Some("operator".to_owned()), None)
+                .expect("leading principal")
+                .as_str(),
+            "operator"
+        );
+        assert_eq!(
+            distro_principal(None, Some("operator".to_owned()))
+                .expect("command principal")
+                .as_str(),
+            "operator"
+        );
+        assert!(distro_principal(None, None).is_err());
+        assert!(distro_principal(Some("operator".to_owned()), Some("other".to_owned())).is_err());
+        assert!(distro_principal(None, Some("not/a/principal".to_owned())).is_err());
     }
 
     #[test]

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -82,8 +82,10 @@ impl Fixture {
         let signing_pubkey = format!("ed25519:{}", keypair.export_public_key().to_base64());
         let embedded = include_str!("../../../distros/community/unicity-ce/Distro.toml");
         let original_pubkey = "ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA=";
-        let manifest = embedded.replace(original_pubkey, &signing_pubkey);
-        let manifest_hash = format!("blake3:{}", blake3::hash(manifest.as_bytes()).to_hex());
+        let manifest_bytes = embedded
+            .replace(original_pubkey, &signing_pubkey)
+            .into_bytes();
+        let manifest_hash = format!("blake3:{}", blake3::hash(&manifest_bytes).to_hex());
         let lock = FixtureLock {
             schema_version: 1,
             distro: FixtureLockMeta {
@@ -102,12 +104,40 @@ impl Fixture {
         hasher.update(b"astrid-distro-lock-sig-v1\0");
         hasher.update(&canonical_lock);
         let signature = keypair.sign(hasher.finalize().as_bytes()).to_hex();
+        let signature_bytes = format!("{signature}\n").into_bytes();
         let release = self.release_dir();
-        fs::write(release.join("Distro.toml"), manifest).expect("write fixture Distro.toml");
-        fs::write(release.join("Distro.lock"), lock_bytes).expect("write fixture Distro.lock");
-        fs::write(release.join("Distro.sig"), format!("{signature}\n"))
-            .expect("write fixture Distro.sig");
-        for name in ["Distro.toml", "Distro.lock", "Distro.sig"] {
+        fs::write(release.join("Distro.toml"), &manifest_bytes).expect("write fixture Distro.toml");
+        fs::write(release.join("Distro.lock"), &lock_bytes).expect("write fixture Distro.lock");
+        fs::write(release.join("Distro.sig"), &signature_bytes).expect("write fixture Distro.sig");
+        let release_manifest = serde_json::json!({
+            "release_files": {
+                "Distro.toml": {
+                    "blake3": blake3::hash(&manifest_bytes).to_hex().to_string(),
+                    "mode": 384,
+                },
+                "Distro.lock": {
+                    "blake3": blake3::hash(&lock_bytes).to_hex().to_string(),
+                    "mode": 384,
+                },
+                "Distro.sig": {
+                    "blake3": blake3::hash(&signature_bytes).to_hex().to_string(),
+                    "mode": 384,
+                },
+            },
+        });
+        let release_manifest_bytes = serde_json::to_vec_pretty(&release_manifest)
+            .expect("serialize fixture release manifest");
+        fs::write(
+            release.join("release-manifest.json"),
+            release_manifest_bytes,
+        )
+        .expect("write fixture release manifest");
+        for name in [
+            "Distro.toml",
+            "Distro.lock",
+            "Distro.sig",
+            "release-manifest.json",
+        ] {
             let path = release.join(name);
             let mut permissions = fs::metadata(&path)
                 .expect("inspect fixture distro member")
@@ -211,8 +241,22 @@ elif [ "$1" = "stop" ]; then
     else
         find "$ASTRID_HOME" -mindepth 1 -maxdepth 1 ! -name astrid.volume -exec rm -rf {} +
     fi
-    printf 'volume-state\n' > "$ASTRID_HOME/astrid.volume"
-    chmod 600 "$ASTRID_HOME/astrid.volume"
+    case "${AOS_TEST_STOP_VOLUME:-present}" in
+        absent)
+            rm -f "$ASTRID_HOME/astrid.volume"
+            ;;
+        empty)
+            : > "$ASTRID_HOME/astrid.volume"
+            chmod 600 "$ASTRID_HOME/astrid.volume"
+            ;;
+        *)
+            printf 'volume-state\n' > "$ASTRID_HOME/astrid.volume"
+            chmod 600 "$ASTRID_HOME/astrid.volume"
+            ;;
+    esac
+    if [ "${AOS_TEST_REMOVE_RUNTIME:-0}" = "1" ]; then
+        rm -rf "$ASTRID_HOME"
+    fi
     exit "${AOS_TEST_EXIT:-0}"
 elif [ "$1" = "--principal" ] && [ "$2" = "default" ] && [ "$3" = "init" ]; then
     output="$AOS_TEST_BOOTSTRAP_ARGS"
@@ -1285,6 +1329,43 @@ fn signed_distro_apply_requires_the_bundled_signature_before_start() {
 }
 
 #[test]
+fn signed_distro_apply_requires_the_bundled_lock_before_start() {
+    let fixture = Fixture::new("distro-apply-missing-lock");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+    fs::remove_file(fixture.release_dir().join("Distro.lock")).expect("remove fixture lock");
+
+    let output = fixture
+        .command()
+        .args(["distro", "apply", "--principal", "operator", "--yes"])
+        .output()
+        .expect("run lockless distro apply");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Distro.lock"));
+    assert!(!fixture.root.join("start-args").exists());
+    assert!(!fixture.root.join("apply-args").exists());
+}
+
+#[test]
+fn signed_distro_apply_requires_the_release_inventory_before_start() {
+    let fixture = Fixture::new("distro-apply-missing-release-manifest");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+    fs::remove_file(fixture.release_dir().join("release-manifest.json"))
+        .expect("remove fixture release manifest");
+
+    let output = fixture
+        .command()
+        .args(["distro", "apply", "--principal", "operator", "--yes"])
+        .output()
+        .expect("run manifestless distro apply");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("release-manifest.json"));
+    assert!(!fixture.root.join("start-args").exists());
+    assert!(!fixture.root.join("apply-args").exists());
+}
+
+#[test]
 fn failed_distro_apply_still_stops_and_does_not_write_a_receipt() {
     let fixture = Fixture::new("distro-apply-failure");
     fixture.install_runtime(RECORDING_RUNTIME);
@@ -1308,6 +1389,84 @@ fn failed_distro_apply_still_stops_and_does_not_write_a_receipt() {
             .exists()
     );
     assert!(!fixture.home.join("runtime/trust").exists());
+}
+
+#[test]
+fn successful_distro_apply_without_a_runtime_writes_no_receipt() {
+    let fixture = Fixture::new("distro-apply-absent-runtime");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+
+    let output = fixture
+        .command()
+        .env("AOS_TEST_REMOVE_RUNTIME", "1")
+        .args(["distro", "apply", "--principal", "operator", "--yes"])
+        .output()
+        .expect("run distro apply without runtime materialization");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("required volume"));
+    assert!(fixture.root.join("start-args").exists());
+    assert!(fixture.root.join("apply-args").exists());
+    assert!(fixture.root.join("stop-args").exists());
+    assert!(
+        !fixture
+            .home
+            .join("receipts")
+            .join("unicity-ce.active.json")
+            .exists()
+    );
+}
+
+#[test]
+fn successful_distro_apply_without_a_volume_writes_no_receipt() {
+    let fixture = Fixture::new("distro-apply-missing-volume");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+
+    let output = fixture
+        .command()
+        .env("AOS_TEST_STOP_VOLUME", "absent")
+        .args(["distro", "apply", "--principal", "operator", "--yes"])
+        .output()
+        .expect("run distro apply without a volume");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("required volume"));
+    assert!(fixture.root.join("start-args").exists());
+    assert!(fixture.root.join("apply-args").exists());
+    assert!(fixture.root.join("stop-args").exists());
+    assert!(
+        !fixture
+            .home
+            .join("receipts")
+            .join("unicity-ce.active.json")
+            .exists()
+    );
+}
+
+#[test]
+fn successful_distro_apply_with_an_empty_volume_writes_no_receipt() {
+    let fixture = Fixture::new("distro-apply-empty-volume");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+
+    let output = fixture
+        .command()
+        .env("AOS_TEST_STOP_VOLUME", "empty")
+        .args(["distro", "apply", "--principal", "operator", "--yes"])
+        .output()
+        .expect("run distro apply with an empty volume");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("shutdown"));
+    assert!(fixture.root.join("start-args").exists());
+    assert!(fixture.root.join("apply-args").exists());
+    assert!(fixture.root.join("stop-args").exists());
+    assert!(
+        !fixture
+            .home
+            .join("receipts")
+            .join("unicity-ce.active.json")
+            .exists()
+    );
 }
 
 #[test]

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -9,6 +9,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use astrid_crypto::KeyPair;
+use serde::Serialize;
+
 struct Fixture {
     root: PathBuf,
     runtime: PathBuf,
@@ -70,6 +73,50 @@ impl Fixture {
             .join("capsules")
     }
 
+    fn release_dir(&self) -> PathBuf {
+        self.home.join("releases").join(env!("CARGO_PKG_VERSION"))
+    }
+
+    fn install_signed_distro(&self) {
+        let keypair = KeyPair::from_secret_key(&[7_u8; 32]).expect("fixture signing key");
+        let signing_pubkey = format!("ed25519:{}", keypair.export_public_key().to_base64());
+        let embedded = include_str!("../../../distros/community/unicity-ce/Distro.toml");
+        let original_pubkey = "ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA=";
+        let manifest = embedded.replace(original_pubkey, &signing_pubkey);
+        let manifest_hash = format!("blake3:{}", blake3::hash(manifest.as_bytes()).to_hex());
+        let lock = FixtureLock {
+            schema_version: 1,
+            distro: FixtureLockMeta {
+                id: "unicity-ce".to_owned(),
+                version: env!("CARGO_PKG_VERSION").to_owned(),
+                resolved_at: "2026-01-01T00:00:00Z".to_owned(),
+            },
+            capsules: Vec::new(),
+            manifest_hash: Some(manifest_hash),
+        };
+        let lock_bytes = toml::to_string_pretty(&lock)
+            .expect("serialize fixture Distro.lock")
+            .into_bytes();
+        let canonical_lock = serde_json::to_vec(&lock).expect("canonicalize fixture Distro.lock");
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"astrid-distro-lock-sig-v1\0");
+        hasher.update(&canonical_lock);
+        let signature = keypair.sign(hasher.finalize().as_bytes()).to_hex();
+        let release = self.release_dir();
+        fs::write(release.join("Distro.toml"), manifest).expect("write fixture Distro.toml");
+        fs::write(release.join("Distro.lock"), lock_bytes).expect("write fixture Distro.lock");
+        fs::write(release.join("Distro.sig"), format!("{signature}\n"))
+            .expect("write fixture Distro.sig");
+        for name in ["Distro.toml", "Distro.lock", "Distro.sig"] {
+            let path = release.join(name);
+            let mut permissions = fs::metadata(&path)
+                .expect("inspect fixture distro member")
+                .permissions();
+            permissions.set_mode(0o600);
+            fs::set_permissions(path, permissions).expect("make fixture distro member private");
+        }
+    }
+
     fn install_runtime(&self, body: &str) {
         fs::write(&self.runtime, body).expect("write fake runtime");
         Self::make_executable(&self.runtime);
@@ -99,7 +146,41 @@ impl Fixture {
             .env("AOS_TEST_DISTRO", self.root.join("child-distro"))
             .env("AOS_TEST_PATH", &self.child_path);
         command
+            .env("AOS_TEST_START", self.root.join("start-args"))
+            .env("AOS_TEST_APPLY", self.root.join("apply-args"))
+            .env("AOS_TEST_STOP", self.root.join("stop-args"))
+            .env("AOS_TEST_APPLY_DISTRO", self.root.join("apply-distro"));
+        command
     }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct FixtureLock {
+    schema_version: u32,
+    distro: FixtureLockMeta,
+    #[serde(rename = "capsule")]
+    capsules: Vec<FixtureCapsule>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    manifest_hash: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct FixtureLockMeta {
+    id: String,
+    version: String,
+    resolved_at: String,
+}
+
+#[derive(Serialize)]
+struct FixtureCapsule {
+    name: String,
+    version: String,
+    source: String,
+    hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resolved_ref: Option<String>,
 }
 
 impl Drop for Fixture {
@@ -109,7 +190,31 @@ impl Drop for Fixture {
 }
 
 const RECORDING_RUNTIME: &str = r#"#!/bin/sh
-if [ "$1" = "--principal" ] && [ "$2" = "default" ] && [ "$3" = "init" ]; then
+if [ "$1" = "start" ]; then
+    for arg in "$@"; do
+        printf '<%s>\n' "$arg"
+    done | tee "$AOS_TEST_ARGS" > "$AOS_TEST_START"
+    mkdir -p "$ASTRID_HOME/trust"
+    exit "${AOS_TEST_EXIT:-0}"
+elif [ "$1" = "--principal" ] && [ "$3" = "distro" ] && [ "$4" = "apply" ]; then
+    for arg in "$@"; do
+        printf '<%s>\n' "$arg"
+    done | tee "$AOS_TEST_ARGS" > "$AOS_TEST_APPLY"
+    printf '%s\n' "$ASTRID_ENFORCED_DISTRO" > "$AOS_TEST_APPLY_DISTRO"
+    exit "${AOS_TEST_APPLY_EXIT:-${AOS_TEST_EXIT:-0}}"
+elif [ "$1" = "stop" ]; then
+    for arg in "$@"; do
+        printf '<%s>\n' "$arg"
+    done | tee "$AOS_TEST_ARGS" > "$AOS_TEST_STOP"
+    if [ "${AOS_TEST_KEEP_TRUST:-0}" = "1" ]; then
+        find "$ASTRID_HOME" -mindepth 1 -maxdepth 1 ! -name astrid.volume ! -name trust -exec rm -rf {} +
+    else
+        find "$ASTRID_HOME" -mindepth 1 -maxdepth 1 ! -name astrid.volume -exec rm -rf {} +
+    fi
+    printf 'volume-state\n' > "$ASTRID_HOME/astrid.volume"
+    chmod 600 "$ASTRID_HOME/astrid.volume"
+    exit "${AOS_TEST_EXIT:-0}"
+elif [ "$1" = "--principal" ] && [ "$2" = "default" ] && [ "$3" = "init" ]; then
     output="$AOS_TEST_BOOTSTRAP_ARGS"
 else
     output="$AOS_TEST_ARGS"
@@ -1020,13 +1125,29 @@ fn malformed_or_ambiguous_product_principals_never_delegate() {
 }
 
 #[test]
-fn product_owns_and_refuses_distro_mutation() {
+fn product_distro_apply_rejects_arbitrary_paths_and_unsigned_bypasses() {
     let fixture = Fixture::new("owned-distro");
     fixture.install_runtime(RECORDING_RUNTIME);
 
     for args in [
         vec!["distro", "apply", "https://example.invalid/other.toml"],
         vec!["--principal", "operator", "distro", "apply", "other"],
+        vec![
+            "distro",
+            "apply",
+            "--principal",
+            "operator",
+            "--yes",
+            "--accept-new-key",
+        ],
+        vec![
+            "distro",
+            "apply",
+            "--principal",
+            "operator",
+            "--yes",
+            "--allow-unsigned",
+        ],
     ] {
         let output = fixture
             .command()
@@ -1037,10 +1158,237 @@ fn product_owns_and_refuses_distro_mutation() {
         assert_eq!(output.status.code(), Some(2));
         assert!(!fixture.args.exists());
         let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
-        assert!(stderr.contains("Unicity CE owns the distribution state"));
-        assert!(stderr.contains("does not expose raw distribution mutation"));
+        assert!(stderr.contains("unexpected argument"), "stderr: {stderr}");
         assert!(!stderr.contains("astrid distro"));
     }
+}
+
+#[test]
+fn product_distro_apply_requires_an_explicit_principal_before_dispatch() {
+    let fixture = Fixture::new("distro-principal-required");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+
+    let output = fixture
+        .command()
+        .args(["distro", "apply", "--yes"])
+        .output()
+        .expect("run distro apply without a principal");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("requires an explicit"));
+    assert!(!fixture.root.join("start-args").exists());
+    assert!(!fixture.root.join("apply-args").exists());
+}
+
+#[test]
+fn signed_distro_apply_stops_to_a_volume_and_writes_a_bound_receipt() {
+    let fixture = Fixture::new("distro-apply-success");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+
+    let output = fixture
+        .command()
+        .args([
+            "distro",
+            "apply",
+            "--principal",
+            "operator",
+            "--yes",
+            "--offline",
+            "--var",
+            "model=fixture",
+        ])
+        .output()
+        .expect("run signed distro apply");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("start-args")).expect("read start args"),
+        "<start>\n"
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("apply-args")).expect("read apply args"),
+        format!(
+            "<--principal>\n<operator>\n<distro>\n<apply>\n<--yes>\n<{}>\n<--offline>\n<--var>\n<model=fixture>\n",
+            fixture.release_dir().join("Distro.toml").display()
+        )
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("apply-distro")).expect("read selected distro"),
+        format!("{}\n", fixture.release_dir().join("Distro.toml").display())
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.root.join("stop-args")).expect("read stop args"),
+        "<stop>\n"
+    );
+
+    let runtime = fixture.home.join("runtime");
+    let entries: Vec<_> = fs::read_dir(&runtime)
+        .expect("read stopped runtime")
+        .map(|entry| {
+            entry
+                .expect("read stopped runtime entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    assert_eq!(entries, vec!["astrid.volume"]);
+    let volume = fs::symlink_metadata(runtime.join("astrid.volume")).expect("inspect volume");
+    assert!(volume.is_file());
+    assert!(!volume.file_type().is_symlink());
+    assert!(volume.len() > 0);
+    assert_eq!(volume.permissions().mode() & 0o7777, 0o600);
+    assert!(!runtime.join("trust").exists());
+    assert!(!runtime.join("run").exists());
+
+    let receipt_path = fixture.home.join("receipts").join("unicity-ce.active.json");
+    let receipt: serde_json::Value =
+        serde_json::from_slice(&fs::read(&receipt_path).expect("read distro apply receipt"))
+            .expect("parse distro apply receipt");
+    assert_eq!(receipt["distro_id"], "unicity-ce");
+    assert_eq!(receipt["distro_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(receipt["principal"], "operator");
+    assert_eq!(receipt["astrid_runtime_version"], "0.10.4");
+    assert!(receipt["signing_pubkey"].as_str().unwrap().len() > 8);
+    assert!(
+        receipt["manifest_blake3"]
+            .as_str()
+            .unwrap()
+            .starts_with("blake3:")
+    );
+    let receipt_metadata = fs::symlink_metadata(&receipt_path).expect("inspect receipt");
+    assert_eq!(receipt_metadata.permissions().mode() & 0o7777, 0o600);
+}
+
+#[test]
+fn signed_distro_apply_requires_the_bundled_signature_before_start() {
+    let fixture = Fixture::new("distro-apply-missing-signature");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+    fs::remove_file(fixture.release_dir().join("Distro.sig")).expect("remove fixture signature");
+
+    let output = fixture
+        .command()
+        .args(["distro", "apply", "--principal", "operator", "--yes"])
+        .output()
+        .expect("run unsigned distro apply");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Distro.sig"));
+    assert!(!fixture.root.join("start-args").exists());
+    assert!(!fixture.root.join("apply-args").exists());
+}
+
+#[test]
+fn failed_distro_apply_still_stops_and_does_not_write_a_receipt() {
+    let fixture = Fixture::new("distro-apply-failure");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+
+    let output = fixture
+        .command()
+        .env("AOS_TEST_APPLY_EXIT", "23")
+        .args(["distro", "apply", "--principal", "operator", "--yes"])
+        .output()
+        .expect("run failing distro apply");
+    assert_eq!(output.status.code(), Some(23));
+    assert!(fixture.root.join("start-args").exists());
+    assert!(fixture.root.join("apply-args").exists());
+    assert!(fixture.root.join("stop-args").exists());
+    assert!(
+        !fixture
+            .home
+            .join("receipts")
+            .join("unicity-ce.active.json")
+            .exists()
+    );
+    assert!(!fixture.home.join("runtime/trust").exists());
+}
+
+#[test]
+fn successful_distro_apply_refuses_a_leftover_runtime_trust_projection() {
+    let fixture = Fixture::new("distro-apply-leftover-trust");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+
+    let output = fixture
+        .command()
+        .env("AOS_TEST_KEEP_TRUST", "1")
+        .args(["distro", "apply", "--principal", "operator", "--yes"])
+        .output()
+        .expect("run distro apply with leftover trust");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("shutdown"));
+    assert!(fixture.home.join("runtime/trust/unicity-ce.pub").exists());
+    assert!(
+        !fixture
+            .home
+            .join("receipts")
+            .join("unicity-ce.active.json")
+            .exists()
+    );
+}
+
+#[test]
+fn signed_distro_apply_refuses_a_manifest_key_swap_before_start() {
+    let fixture = Fixture::new("distro-apply-key-swap");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+    let manifest_path = fixture.release_dir().join("Distro.toml");
+    let manifest = fs::read_to_string(&manifest_path)
+        .expect("read fixture manifest")
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with("pubkey =") {
+                "pubkey = \"ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\""
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(manifest_path, manifest).expect("swap fixture signing key");
+
+    let output = fixture
+        .command()
+        .args(["distro", "apply", "--principal", "operator", "--yes"])
+        .output()
+        .expect("run key-swapped distro apply");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("manifest-hash"));
+    assert!(!fixture.root.join("start-args").exists());
+    assert!(!fixture.root.join("apply-args").exists());
+}
+
+#[test]
+fn signed_distro_apply_refuses_a_receipt_principal_mismatch_before_dispatch() {
+    let fixture = Fixture::new("distro-apply-receipt-mismatch");
+    fixture.install_runtime(RECORDING_RUNTIME);
+    fixture.install_signed_distro();
+
+    let first = fixture
+        .command()
+        .args(["distro", "apply", "--principal", "operator", "--yes"])
+        .status()
+        .expect("run initial signed distro apply");
+    assert!(first.success());
+    fs::remove_file(fixture.root.join("start-args")).expect("reset start marker");
+    fs::remove_file(fixture.root.join("apply-args")).expect("reset apply marker");
+
+    let output = fixture
+        .command()
+        .args(["distro", "apply", "--principal", "other", "--yes"])
+        .output()
+        .expect("run mismatched repeat distro apply");
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("before dispatch"));
+    assert!(!fixture.root.join("start-args").exists());
+    assert!(!fixture.root.join("apply-args").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add a selected `aos distro apply --principal P --yes` path that verifies the
bundled Distro.toml, Distro.lock, and Distro.sig with Astrid 0.10.4's signed
lock algorithm, binds those members to the installed release-manifest.json
inventory, seeds the runtime trust pin, confirms a volume-only stop with an
exact nonempty private 0600 `astrid.volume`, and records an AOS-owned
activation receipt.

Trust root is the authenticated AOS package identity. The Distro.toml pubkey is
not self-authenticating. Only the selected bundled Distro path is accepted.

This is a new successor on current `main` after #126 and #128. Closed unmerged
#117 is not restacked.

## Changes

- Verify release-dir Distro.toml / Distro.lock / Distro.sig before start
- Require installed release-manifest.json and exact Distro.toml/lock/sig
  digest and mode 0600 inventory binding
- Require an explicit principal and `--yes`; reject arbitrary Distro paths and
  unsigned bypass flags (`--accept-new-key`, `--allow-unsigned`)
- Forward only existing Astrid 0.10.4 apply flags: optional `--offline` / `--var`
- On apply failure, still stop and write no receipt
- On leftover `runtime/trust` after apply, fail stop and write no receipt
- After a successful apply stop, require exclusive nonempty private 0600
  `astrid.volume` before writing the receipt; generic `confirm_stopped`
  semantics are unchanged
- Repeat apply fails before dispatch when an existing receipt does not bind the
  same Distro identity/version, Distro.toml digest, signing pubkey, principal,
  and Astrid runtime version

## Exact head

- Base: `a8c192bd02288253a65ec60001261c172bb4275e`
- Head: `630d0b3f484f8d9a3400ad74c5e07107178f5e56`
- Unique commits:
  - `feat(distro): apply signed Unicity CE with volume-only stop`
  - `fix(distro): require volume and release inventory after apply`

## Scope

- `CHANGELOG.md`
- `Cargo.toml` / `Cargo.lock` / `crates/unicity-aos-bootstrap/Cargo.toml`
- `crates/unicity-aos-bootstrap/src/main.rs`
- `crates/unicity-aos-bootstrap/src/distro_trust.rs`
- `crates/unicity-aos-bootstrap/tests/cli_boundary.rs`

The Distro.toml / Distro.lock verification helpers exist only to serve this
selected apply path. Landing the parser without the command, or the command
without signed verification, would be a nonfunctional intermediate, so they
stay in one PR.

No `install.sh`, `package-release.sh`, schema-v2 membership, `status.rs` pin
strings, `confirm_stopped` semantics, `runtime/bin` allowlist, runtime pin
change, or live installation state changes. Signed Distro member planting from
#128 is preserved.

## Verification

- GPG: good signatures from Joshua J. Bouw `<jjb@unicity-labs.com>`
- DCO: `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`
- `cargo fmt --all -- --check`
- `cargo clippy -p unicity-aos-bootstrap --offline --all-targets -- -D warnings`
- `cargo test -p unicity-aos-bootstrap --offline --test cli_boundary`

## Residuals and claim limits

- Product version remains 2026.9.0.
- Packaged runtime pin remains Astrid 0.10.4 / `b6bf5d1d`.
- Consumer still fails closed if Distro.lock, Distro.sig, or release-manifest.json
  are absent from `$AOS_HOME/releases/2026.9.0/`.
- Landed schema-v2 / aos-mcp membership from #125 is unchanged.
- Landed stop-confirmation and volume-only contract from #126 are unchanged.
- Landed installer Distro.lock/Distro.sig planting from #128 is unchanged.
- This does not package Distro.sig production or change `confirm_stopped`.
- Closed unmerged #117 remains retired evidence only.

## AI / tool disclosure

Codex was used to implement the selected Distro Apply consumer, signed
ephemeral fixtures, release-manifest inventory binding, and volume-only receipt
path on current `main` without changing installer packaging or stop-confirmation
semantics.
