### PR TITLE
fix(install): plant signed Distro.lock and Distro.sig into immutable releases

### DIFF
--- a/changes/install-plant-signed-distro.fixed.md
+++ b/changes/install-plant-signed-distro.fixed.md
@@ -1,0 +1,3 @@
+- Updated the installer to detect signed release inventories and atomically
+  plant authenticated `Distro.toml`, `Distro.lock`, and `Distro.sig` members
+  with immutable `0600` permissions and matching BLAKE3 records.

--- a/install.sh
+++ b/install.sh
@@ -780,6 +780,162 @@ bundle="$work/unpack/$bundle_name"
 for file in bin/aos libexec/install.sh runtime/bin/astrid runtime/bin/astrid-daemon runtime/bin/astrid-build runtime/bin/astrid-emit release-manifest.json Distro.toml capsule-assets.txt; do
   [ -f "$bundle/$file" ] || { echo "release archive is missing $file" >&2; exit 1; }
 done
+
+# Read the two optional signed-distro members from the schema-v2 release
+# inventory.  Keep this parser dependency-free: the installer is also used on
+# hosts that do not have Python or jq.  The archive manifest is JSON emitted by
+# package-release.sh; the small scanner still tracks quoted strings and nested
+# objects so a member name in another manifest field cannot opt into signing.
+release_inventory_entry() {
+  manifest=$1
+  wanted=$2
+  awk -v wanted="$wanted" '
+    function object_after(text, start,    open, i, c, depth, quoted, escaped) {
+      open = index(substr(text, start), "{")
+      if (!open) return ""
+      open += start - 1
+      depth = 1
+      quoted = 0
+      escaped = 0
+      for (i = open + 1; i <= length(text); i++) {
+        c = substr(text, i, 1)
+        if (quoted) {
+          if (escaped) escaped = 0
+          else if (c == "\\") escaped = 1
+          else if (c == "\"") quoted = 0
+          continue
+        }
+        if (c == "\"") quoted = 1
+        else if (c == "{") depth++
+        else if (c == "}") {
+          depth--
+          if (depth == 0) return substr(text, open + 1, i - open - 1)
+        }
+      }
+      return ""
+    }
+    {
+      if (NR == 1) all = $0
+      else all = all " " $0
+    }
+    END {
+      release_start = index(all, "\"release_files\"")
+      if (!release_start) {
+        print "missing|||"
+        exit
+      }
+      release_object = object_after(all, release_start + length("\"release_files\""))
+      if (release_object == "") {
+        print "invalid|||"
+        exit
+      }
+
+      marker = "\"" wanted "\""
+      search = release_object
+      found = 0
+      while ((position = index(search, marker)) != 0) {
+        tail = substr(search, position + length(marker))
+        if (tail ~ /^[[:space:]]*:/) {
+          found = 1
+          break
+        }
+        search = substr(search, position + length(marker))
+      }
+      if (!found) {
+        print "missing|||"
+        exit
+      }
+      sub(/^[[:space:]]*:[[:space:]]*/, "", tail)
+      if (substr(tail, 1, 1) != "{") {
+        print "invalid|||"
+        exit
+      }
+      record = object_after(tail, 1)
+      if (record == "") {
+        print "invalid|||"
+        exit
+      }
+      digest = ""
+      field = record
+      if (field ~ /"blake3"[[:space:]]*:[[:space:]]*"/) {
+        sub(/.*"blake3"[[:space:]]*:[[:space:]]*"/, "", field)
+        sub(/".*/, "", field)
+        digest = field
+      }
+      mode = ""
+      field = record
+      if (field ~ /"mode"[[:space:]]*:[[:space:]]*[0-9]+/) {
+        sub(/.*"mode"[[:space:]]*:[[:space:]]*/, "", field)
+        sub(/[^0-9].*/, "", field)
+        mode = field
+      }
+      print "found|" digest "|" mode "|"
+    }
+  ' "$manifest"
+}
+
+release_inventory_status() {
+  printf '%s' "$1" | awk -F '|' '{print $1}'
+}
+
+release_inventory_digest() {
+  printf '%s' "$1" | awk -F '|' '{print $2}'
+}
+
+release_inventory_mode() {
+  printf '%s' "$1" | awk -F '|' '{print $3}'
+}
+
+distro_toml_inventory=$(release_inventory_entry "$bundle/release-manifest.json" Distro.toml)
+distro_lock_inventory=$(release_inventory_entry "$bundle/release-manifest.json" Distro.lock)
+distro_sig_inventory=$(release_inventory_entry "$bundle/release-manifest.json" Distro.sig)
+distro_toml_inventory_status=$(release_inventory_status "$distro_toml_inventory")
+distro_lock_inventory_status=$(release_inventory_status "$distro_lock_inventory")
+distro_sig_inventory_status=$(release_inventory_status "$distro_sig_inventory")
+distro_archive_signed=0
+if [ "$distro_lock_inventory_status" != missing ] || [ "$distro_sig_inventory_status" != missing ]; then
+  distro_archive_signed=1
+fi
+if [ "$distro_archive_signed" -eq 1 ]; then
+  [ "$distro_toml_inventory_status" = found ] && \
+    [ "$distro_lock_inventory_status" = found ] && \
+    [ "$distro_sig_inventory_status" = found ] || {
+      echo "signed release inventory is missing a Distro member record" >&2
+      exit 1
+    }
+  for distro_member in Distro.toml Distro.lock Distro.sig; do
+    [ -f "$bundle/$distro_member" ] && [ ! -L "$bundle/$distro_member" ] || {
+      echo "signed release archive is missing a regular $distro_member" >&2
+      exit 1
+    }
+  done
+  command -v b3sum >/dev/null 2>&1 || {
+    echo "b3sum is required to verify signed Distro member inventory" >&2
+    exit 1
+  }
+  for distro_member in Distro.toml Distro.lock Distro.sig; do
+    case "$distro_member" in
+      Distro.toml) distro_inventory="$distro_toml_inventory" ;;
+      Distro.lock) distro_inventory="$distro_lock_inventory" ;;
+      Distro.sig) distro_inventory="$distro_sig_inventory" ;;
+    esac
+    distro_digest=$(release_inventory_digest "$distro_inventory")
+    distro_mode=$(release_inventory_mode "$distro_inventory")
+    printf '%s\n' "$distro_digest" | grep -Eq '^[0-9a-f]{64}$' || {
+      echo "signed release inventory has a malformed $distro_member digest" >&2
+      exit 1
+    }
+    [ "$distro_mode" = 384 ] || {
+      echo "signed release inventory has an invalid $distro_member mode" >&2
+      exit 1
+    }
+    actual_distro_digest=$(b3sum -- "$bundle/$distro_member" | awk '{print $1}')
+    [ "$actual_distro_digest" = "$distro_digest" ] || {
+      echo "signed release inventory digest mismatch: $distro_member" >&2
+      exit 1
+    }
+  done
+fi
 [ -d "$bundle/capsules" ] || { echo "release archive has no capsule directory" >&2; exit 1; }
 if ! awk '
   !/^aos-[a-z0-9-]+\.capsule$/ { invalid = 1 }
