### PR TITLE
fix(release): invoke runtime archive validator with Python

### DIFF
--- a/.github/workflows/rehearsal-sign-darwin.yml
+++ b/.github/workflows/rehearsal-sign-darwin.yml
@@ -635,7 +635,7 @@ jobs:
       - name: Compose the GNU native sealer source
         run: |
           set -euo pipefail
-          "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py" \
+          python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py" \
             "$LINUX_RUNTIME_ARCHIVE" \
             "astrid-${ASTRID_RUNTIME_VERSION}-${LINUX_TARGET}" \
             astrid astrid-daemon astrid-build astrid-emit
@@ -662,7 +662,7 @@ jobs:
       - name: Compose the Darwin candidate
         run: |
           set -euo pipefail
-          "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py" \
+          python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py" \
             "$DARWIN_RUNTIME_ARCHIVE" \
             "astrid-${ASTRID_RUNTIME_VERSION}-${DARWIN_TARGET}" \
             astrid astrid-daemon astrid-build astrid-emit

--- a/changes/rehearsal-python3-validator.fixed.md
+++ b/changes/rehearsal-python3-validator.fixed.md
@@ -1,0 +1,1 @@
+- Run the runtime archive validator through Python during Darwin rehearsal composition so mode-0644 sources execute reliably.

--- a/scripts/test-invoke-runtime-archive-validator.sh
+++ b/scripts/test-invoke-runtime-archive-validator.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+validator="$repo_root/scripts/validate-runtime-archive.py"
+
+[[ -f "$validator" ]]
+
+source_mode=$(python3 - "$validator" <<'PY'
+import os
+import sys
+
+print(oct(os.stat(sys.argv[1]).st_mode & 0o777))
+PY
+)
+[[ "$source_mode" == "0o644" ]]
+
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/rehearsal-validator-XXXXXX")
+trap 'rm -rf "$scratch"' EXIT
+
+fixture="$scratch/validate-runtime-archive.py"
+archive="$scratch/runtime.tar.gz"
+root="astrid-2026.9.0-x86_64-unknown-linux-gnu"
+tool="astrid-build"
+
+cp "$validator" "$fixture"
+chmod 0644 "$fixture"
+
+fixture_mode=$(python3 - "$fixture" <<'PY'
+import os
+import sys
+
+print(oct(os.stat(sys.argv[1]).st_mode & 0o777))
+PY
+)
+[[ "$fixture_mode" == "0o644" ]]
+
+python3 - "$archive" "$root" "$tool" <<'PY'
+import io
+import sys
+import tarfile
+from pathlib import Path
+
+archive_path = Path(sys.argv[1])
+root = sys.argv[2]
+tool = sys.argv[3]
+
+with tarfile.open(archive_path, mode="w:gz") as archive:
+    directory = tarfile.TarInfo(root)
+    directory.type = tarfile.DIRTYPE
+    directory.mode = 0o755
+    archive.addfile(directory)
+
+    data = b"fixture"
+    member = tarfile.TarInfo(f"{root}/{tool}")
+    member.mode = 0o755
+    member.size = len(data)
+    archive.addfile(member, io.BytesIO(data))
+PY
+
+python3 "$fixture" "$archive" "$root" "$tool"
+
+set +e
+"$fixture" "$archive" "$root" "$tool" >"$scratch/direct.stdout" 2>"$scratch/direct.stderr"
+status=$?
+set -e
+
+if [[ "$status" -ne 126 ]]; then
+  echo "mode-0644 validator direct-exec status was $status, expected 126" >&2
+  cat "$scratch/direct.stderr" >&2
+  exit 1
+fi

--- a/scripts/test-rehearsal-sign-workflow-contract.sh
+++ b/scripts/test-rehearsal-sign-workflow-contract.sh
@@ -55,6 +55,18 @@ bash -n "$repo_root/scripts/bind-rehearsal-consumed-artifacts.sh"
 grep -Fq 'print_stat' "$repo_root/scripts/bind-rehearsal-consumed-artifacts.sh"
 grep -Fq 'chmod 0755' "$repo_root/scripts/bind-rehearsal-consumed-artifacts.sh"
 bash "$repo_root/scripts/test-bind-rehearsal-consumed-artifacts.sh"
