### PR TITLE
fix(release): require Astrid 2026.9.0 capsule archive members

### DIFF
--- a/changes/capsule-release-durable-format.fixed.md
+++ b/changes/capsule-release-durable-format.fixed.md
@@ -1,0 +1,1 @@
+- Require Community capsule archives to use Astrid 2026.9 durable members, including the signed provenance envelope and canonical WIT dependency tree, with fail-closed member types and structural provenance validation.

--- a/changes/capsule-release-durable-format.fixed.md
+++ b/changes/capsule-release-durable-format.fixed.md
@@ -1,1 +1,2 @@
 - Require Community capsule archives to use Astrid 2026.9 durable members, including the signed provenance envelope and canonical WIT dependency tree, with fail-closed member types and structural provenance validation.
+- Emit that exact durable archive from the authenticated publication inventory fixture so the release contract rejects stale Capsule.toml-plus-wasm positives.

--- a/scripts/capsule_release.py
+++ b/scripts/capsule_release.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import io
+import json
 import re
 import stat
 import sys
@@ -22,6 +23,21 @@ except ModuleNotFoundError:  # Python 3.10 and older
 ROOT = Path(__file__).resolve().parent.parent
 POLICY = ROOT / "release" / "community-capsules.txt"
 DISTRO = ROOT / "distros" / "community" / "unicity-ce" / "Distro.toml"
+PROVENANCE_FILE = "Capsule.provenance.json"
+PROVENANCE_KEYS = frozenset(
+    {"schema_version", "algorithm", "content_digest", "signer", "signature"}
+)
+DURABLE_DIRECTORY_MEMBERS = frozenset(
+    {"wit", "wit/deps", "wit/deps/astrid-contracts"}
+)
+DURABLE_FILE_MEMBERS = frozenset(
+    {
+        "Capsule.toml",
+        PROVENANCE_FILE,
+        "wit/capsule.wit",
+        "wit/deps/astrid-contracts/astrid-contracts.wit",
+    }
+)
 
 
 class ContractError(RuntimeError):
@@ -190,6 +206,57 @@ def _read_embedded_manifest(archive: tarfile.TarFile, member: tarfile.TarInfo, a
         raise ContractError(f"{asset}: embedded Capsule.toml is invalid: {error}") from error
 
 
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"invalid JSON constant {value!r}")
+
+
+def _read_provenance(archive: tarfile.TarFile, member: tarfile.TarInfo, asset: Path) -> None:
+    if member.size > 64 * 1024:
+        raise ContractError(f"{asset}: {PROVENANCE_FILE} exceeds 64 KiB")
+    stream = archive.extractfile(member)
+    if stream is None:
+        raise ContractError(f"{asset}: {PROVENANCE_FILE} is not a regular file")
+    try:
+        envelope = json.loads(
+            stream.read().decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeDecodeError, ValueError) as error:
+        raise ContractError(f"{asset}: {PROVENANCE_FILE} is invalid JSON: {error}") from error
+    if not isinstance(envelope, dict):
+        raise ContractError(f"{asset}: {PROVENANCE_FILE} must contain a JSON object")
+    if set(envelope) != PROVENANCE_KEYS:
+        missing = sorted(PROVENANCE_KEYS - set(envelope))
+        unexpected = sorted(set(envelope) - PROVENANCE_KEYS)
+        raise ContractError(
+            f"{asset}: {PROVENANCE_FILE} keys differ; missing={missing}, unexpected={unexpected}"
+        )
+    if type(envelope["schema_version"]) is not int or envelope["schema_version"] != 1:
+        raise ContractError(f"{asset}: {PROVENANCE_FILE} schema_version must be integer 1")
+    if envelope["algorithm"] != "ed25519-blake3-tree-v1":
+        raise ContractError(
+            f"{asset}: {PROVENANCE_FILE} algorithm must be 'ed25519-blake3-tree-v1'"
+        )
+    content_digest = envelope["content_digest"]
+    if not isinstance(content_digest, str) or re.fullmatch(r"[0-9a-f]{64}", content_digest) is None:
+        raise ContractError(
+            f"{asset}: {PROVENANCE_FILE} content_digest must be 64 lowercase hexadecimal characters"
+        )
+    for key in ("algorithm", "signer", "signature"):
+        if not isinstance(envelope[key], str) or not envelope[key]:
+            raise ContractError(f"{asset}: {PROVENANCE_FILE} {key} must be a non-empty string")
+
+
 def validate_archive(asset: Path, spec: CapsuleSpec) -> None:
     try:
         archive = tarfile.open(asset, mode="r:gz")
@@ -215,13 +282,24 @@ def validate_archive(asset: Path, spec: CapsuleSpec) -> None:
             names[canonical_name] = member
             portability_names[portability_name] = canonical_name
 
-        expected_members = {"Capsule.toml", *spec.components}
+        expected_members = {
+            *DURABLE_DIRECTORY_MEMBERS,
+            *DURABLE_FILE_MEMBERS,
+            *spec.components,
+        }
         if set(names) != expected_members:
             raise ContractError(
                 f"{asset}: archive member set differs; "
                 f"missing={sorted(expected_members - set(names))}, "
                 f"unexpected={sorted(set(names) - expected_members)}"
             )