@@ -1001,6 +1157,10 @@ for name in astrid astrid-daemon astrid-build astrid-emit; do
 done
 install -m 0600 "$bundle/release-manifest.json" "$release_stage/release-manifest.json"
 install -m 0600 "$bundle/Distro.toml" "$release_stage/Distro.toml"
+if [ "$distro_archive_signed" -eq 1 ]; then
+  install -m 0600 "$bundle/Distro.lock" "$release_stage/Distro.lock"
+  install -m 0600 "$bundle/Distro.sig" "$release_stage/Distro.sig"
+fi
 install -m 0600 "$bundle/capsule-assets.txt" "$release_stage/capsule-assets.txt"
 while IFS= read -r capsule; do
   install -m 0600 "$bundle/capsules/$capsule" "$release_stage/capsules/$capsule"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -269,6 +269,105 @@ test "$(stat -c '%a' "$release_dir/release-manifest.json" 2>/dev/null || stat -f
 test "$(stat -c '%a' "$release_dir/runtime/bin/astrid" 2>/dev/null || stat -f '%Lp' "$release_dir/runtime/bin/astrid")" = 700
 test "$(stat -c '%a' "$release_dir/capsules" 2>/dev/null || stat -f '%Lp' "$release_dir/capsules")" = 700
 
+unsigned_asset="$work/unsigned-asset.tar.gz"
+unsigned_metadata="$work/release-unsigned.toml"
+cp "$asset" "$unsigned_asset"
+cp "$release_metadata" "$unsigned_metadata"
+bundle_root_name="unicity-aos-2026.9.0-x86_64-unknown-linux-gnu"
+
+set_fixture_asset() {
+  archive=$1
+  previous_sha256=$asset_sha256
+  previous_blake3=$asset_blake3
+  previous_size=$asset_size
+  cp "$archive" "$asset"
+  asset_sha256=$(shasum -a 256 "$asset" | awk '{print $1}')
+  asset_blake3=$(b3sum "$asset" | awk '{print $1}')
+  asset_size=$(wc -c < "$asset" | tr -d ' ')
+  sed -i.bak "s/sha256 = \"$previous_sha256\"/sha256 = \"$asset_sha256\"/g" "$release_metadata"
+  rm "$release_metadata.bak"
+  sed -i.bak "s/blake3 = \"$previous_blake3\"/blake3 = \"$asset_blake3\"/g" "$release_metadata"
+  rm "$release_metadata.bak"
+  sed -i.bak "s/^size = $previous_size$/size = $asset_size/g" "$release_metadata"
+  rm "$release_metadata.bak"
+}
+
+restore_unsigned_fixture_asset() {
+  cp "$unsigned_asset" "$asset"
+  cp "$unsigned_metadata" "$release_metadata"
+  asset_sha256=$(shasum -a 256 "$asset" | awk '{print $1}')
+  asset_blake3=$(b3sum "$asset" | awk '{print $1}')
+  asset_size=$(wc -c < "$asset" | tr -d ' ')
+}
+
+signed_tree="$work/signed-tree"
+mkdir "$signed_tree"
+tar -xzf "$unsigned_asset" -C "$signed_tree"
+signed_root="$signed_tree/$bundle_root_name"
+printf 'schema-version = 1\nsigned fixture lock\n' > "$signed_root/Distro.lock"
+printf 'signed fixture signature\n' > "$signed_root/Distro.sig"
+lock_blake3=$(b3sum "$signed_root/Distro.lock" | awk '{print $1}')
+sig_blake3=$(b3sum "$signed_root/Distro.sig" | awk '{print $1}')
+python3 - "$signed_root/release-manifest.json" "$lock_blake3" "$sig_blake3" <<'PY'
+import json
+import pathlib
+import sys
+
+path, lock_digest, sig_digest = sys.argv[1:]
+manifest = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+manifest["release_files"]["Distro.lock"] = {"blake3": lock_digest, "mode": 0o600}
+manifest["release_files"]["Distro.sig"] = {"blake3": sig_digest, "mode": 0o600}
+pathlib.Path(path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+signed_archive="$work/signed-distro.tar.gz"
+COPYFILE_DISABLE=1 tar -czf "$signed_archive" -C "$signed_tree" "$bundle_root_name"
+set_fixture_asset "$signed_archive"
+signed_home="$work/signed-home"
+mkdir -p "$signed_home/.astrid"
+printf 'standalone-runtime-state\n' > "$signed_home/.astrid/sentinel"
+PATH="$fake_bin:$PATH" HOME="$signed_home" AOS_TEST_FIXTURE="$fixture" \
+  AOS_VERSION=2026.9.0 sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
+signed_release_dir="$signed_home/.aos/releases/2026.9.0"
+for distro_member in Distro.toml Distro.lock Distro.sig; do
+  test -f "$signed_release_dir/$distro_member"
+  test "$(stat -c '%a' "$signed_release_dir/$distro_member" 2>/dev/null || stat -f '%Lp' "$signed_release_dir/$distro_member")" = 600
+  test ! -e "$signed_home/.aos/runtime/$distro_member"
+  test ! -e "$signed_home/.astrid/$distro_member"
+done
+test "$(cat "$signed_home/.astrid/sentinel")" = standalone-runtime-state
+
+missing_tree="$work/signed-missing-tree"
+mkdir "$missing_tree"
+tar -xzf "$signed_archive" -C "$missing_tree"
+rm "$missing_tree/$bundle_root_name/Distro.sig"
+missing_archive="$work/signed-missing-distro.tar.gz"
+COPYFILE_DISABLE=1 tar -czf "$missing_archive" -C "$missing_tree" "$bundle_root_name"
+set_fixture_asset "$missing_archive"
+missing_home="$work/signed-missing-home"
+if PATH="$fake_bin:$PATH" HOME="$missing_home" AOS_TEST_FIXTURE="$fixture" \
+  AOS_VERSION=2026.9.0 sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a signed archive missing Distro.sig" >&2
+  exit 1
+fi
+test ! -e "$missing_home/.aos/releases/2026.9.0"
+
+symlink_tree="$work/signed-symlink-tree"
+mkdir "$symlink_tree"
+tar -xzf "$signed_archive" -C "$symlink_tree"
+rm "$symlink_tree/$bundle_root_name/Distro.sig"
+ln -s Distro.lock "$symlink_tree/$bundle_root_name/Distro.sig"
+symlink_archive="$work/signed-symlink-distro.tar.gz"
+COPYFILE_DISABLE=1 tar -czf "$symlink_archive" -C "$symlink_tree" "$bundle_root_name"
+set_fixture_asset "$symlink_archive"
+symlink_home="$work/signed-symlink-home"
+if PATH="$fake_bin:$PATH" HOME="$symlink_home" AOS_TEST_FIXTURE="$fixture" \
+  AOS_VERSION=2026.9.0 sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a signed archive with a Distro.sig symlink" >&2
+  exit 1
+fi
+test ! -e "$symlink_home/.aos/releases/2026.9.0"
+restore_unsigned_fixture_asset
+
 python=${PYTHON3:-python3}
 "$python" "$repo_root/scripts/release_metadata.py" render-channel \
   --channel stable \

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -336,6 +336,120 @@ for distro_member in Distro.toml Distro.lock Distro.sig; do
 done
 test "$(cat "$signed_home/.astrid/sentinel")" = standalone-runtime-state
 
+# Signed archives must carry a complete, authenticated Distro inventory.  Keep
+# each mutation in the archive manifest so the installer exercises its own
+# fail-closed parser rather than a packaging helper.
+incomplete_lock_tree="$work/signed-incomplete-lock-tree"
+mkdir "$incomplete_lock_tree"
+tar -xzf "$signed_archive" -C "$incomplete_lock_tree"
+python3 - "$incomplete_lock_tree/$bundle_root_name/release-manifest.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["release_files"].pop("Distro.sig")
+path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+incomplete_lock_archive="$work/signed-incomplete-lock-distro.tar.gz"
+COPYFILE_DISABLE=1 tar -czf "$incomplete_lock_archive" -C "$incomplete_lock_tree" "$bundle_root_name"
+set_fixture_asset "$incomplete_lock_archive"
+incomplete_lock_home="$work/signed-incomplete-lock-home"
+if PATH="$fake_bin:$PATH" HOME="$incomplete_lock_home" AOS_TEST_FIXTURE="$fixture" \
+  AOS_VERSION=2026.9.0 sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a signed inventory listing Distro.lock without Distro.sig" >&2
+  exit 1
+fi
+test ! -e "$incomplete_lock_home/.aos/releases/2026.9.0"
+
+incomplete_toml_tree="$work/signed-incomplete-toml-tree"
+mkdir "$incomplete_toml_tree"
+tar -xzf "$signed_archive" -C "$incomplete_toml_tree"
+python3 - "$incomplete_toml_tree/$bundle_root_name/release-manifest.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["release_files"].pop("Distro.toml")
+path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+incomplete_toml_archive="$work/signed-incomplete-toml-distro.tar.gz"
+COPYFILE_DISABLE=1 tar -czf "$incomplete_toml_archive" -C "$incomplete_toml_tree" "$bundle_root_name"
+set_fixture_asset "$incomplete_toml_archive"
+incomplete_toml_home="$work/signed-incomplete-toml-home"
+if PATH="$fake_bin:$PATH" HOME="$incomplete_toml_home" AOS_TEST_FIXTURE="$fixture" \
+  AOS_VERSION=2026.9.0 sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a signed inventory listing Distro.lock and Distro.sig without Distro.toml" >&2
+  exit 1
+fi
+test ! -e "$incomplete_toml_home/.aos/releases/2026.9.0"
+
+digest_mismatch_tree="$work/signed-digest-mismatch-tree"
+mkdir "$digest_mismatch_tree"
+tar -xzf "$signed_archive" -C "$digest_mismatch_tree"
+printf 'tampered signed Distro.lock\n' >> "$digest_mismatch_tree/$bundle_root_name/Distro.lock"
+digest_mismatch_archive="$work/signed-digest-mismatch-distro.tar.gz"
+COPYFILE_DISABLE=1 tar -czf "$digest_mismatch_archive" -C "$digest_mismatch_tree" "$bundle_root_name"
+set_fixture_asset "$digest_mismatch_archive"
+digest_mismatch_home="$work/signed-digest-mismatch-home"
+if PATH="$fake_bin:$PATH" HOME="$digest_mismatch_home" AOS_TEST_FIXTURE="$fixture" \
+  AOS_VERSION=2026.9.0 sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a signed Distro member whose bytes disagreed with inventory" >&2
+  exit 1
+fi
+test ! -e "$digest_mismatch_home/.aos/releases/2026.9.0"
+
+mode_mutation_tree="$work/signed-mode-mutation-tree"
+mkdir "$mode_mutation_tree"
+tar -xzf "$signed_archive" -C "$mode_mutation_tree"
+python3 - "$mode_mutation_tree/$bundle_root_name/release-manifest.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["release_files"]["Distro.lock"]["mode"] = 0o644
+path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+mode_mutation_archive="$work/signed-mode-mutation-distro.tar.gz"
+COPYFILE_DISABLE=1 tar -czf "$mode_mutation_archive" -C "$mode_mutation_tree" "$bundle_root_name"
+set_fixture_asset "$mode_mutation_archive"
+mode_mutation_home="$work/signed-mode-mutation-home"
+if PATH="$fake_bin:$PATH" HOME="$mode_mutation_home" AOS_TEST_FIXTURE="$fixture" \
+  AOS_VERSION=2026.9.0 sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a signed Distro member with a non-0600 inventory mode" >&2
+  exit 1
+fi
+test ! -e "$mode_mutation_home/.aos/releases/2026.9.0"
+
+malformed_digest_tree="$work/signed-malformed-digest-tree"
+mkdir "$malformed_digest_tree"
+tar -xzf "$signed_archive" -C "$malformed_digest_tree"
+python3 - "$malformed_digest_tree/$bundle_root_name/release-manifest.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+manifest = json.loads(path.read_text(encoding="utf-8"))
+manifest["release_files"]["Distro.sig"]["blake3"] = "malformed"
+path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+malformed_digest_archive="$work/signed-malformed-digest-distro.tar.gz"
+COPYFILE_DISABLE=1 tar -czf "$malformed_digest_archive" -C "$malformed_digest_tree" "$bundle_root_name"
+set_fixture_asset "$malformed_digest_archive"
+malformed_digest_home="$work/signed-malformed-digest-home"
+if PATH="$fake_bin:$PATH" HOME="$malformed_digest_home" AOS_TEST_FIXTURE="$fixture" \
+  AOS_VERSION=2026.9.0 sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a signed Distro member with a malformed inventory digest" >&2
+  exit 1
+fi
+test ! -e "$malformed_digest_home/.aos/releases/2026.9.0"
+
 missing_tree="$work/signed-missing-tree"
 mkdir "$missing_tree"
 tar -xzf "$signed_archive" -C "$missing_tree"


### PR DESCRIPTION
## Summary

Plant authenticated `Distro.toml`, `Distro.lock`, and `Distro.sig` from a signed
release inventory into `$AOS_HOME/releases/<version>/` with immutable `0600`
permissions and matching BLAKE3 records. Fail closed if the signed inventory is
incomplete or if a listed member's bytes, digest, or mode do not match. Unsigned
nightly inventories remain Distro.toml-only.

This does not implement Distro Apply.

## Changes

- Detect a signed Distro inventory in the installed archive and require all
  three Distro members before planting
- Refuse incomplete inventory, non-regular/symlink Distro members, digest
  mismatch, malformed digest, and non-384 mode
- Plant matching Distro members at `0600` under the immutable release staging
  directory and make the release visible only after a final move
- Keep unsigned installs Distro.toml-only
- Add installer falsifiers for lock-without-sig, lock+sig-without-toml, Distro.lock
  byte mismatch, mode `0644`, and malformed digest

## Exact head

- Base: `86be33df80b4639c4c0700c01855a0fe91609b63`
- Head: `59a7eefca951b3eafe5f658643fbef82f3bbff13`
- Tree: `0c588be536b56c86fb6bebc26026a547fb53ddbf`
- Unique commits:
  - `fix(install): plant signed Distro.lock and Distro.sig into immutable releases`
  - `test(install): reject incomplete Distro inventory and digest mismatch`

## Scope

- `install.sh`
- `scripts/test-install.sh`
- `changes/install-plant-signed-distro.fixed.md`

No Distro Apply, Distro.toml production pubkey, `package-release.sh`, rehearsal
workflow, runtime pin, tag, or live installation state changes.

## Verification

- GPG: good signature from Joshua J. Bouw `<jjb@unicity-labs.com>`
- DCO: `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`
- `sh -n install.sh`
- `bash scripts/test-install.sh`
- `git diff --check`

## Residuals and claim limits

- Product version remains 2026.9.0.
- Packaged runtime pin remains Astrid 0.10.4 / `b6bf5d1d`.
- This does not implement Distro Apply or move trust pins.
- Signed installs require `b3sum` and fail closed without it.
- The installer manifest parser is shaped for the flat `package-release.sh`
  inventory; nested or duplicate JSON is outside the producer contract.

## AI / tool disclosure

Codex was used to add signed Distro inventory planting in `install.sh` and to
add fail-closed installer tests for incomplete inventory, digest mismatch, and
mode mutation without changing Distro Apply or packaging.