+validator_harness="$repo_root/scripts/test-invoke-runtime-archive-validator.sh"
+[[ -f "$validator_harness" ]]
+bash -n "$validator_harness"
+bash "$validator_harness"
+if [[ $(grep -Fc 'python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py"' "$workflow") -ne 2 ]]; then
+  echo "rehearsal workflow must invoke the runtime archive validator with python3 at both compose sites" >&2
+  exit 1
+fi
+if grep -Eq '^[[:space:]]*"\$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive\.py"' "$workflow"; then
+  echo "rehearsal workflow must not direct-exec the runtime archive validator" >&2
+  exit 1
+fi
 if grep -Fq '[[ -f "$DARWIN_AOS_BINARY" && -x "$DARWIN_AOS_BINARY" ]]' "$workflow"; then
   echo "rehearsal workflow must not assert execute bits before chmod" >&2
   exit 1
@@ -193,6 +205,39 @@ if 'ASTRID_RUNTIME_VERSION: &str = "0.10.4"' not in compose:
     raise SystemExit("compose job must reject a leftover production ASTRID_RUNTIME_VERSION overlay")
 if 'runtime["version"] != "2026.9.0"' not in compose:
     raise SystemExit("compose job must validate runtime-compatibility version")
+
+validator_call = 'python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py"'
+for step_name in ("Compose the GNU native sealer source", "Compose the Darwin candidate"):
+    step = re.search(
+        rf"(?ms)^      - name: {re.escape(step_name)}\n(?P<body>.*?)(?=^      - name:|\Z)",
+        compose,
+    )
+    if step is None:
+        raise SystemExit(f"compose job is missing {step_name}")
+    body = step.group("body")
+    if body.count(validator_call) != 1:
+        raise SystemExit(f"{step_name} must invoke the runtime archive validator exactly once")
+    if re.search(rf"(?m)^\s*{re.escape(validator_call)}\s+\\\s*$", body) is None:
+        raise SystemExit(f"{step_name} must invoke the validator with python3 and continued arguments")
+
+if re.search(r'(?m)^\s*"\$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive\.py"', compose):
+    raise SystemExit("compose job must not direct-exec the runtime archive validator")
+
+lines = text.splitlines()
+for index, line in enumerate(lines):
+    if "scripts/validate-runtime-archive.py" in line and (
+        re.search(r"\bchmod\b", line) or ".chmod(" in line
+    ):
+        raise SystemExit("rehearsal workflow must not chmod the runtime archive validator")
+    if re.match(r"^\s*chmod\b", line):
+        command = line
+        end = index
+        while command.rstrip().endswith("\\") and end + 1 < len(lines):
+            end += 1
+            command += "\n" + lines[end]
+        if "scripts/validate-runtime-archive.py" in command:
+            raise SystemExit("rehearsal workflow must not chmod the runtime archive validator")
+
 if "Prove overlay-built GNU AOS accepts the signed Distro" not in compose:
     raise SystemExit("compose job must execute overlay-built AOS against the signed Distro")
 probe = '"$LINUX_AOS_BINARY" distro apply --principal operator-qa --yes'


### PR DESCRIPTION
## Summary
Invoke the Darwin rehearsal runtime-archive validator through the job's configured `python3` at both GNU and Darwin compose sites. The validator source remains mode 0644; the workflow no longer direct-executes it.

Run 33949309961 failed at Compose the GNU native sealer source with exit 126 (`Permission denied`) on `scripts/validate-runtime-archive.py`. The tree records that file as mode 100644.

## Scope
- `.github/workflows/rehearsal-sign-darwin.yml` invokes `python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py"` in Compose the GNU native sealer source and Compose the Darwin candidate.
- `scripts/test-invoke-runtime-archive-validator.sh` proves a mode-0644 validator fixture succeeds through `python3` and that direct-exec fails with status 126.
- `scripts/test-rehearsal-sign-workflow-contract.sh` requires both python3 invoke sites, rejects direct-exec, and rejects chmod of the validator source.
- Changelog fragment `changes/rehearsal-python3-validator.fixed.md`.

## Invariants
- Rehearsal remains dispatch-only and prepare-only.
- Astrid source pin remains `1897e086549ac447c6b6cc47ad264a500ebe9fcb`.
- `AOS_PRODUCT_VERSION` / rehearsal `ASTRID_RUNTIME_VERSION` remain `2026.9.0`.
- Production `ASTRID_RUNTIME_VERSION` `"0.10.4"` and production Distro pubkey are unchanged.
- `scripts/validate-runtime-archive.py` mode remains `100644`.
- No package-release, installer, Distro Apply, tag, dispatch, or Astrid re-pin changes.

## Tests
- `bash scripts/test-invoke-runtime-archive-validator.sh`
- `bash scripts/test-rehearsal-sign-workflow-contract.sh`

## Out of scope
Does not dispatch Darwin rehearsal, name a signed Darwin object, re-pin Astrid, or change production Distro Apply.