+
+        for name in DURABLE_DIRECTORY_MEMBERS:
+            if not names[name].isdir():
+                raise ContractError(f"{asset}: archive member {name!r} must be a directory")
+        for name in (*DURABLE_FILE_MEMBERS, *spec.components):
+            if not names[name].isfile():
+                raise ContractError(f"{asset}: archive member {name!r} must be a regular file")
 
         manifest_member = names.get("Capsule.toml")
         if manifest_member is None or not manifest_member.isfile():
@@ -248,6 +326,11 @@ def validate_archive(asset: Path, spec: CapsuleSpec) -> None:
             member = names.get(component)
             if member is None or not member.isfile():
                 raise ContractError(f"{asset}: component {component} is missing")
+
+        _read_provenance(archive, names[PROVENANCE_FILE], asset)
+        for name in ("wit/capsule.wit", "wit/deps/astrid-contracts/astrid-contracts.wit"):
+            if names[name].size == 0:
+                raise ContractError(f"{asset}: archive member {name!r} must not be empty")
 
 
 def validate_artifacts(directory: Path, specs: list[CapsuleSpec]) -> None:

--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import json
 import sys
 import tarfile
 import tempfile
@@ -61,6 +62,25 @@ def add_bytes(
     archive.addfile(member, io.BytesIO(data) if member.isfile() else None)
 
 
+def provenance_bytes(*, mutation: Optional[str] = None) -> bytes:
+    envelope: dict[str, object] = {
+        "schema_version": 1,
+        "algorithm": "ed25519-blake3-tree-v1",
+        "content_digest": "0" * 64,
+        "signer": "fixture-signer",
+        "signature": "fixture-signature",
+    }
+    if mutation == "provenance-wrong-schema":
+        envelope["schema_version"] = 2
+    elif mutation == "provenance-wrong-algorithm":
+        envelope["algorithm"] = "wrong-algorithm"
+    elif mutation == "provenance-wrong-digest":
+        envelope["content_digest"] = "not-a-digest"
+    elif mutation == "provenance-extra-key":
+        envelope["extra"] = "not allowed"
+    return json.dumps(envelope).encode("utf-8")
+
+
 def write_fixture(path: Path, spec: CapsuleSpec, *, mutation: Optional[str] = None) -> None:
     manifest = spec.manifest.read_bytes()
     with tarfile.open(path, mode="w:gz") as archive:
@@ -88,6 +108,10 @@ def write_fixture(path: Path, spec: CapsuleSpec, *, mutation: Optional[str] = No
             archive.addfile(device)
         if mutation == "unexpected-member":
             add_bytes(archive, "unexpected.txt", b"not allowed")
+        if mutation == "provenance-directory":
+            add_bytes(archive, "Capsule.provenance.json", b"", kind=tarfile.DIRTYPE)
+        if mutation == "provenance-non-json":
+            add_bytes(archive, "Capsule.provenance.json", b"not json")
         if mutation == "wrong-manifest":
             manifest = manifest.replace(
                 f'name = "{spec.package}"'.encode(),
@@ -101,6 +125,28 @@ def write_fixture(path: Path, spec: CapsuleSpec, *, mutation: Optional[str] = No
             if mutation == "missing-component" and component == spec.components[0]:
                 continue
             add_bytes(archive, component, b"\x00asm")
+        if mutation != "missing-wit-tree":
+            add_bytes(archive, "wit", b"", kind=tarfile.DIRTYPE)
+            if mutation != "missing-wit-capsule":
+                add_bytes(archive, "wit/capsule.wit", b"package fixture:capsule;\n")
+            add_bytes(archive, "wit/deps", b"", kind=tarfile.DIRTYPE)
+            add_bytes(archive, "wit/deps/astrid-contracts", b"", kind=tarfile.DIRTYPE)
+            if mutation != "missing-contracts-wit":
+                contracts_wit = b"package fixture:contracts;\n"
+                if mutation == "empty-wit":
+                    contracts_wit = b""
+                add_bytes(
+                    archive,
+                    "wit/deps/astrid-contracts/astrid-contracts.wit",
+                    contracts_wit,
+                )
+        if mutation != "missing-provenance":
+            if mutation == "provenance-directory":
+                pass
+            elif mutation == "provenance-non-json":
+                pass
+            else:
+                add_bytes(archive, "Capsule.provenance.json", provenance_bytes(mutation=mutation))
 
 
 class CapsuleReleaseTests(unittest.TestCase):
@@ -161,6 +207,39 @@ class CapsuleReleaseTests(unittest.TestCase):
 
     def test_rejects_unexpected_member(self) -> None:
         self.assert_mutation_rejected("unexpected-member")
+
+    def test_rejects_missing_provenance(self) -> None:
+        self.assert_mutation_rejected("missing-provenance")
+
+    def test_rejects_missing_wit_tree(self) -> None:
+        self.assert_mutation_rejected("missing-wit-tree")
+
+    def test_rejects_missing_wit_capsule(self) -> None:
+        self.assert_mutation_rejected("missing-wit-capsule")
+
+    def test_rejects_missing_contracts_wit(self) -> None:
+        self.assert_mutation_rejected("missing-contracts-wit")
+
+    def test_rejects_provenance_directory(self) -> None:
+        self.assert_mutation_rejected("provenance-directory")
+
+    def test_rejects_non_json_provenance(self) -> None:
+        self.assert_mutation_rejected("provenance-non-json")
+
+    def test_rejects_wrong_provenance_schema(self) -> None:
+        self.assert_mutation_rejected("provenance-wrong-schema")
+
+    def test_rejects_wrong_provenance_algorithm(self) -> None:
+        self.assert_mutation_rejected("provenance-wrong-algorithm")
+
+    def test_rejects_wrong_provenance_digest(self) -> None:
+        self.assert_mutation_rejected("provenance-wrong-digest")
+
+    def test_rejects_extra_provenance_key(self) -> None:
+        self.assert_mutation_rejected("provenance-extra-key")
+
+    def test_rejects_empty_wit(self) -> None:
+        self.assert_mutation_rejected("empty-wit")
 
     def test_rejects_wrong_embedded_identity(self) -> None:
         self.assert_mutation_rejected("wrong-manifest")

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import io
 import shutil
 import sys
-import tarfile
 import tempfile
 import unittest
 from pathlib import Path
@@ -17,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import capsule_release
 import release_metadata
 import release_publication
+from test_capsule_release import write_fixture
 
 
 VERSION = "2026.9.0"
@@ -49,25 +48,13 @@ EXPECTED_CAPSULE_ASSETS = frozenset(
 )
 
 
-def add_file(archive: tarfile.TarFile, name: str, value: bytes) -> None:
-    member = tarfile.TarInfo(name)
-    member.size = len(value)
-    member.mtime = 0
-    member.uid = 0
-    member.gid = 0
-    archive.addfile(member, io.BytesIO(value))
-
-
 class ReleasePublicationTests(unittest.TestCase):
     def fixture(self, root: Path) -> tuple[Path, Path]:
         artifacts = root / "artifacts"
         artifacts.mkdir()
         specs = capsule_release.source_contract()
         for spec in specs:
-            with tarfile.open(artifacts / spec.asset, "w:gz") as archive:
-                add_file(archive, "Capsule.toml", spec.manifest.read_bytes())
-                for component in spec.components:
-                    add_file(archive, component, b"\0asm")
+            write_fixture(artifacts / spec.asset, spec)
 
         for target in release_metadata.TARGETS:
             (artifacts / f"unicity-aos-{VERSION}-{target}.tar.gz").write_bytes(


### PR DESCRIPTION
## Summary
Update the Community capsule release validator so Astrid 2026.9.0 archives are accepted only when they carry the exact durable member set: `Capsule.toml`, component wasm files, `Capsule.provenance.json`, and the canonical WIT tree. Unexpected members still fail closed. The authenticated publication inventory fixture now emits that same archive so the release-contract job no longer treats a stale Capsule.toml-plus-wasm positive as complete.

## Scope
- `scripts/capsule_release.py` requires the durable directories and files, checks member types, rejects empty WIT files, and structurally validates the provenance envelope (`schema_version = 1`, `algorithm = ed25519-blake3-tree-v1`, 64-lowercase-hex `content_digest`, non-empty `signer`/`signature`, exact key set, size <= 64 KiB).
- `scripts/test_capsule_release.py` fixtures emit that member set and add mutants for missing provenance/WIT, directory-or-non-JSON provenance, wrong schema/algorithm/digest, extra envelope keys, and empty WIT.
- `scripts/test_release_publication.py` reuses that helper for the complete authenticated inventory; negative asset-set coverage is unchanged.
- Changelog fragment `changes/capsule-release-durable-format.fixed.md`.

## Invariants
- This is a structural archive contract, not a second cryptographic verifier. Capsule install/runtime remains the signature authority.
- Production Distro.toml, production pubkey, and production `ASTRID_RUNTIME_VERSION` are unchanged.
- No workflow, package-release, installer, or Distro Apply changes.
- The validator is not loosened and optional members are not restored.

## Tests
- `python3 scripts/test_capsule_release.py`
- `python3 scripts/test_release_publication.py`
- Local full Release Contract entrypoint matching CI.
- Local all-22 `astrid-build` of Community capsules against the validator at `3a108ab0`, using Astrid 2026.9.0 `astrid-build` from the Darwin runtime artifact of aos-ce run 33941436571 (Astrid source `3de333f1`). That run is machinery/member-set evidence, not a named signed Darwin object. This successor does not change validator behavior.

## Out of scope
Does not name a signed Darwin archive, complete Distro Apply, change the production runtime pin, or re-pin Astrid after later pre-tag landings.
