### PR TITLE
ci(release): chmod rehearsal AOS artifacts before execute bind

### DIFF
--- a/.github/workflows/rehearsal-sign-darwin.yml
+++ b/.github/workflows/rehearsal-sign-darwin.yml
@@ -558,10 +558,11 @@ jobs:
           LINUX_RUNTIME_ARCHIVE="astrid-linux/astrid-${ASTRID_RUNTIME_VERSION}-${LINUX_TARGET}.tar.gz"
           DARWIN_AOS_BINARY="aos-darwin-binary/aos"
           LINUX_AOS_BINARY="aos-linux-binary/aos"
-          [[ -f "$DARWIN_RUNTIME_ARCHIVE" && -f "$LINUX_RUNTIME_ARCHIVE" ]]
-          [[ -f "$DARWIN_AOS_BINARY" && -x "$DARWIN_AOS_BINARY" ]]
-          [[ -f "$LINUX_AOS_BINARY" && -x "$LINUX_AOS_BINARY" ]]
-          chmod 0755 "$DARWIN_AOS_BINARY" "$LINUX_AOS_BINARY"
+          bash scripts/bind-rehearsal-consumed-artifacts.sh \
+            "$DARWIN_RUNTIME_ARCHIVE" \
+            "$LINUX_RUNTIME_ARCHIVE" \
+            "$DARWIN_AOS_BINARY" \
+            "$LINUX_AOS_BINARY"
           {
             echo "DARWIN_RUNTIME_ARCHIVE=$DARWIN_RUNTIME_ARCHIVE"
             echo "LINUX_RUNTIME_ARCHIVE=$LINUX_RUNTIME_ARCHIVE"

--- a/changes/rehearsal-bind-exec-mode.fixed.md
+++ b/changes/rehearsal-bind-exec-mode.fixed.md
@@ -1,0 +1,1 @@
+- Restore executable mode on downloaded Darwin rehearsal AOS binaries with chmod 0755 before the execute-bit bind, and reject missing, symlink, or non-regular artifact paths.

--- a/scripts/bind-rehearsal-consumed-artifacts.sh
+++ b/scripts/bind-rehearsal-consumed-artifacts.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: bind-rehearsal-consumed-artifacts.sh DARWIN_RUNTIME LINUX_RUNTIME DARWIN_AOS LINUX_AOS" >&2
+  exit 1
+fi
+
+require_regular_file() {
+  local path="$1"
+  if [[ -L "$path" ]]; then
+    echo "rehearsal artifact must not be a symlink: $path" >&2
+    exit 1
+  fi
+  if [[ ! -f "$path" ]]; then
+    echo "rehearsal artifact is missing or not a regular file: $path" >&2
+    exit 1
+  fi
+}
+
+print_stat() {
+  local path="$1"
+  echo "rehearsal artifact stat: $path"
+  if stat --version >/dev/null 2>&1; then
+    stat --printf '  name=%n mode=%a uid=%u gid=%g type=%F\n' -- "$path"
+  else
+    stat -f '  name=%N mode=%Lp uid=%u gid=%g type=%HT' -- "$path"
+  fi
+}
+
+DARWIN_RUNTIME_ARCHIVE="$1"
+LINUX_RUNTIME_ARCHIVE="$2"
+DARWIN_AOS_BINARY="$3"
+LINUX_AOS_BINARY="$4"
+
+require_regular_file "$DARWIN_RUNTIME_ARCHIVE"
+require_regular_file "$LINUX_RUNTIME_ARCHIVE"
+require_regular_file "$DARWIN_AOS_BINARY"
+require_regular_file "$LINUX_AOS_BINARY"
+echo "rehearsal consumed artifacts before chmod"
+print_stat "$DARWIN_RUNTIME_ARCHIVE"
+print_stat "$LINUX_RUNTIME_ARCHIVE"
+print_stat "$DARWIN_AOS_BINARY"
+print_stat "$LINUX_AOS_BINARY"
+chmod 0755 "$DARWIN_AOS_BINARY" "$LINUX_AOS_BINARY"
+echo "rehearsal AOS binaries after chmod 0755"
+print_stat "$DARWIN_AOS_BINARY"
+print_stat "$LINUX_AOS_BINARY"
+if [[ ! -x "$DARWIN_AOS_BINARY" || ! -x "$LINUX_AOS_BINARY" ]]; then
+  echo "rehearsal AOS binaries are not executable after chmod 0755" >&2
+  exit 1
+fi

--- a/scripts/test-bind-rehearsal-consumed-artifacts.sh
+++ b/scripts/test-bind-rehearsal-consumed-artifacts.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+binder="$repo_root/scripts/bind-rehearsal-consumed-artifacts.sh"
+
+bash -n "$binder"
+
+file_mode() {
+  python3 -c 'import os, sys; print(oct(os.stat(sys.argv[1]).st_mode & 0o777))' "$1"
+}
+
+make_layout() {
+  local root="$1"
+  mkdir -p "$root/astrid-darwin" "$root/astrid-linux" "$root/aos-darwin-binary" "$root/aos-linux-binary"
+  printf 'darwin-runtime\n' > "$root/astrid-darwin/astrid-2026.9.0-aarch64-apple-darwin.tar.gz"
+  printf 'linux-runtime\n' > "$root/astrid-linux/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz"
+  printf 'darwin-aos\n' > "$root/aos-darwin-binary/aos"
+  printf 'linux-aos\n' > "$root/aos-linux-binary/aos"
+  chmod 0644 \
+    "$root/astrid-darwin/astrid-2026.9.0-aarch64-apple-darwin.tar.gz" \
+    "$root/astrid-linux/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz" \
+    "$root/aos-darwin-binary/aos" \
+    "$root/aos-linux-binary/aos"
+}
+
+bind() {
+  local root="$1"
+  (
+    cd "$root"
+    bash "$binder" \
+      astrid-darwin/astrid-2026.9.0-aarch64-apple-darwin.tar.gz \
+      astrid-linux/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz \
+      aos-darwin-binary/aos \
+      aos-linux-binary/aos
+  )
+}
+
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/rehearsal-bind-XXXXXX")
+trap 'rm -rf "$scratch"' EXIT
+
+happy="$scratch/happy"
+make_layout "$happy"
+[[ "$(file_mode "$happy/aos-darwin-binary/aos")" == "0o644" ]]
+[[ "$(file_mode "$happy/aos-linux-binary/aos")" == "0o644" ]]
+if [[ -x "$happy/aos-darwin-binary/aos" || -x "$happy/aos-linux-binary/aos" ]]; then
+  echo "fixture AOS binaries must start non-executable (mode 0644)" >&2
+  exit 1
+fi
+bind "$happy"
+[[ "$(file_mode "$happy/aos-darwin-binary/aos")" == "0o755" ]]
+[[ "$(file_mode "$happy/aos-linux-binary/aos")" == "0o755" ]]
+[[ -x "$happy/aos-darwin-binary/aos" && -x "$happy/aos-linux-binary/aos" ]]
+[[ "$(file_mode "$happy/astrid-darwin/astrid-2026.9.0-aarch64-apple-darwin.tar.gz")" == "0o644" ]]
+[[ "$(file_mode "$happy/astrid-linux/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz")" == "0o644" ]]
+
+missing="$scratch/missing"
+make_layout "$missing"
+rm -f "$missing/aos-linux-binary/aos"
+if bind "$missing"; then
+  echo "missing AOS binary must fail closed" >&2
+  exit 1
+fi
+
+symlink="$scratch/symlink"
+make_layout "$symlink"
+rm -f "$symlink/aos-darwin-binary/aos"
+printf 'target\n' > "$symlink/aos-darwin-binary/target"
+chmod 0644 "$symlink/aos-darwin-binary/target"
+ln -s target "$symlink/aos-darwin-binary/aos"
+if bind "$symlink"; then
+  echo "symlink AOS binary must fail closed" >&2
+  exit 1
+fi
+[[ "$(file_mode "$symlink/aos-darwin-binary/target")" == "0o644" ]]
+if [[ -x "$symlink/aos-darwin-binary/target" ]]; then
+  echo "rejected symlink must not chmod its target" >&2
+  exit 1
+fi
+
+directory="$scratch/directory"
+make_layout "$directory"
+rm -f "$directory/aos-linux-binary/aos"
+mkdir "$directory/aos-linux-binary/aos"
+if bind "$directory"; then
+  echo "directory AOS path must fail closed" >&2
+  exit 1
+fi
+
+fifo="$scratch/fifo"
+make_layout "$fifo"
+rm -f "$fifo/aos-darwin-binary/aos"
+mkfifo "$fifo/aos-darwin-binary/aos"
+if bind "$fifo"; then
+  echo "non-regular AOS path must fail closed" >&2
+  exit 1
+fi

--- a/scripts/test-rehearsal-sign-workflow-contract.sh
+++ b/scripts/test-rehearsal-sign-workflow-contract.sh
@@ -50,6 +50,19 @@ for scalar_binding in \
 do
   grep -Fq "$scalar_binding" "$workflow"
 done
+grep -Fq 'bash scripts/bind-rehearsal-consumed-artifacts.sh' "$workflow"
+bash -n "$repo_root/scripts/bind-rehearsal-consumed-artifacts.sh"
+grep -Fq 'print_stat' "$repo_root/scripts/bind-rehearsal-consumed-artifacts.sh"
+grep -Fq 'chmod 0755' "$repo_root/scripts/bind-rehearsal-consumed-artifacts.sh"
+bash "$repo_root/scripts/test-bind-rehearsal-consumed-artifacts.sh"
+if grep -Fq '[[ -f "$DARWIN_AOS_BINARY" && -x "$DARWIN_AOS_BINARY" ]]' "$workflow"; then
+  echo "rehearsal workflow must not assert execute bits before chmod" >&2
+  exit 1
+fi
+if grep -Fq '[[ -f "$LINUX_AOS_BINARY" && -x "$LINUX_AOS_BINARY" ]]' "$workflow"; then
+  echo "rehearsal workflow must not assert execute bits before chmod" >&2
+  exit 1
+fi
 grep -Fq 'QA_SEED_FILE="$RUNNER_TEMP/rehearsal-qa-seed"' "$workflow"
 [[ $(grep -Fc 'QA_SEED_FILE' "$workflow") -ge 4 ]]
 grep -Fq 'actions/upload-artifact@' "$workflow"


### PR DESCRIPTION
## Summary
Repair the Darwin rehearsal bind step so consumed artifacts must be regular non-symlink files, AOS binaries are chmod 0755, and execute bits are asserted only after that chmod. Add stat diagnostics and a harness that starts from mode 0644.

Run 33947954689 failed at Bind exact consumed artifacts with `[[ -f && -x ]]` before chmod 0755. This change does not claim a transport-mode cause beyond that assertion order.

## Scope
- `scripts/bind-rehearsal-consumed-artifacts.sh` requires regular non-symlink files, prints `stat` diagnostics, chmod 0755, then asserts `-x`.
- `.github/workflows/rehearsal-sign-darwin.yml` calls that binder before writing `GITHUB_ENV`.
- `scripts/test-bind-rehearsal-consumed-artifacts.sh` proves mode-0644 input succeeds only after chmod and missing/symlink/non-regular paths fail closed.
- `scripts/test-rehearsal-sign-workflow-contract.sh` requires the binder and forbids the old `-x`-before-chmod assertions.
- Changelog fragment `changes/rehearsal-bind-exec-mode.fixed.md`.

## Invariants
- Rehearsal remains dispatch-only and prepare-only.
- Astrid source pin remains `1897e086549ac447c6b6cc47ad264a500ebe9fcb`.
- `AOS_PRODUCT_VERSION` / rehearsal `ASTRID_RUNTIME_VERSION` remain `2026.9.0`.
- Production `ASTRID_RUNTIME_VERSION` `"0.10.4"` and production Distro pubkey are unchanged.
- No package-release, installer, Distro Apply, tag, or dispatch changes.

## Tests
- `bash scripts/test-bind-rehearsal-consumed-artifacts.sh`
- `bash scripts/test-rehearsal-sign-workflow-contract.sh`

## Out of scope
Does not dispatch Darwin rehearsal, name a signed Darwin object, or change production Distro Apply.
