### PR TITLE
fix(release): include Darwin FSKit provider

### DIFF
--- a/.github/workflows/rehearsal-sign-darwin.yml
+++ b/.github/workflows/rehearsal-sign-darwin.yml
@@ -247,16 +247,20 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: rehearsal-astrid-${{ env.ASTRID_SOURCE_COMMIT }}-darwin
-      - name: Build the four runtime binaries
+      - name: Build the Darwin runtime binaries
         run: |
           VERSION=$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')
           [[ "$VERSION" == "$ASTRID_RUNTIME_VERSION" ]]
-          cargo build --locked --release --target "$ASTRID_RUNTIME_TARGET" -p astrid
+          cargo build --locked --release --target "$ASTRID_RUNTIME_TARGET" \
+            -p astrid -p astrid-storage-provider-fskit
       - name: Package the rehearsal runtime archive
         run: |
           root="astrid-${ASTRID_RUNTIME_VERSION}-${ASTRID_RUNTIME_TARGET}"
           mkdir -p "$RUNNER_TEMP/runtime-stage/$root"
-          for binary in astrid astrid-daemon astrid-build astrid-emit; do
+          for binary in \
+            astrid astrid-daemon astrid-build astrid-emit \
+            astrid-storage-provider-fskit
+          do
             install -m 0755 \
               "target/${ASTRID_RUNTIME_TARGET}/release/$binary" \
               "$RUNNER_TEMP/runtime-stage/$root/$binary"
@@ -665,7 +669,8 @@ jobs:
           python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py" \
             "$DARWIN_RUNTIME_ARCHIVE" \
             "astrid-${ASTRID_RUNTIME_VERSION}-${DARWIN_TARGET}" \
-            astrid astrid-daemon astrid-build astrid-emit
+            astrid astrid-daemon astrid-build astrid-emit \
+            astrid-storage-provider-fskit
           python3 scripts/capsule_release.py --artifacts capsule-artifacts
           "$REHEARSAL_CHECKOUT/scripts/package-release.sh" \
             "$DARWIN_TARGET" \

--- a/changes/darwin-fskit-artifact.fixed.md
+++ b/changes/darwin-fskit-artifact.fixed.md
@@ -1,0 +1,1 @@
+- Include the authenticated FSKit storage provider in Darwin product archives and installations while retaining the portable four-binary runtime contract on Linux.

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -28,7 +28,16 @@ pub(crate) const RUNTIME_EXECUTABLE_NAMES: &[&str] = &[
     "astrid-emit.exe",
 ];
 
-#[cfg(not(windows))]
+#[cfg(target_os = "macos")]
+pub(crate) const RUNTIME_EXECUTABLE_NAMES: &[&str] = &[
+    "astrid",
+    "astrid-daemon",
+    "astrid-build",
+    "astrid-emit",
+    "astrid-storage-provider-fskit",
+];
+
+#[cfg(all(not(windows), not(target_os = "macos")))]
 pub(crate) const RUNTIME_EXECUTABLE_NAMES: &[&str] =
     &["astrid", "astrid-daemon", "astrid-build", "astrid-emit"];
 
@@ -799,8 +808,8 @@ fn materialize_manifest(capsule_dir: &Path) -> io::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        AosHome, UNICITY_CE_MANIFEST, capsule_assets_from_manifest, materialize_manifest,
-        runtime_binary_name, runtime_daemon_binary_name,
+        AosHome, RUNTIME_EXECUTABLE_NAMES, UNICITY_CE_MANIFEST, capsule_assets_from_manifest,
+        materialize_manifest, runtime_binary_name, runtime_daemon_binary_name,
     };
     use std::ffi::OsString;
     use std::fs;
@@ -817,6 +826,30 @@ mod tests {
                 .expect("clock after epoch")
                 .as_nanos()
         ))
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn runtime_inventory_includes_the_darwin_storage_provider() {
+        assert_eq!(
+            RUNTIME_EXECUTABLE_NAMES,
+            [
+                "astrid",
+                "astrid-daemon",
+                "astrid-build",
+                "astrid-emit",
+                "astrid-storage-provider-fskit",
+            ]
+        );
+    }
+
+    #[cfg(all(not(windows), not(target_os = "macos")))]
+    #[test]
+    fn runtime_inventory_keeps_the_portable_four_binary_contract() {
+        assert_eq!(
+            RUNTIME_EXECUTABLE_NAMES,
+            ["astrid", "astrid-daemon", "astrid-build", "astrid-emit"]
+        );
     }
 
     fn install_capsule_fixtures(root: &std::path::Path) -> PathBuf {

--- a/install.sh
+++ b/install.sh
@@ -555,16 +555,19 @@ validate_accepted_channel() {
 
 os=$(uname -s)
 arch=$(uname -m)
+runtime_binaries="astrid astrid-daemon astrid-build astrid-emit"
 case "$os:$arch" in
   Darwin:arm64|Darwin:aarch64)
     target=aarch64-apple-darwin
     cosign_asset=cosign-darwin-arm64
     cosign_sha256=94b42a9e697be95675f6160ab031a9a5f1ec1e646d6f648d7b2f5cd59ececbc5
+    runtime_binaries="$runtime_binaries astrid-storage-provider-fskit"
     ;;
   Darwin:x86_64)
     target=x86_64-apple-darwin
     cosign_asset=cosign-darwin-amd64
     cosign_sha256=14d2678dfbfde18798151e86fbd91ebdadbb7424b18412a42a155dd8a2df4c7a
+    runtime_binaries="$runtime_binaries astrid-storage-provider-fskit"
     ;;
   Linux:aarch64|Linux:arm64)
     target=aarch64-unknown-linux-gnu
@@ -777,7 +780,11 @@ bundle_name=$(tar -tzf "$work/$asset" | awk 'NR == 1 { sub(/\/.*/, "", $0); prin
 bundle="$work/unpack/$bundle_name"
 [ -d "$bundle" ] || { echo "release archive has no Unicity AOS bundle" >&2; exit 1; }
 
-for file in bin/aos libexec/install.sh runtime/bin/astrid runtime/bin/astrid-daemon runtime/bin/astrid-build runtime/bin/astrid-emit release-manifest.json Distro.toml capsule-assets.txt; do
+for file in bin/aos libexec/install.sh release-manifest.json Distro.toml capsule-assets.txt; do
+  [ -f "$bundle/$file" ] || { echo "release archive is missing $file" >&2; exit 1; }
+done
+for name in $runtime_binaries; do
+  file="runtime/bin/$name"
   [ -f "$bundle/$file" ] || { echo "release archive is missing $file" >&2; exit 1; }
 done
 
@@ -1004,7 +1011,7 @@ if [ -L "$AOS_BIN_DIR/aos" ] || { [ -e "$AOS_BIN_DIR/aos" ] && [ ! -f "$AOS_BIN_
   echo "refusing non-regular install destination: $AOS_BIN_DIR/aos" >&2
   exit 1
 fi
-for name in astrid astrid-daemon astrid-build astrid-emit; do
+for name in $runtime_binaries; do
   legacy="$AOS_HOME/runtime/bin/$name"
   [ ! -L "$legacy" ] || {
     echo "refusing symlinked legacy runtime executable: $legacy" >&2
@@ -1043,7 +1050,7 @@ if [ "$AOS_BIN_DIR" = "$AOS_HOME/bin" ]; then
 fi
 rollback="$work/rollback"
 mkdir "$rollback"
-for name in astrid astrid-daemon astrid-build astrid-emit; do
+for name in $runtime_binaries; do
   legacy="$AOS_HOME/runtime/bin/$name"
   if [ -f "$legacy" ]; then
     cp -p "$legacy" "$rollback/$name"
@@ -1122,7 +1129,7 @@ restore() {
   elif [ -f "$rollback/release.touched" ]; then
     rm -rf "$release_dir" || result=1
   fi
-  for name in aos installer astrid astrid-daemon astrid-build astrid-emit channel-current; do
+  for name in aos installer $runtime_binaries channel-current; do
     case "$name" in
       aos) destination="$AOS_BIN_DIR/aos" ;;
       installer) destination="$AOS_HOME/libexec/install.sh" ;;
@@ -1152,7 +1159,7 @@ mkdir "$release_stage"
 chmod 700 "$release_stage"
 mkdir "$release_stage/runtime" "$release_stage/runtime/bin" "$release_stage/capsules"
 chmod 700 "$release_stage/runtime" "$release_stage/runtime/bin" "$release_stage/capsules"
-for name in astrid astrid-daemon astrid-build astrid-emit; do
+for name in $runtime_binaries; do
   install -m 0700 "$bundle/runtime/bin/$name" "$release_stage/runtime/bin/$name"
 done
 install -m 0600 "$bundle/release-manifest.json" "$release_stage/release-manifest.json"
@@ -1178,7 +1185,7 @@ stage_channel_receipt
 # runtime home. They are no longer a valid launch location; remove only those
 # known managed files after the new immutable release is committed.
 if [ -d "$AOS_HOME/runtime/bin" ] && [ ! -L "$AOS_HOME/runtime/bin" ]; then
-  for name in astrid astrid-daemon astrid-build astrid-emit; do
+  for name in $runtime_binaries; do
     legacy="$AOS_HOME/runtime/bin/$name"
     [ ! -L "$legacy" ] || { echo "refusing symlinked legacy runtime executable: $legacy" >&2; exit 1; }
     [ ! -e "$legacy" ] || [ -f "$legacy" ] || {

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -147,12 +147,18 @@ try:
 except (OSError, json.JSONDecodeError) as error:
     raise SystemExit(f"release manifest is unreadable: {error}")
 
+runtime_executables = [
+    "astrid",
+    "astrid-daemon",
+    "astrid-build",
+    "astrid-emit",
+]
+target = manifest.get("target")
+if isinstance(target, str) and target.endswith("-apple-darwin"):
+    runtime_executables.append("astrid-storage-provider-fskit")
 expected_executables = [
     "bin/aos",
-    "runtime/bin/astrid",
-    "runtime/bin/astrid-daemon",
-    "runtime/bin/astrid-build",
-    "runtime/bin/astrid-emit",
+    *(f"runtime/bin/{name}" for name in runtime_executables),
 ]
 executables = manifest.get("executables")
 if executables != expected_executables:
@@ -486,6 +492,11 @@ if [[ ! "$runtime_blake3" =~ ^[0-9a-f]{64}$ ]]; then
 fi
 python3 "$repo_root/scripts/capsule_release.py" --artifacts "$capsule_artifacts"
 
+runtime_binaries=(astrid astrid-daemon astrid-build astrid-emit)
+if [[ "$target" == *-apple-darwin ]]; then
+  runtime_binaries+=(astrid-storage-provider-fskit)
+fi
+
 work=$(mktemp -d)
 signing_seed=
 trap '[[ -z "$signing_seed" ]] || destroy_distro_seed "$signing_seed"; rm -rf "$work"' EXIT
@@ -500,7 +511,7 @@ mkdir -p \
 python3 "$repo_root/scripts/validate-runtime-archive.py" \
   "$runtime_archive" \
   "astrid-${runtime_version}-${target}" \
-  astrid astrid-daemon astrid-build astrid-emit
+  "${runtime_binaries[@]}"
 tar -xzf "$runtime_archive" -C "$work/runtime-extract"
 
 runtime_root="$work/runtime-extract/astrid-${runtime_version}-${target}"
@@ -511,7 +522,7 @@ fi
 
 install -m 0755 "$aos_binary" "$work/$root/bin/aos"
 install -m 0644 "$repo_root/install.sh" "$work/$root/libexec/install.sh"
-for binary in astrid astrid-daemon astrid-build astrid-emit; do
+for binary in "${runtime_binaries[@]}"; do
   if [[ ! -x "$runtime_root/$binary" ]]; then
     echo "runtime archive is missing $binary" >&2
     exit 1
@@ -548,7 +559,7 @@ record_release_file() {
 }
 record_release_file bin/aos 755
 record_release_file libexec/install.sh 600
-for binary in astrid astrid-daemon astrid-build astrid-emit; do
+for binary in "${runtime_binaries[@]}"; do
   record_release_file "runtime/bin/$binary" 755
 done
 record_release_file capsule-assets.txt 600
@@ -584,6 +595,11 @@ manifest = {
         "runtime/bin/astrid-daemon",
         "runtime/bin/astrid-build",
         "runtime/bin/astrid-emit",
+        *(
+            ["runtime/bin/astrid-storage-provider-fskit"]
+            if target.endswith("-apple-darwin")
+            else []
+        ),
     ],
     "layout": {
         "release_directory": f"releases/{product}",

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -145,8 +145,8 @@ cp "$release_metadata" "$fixture/release-good.toml"
 cat > "$fake_bin/uname" <<'EOF'
 #!/bin/sh
 case "${1:-}" in
-  -s) echo Linux ;;
-  -m) echo x86_64 ;;
+  -s) echo "${AOS_TEST_UNAME_S:-Linux}" ;;
+  -m) echo "${AOS_TEST_UNAME_M:-x86_64}" ;;
   *) exit 2 ;;
 esac
 EOF
@@ -223,7 +223,9 @@ case "$1" in
     if [ "${AOS_TEST_BAD_COSIGN_DIGEST:-0}" = 1 ]; then
       printf '%064d  %s\n' 0 "$1"
     else
-      printf '%s  %s\n' ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc "$1"
+      printf '%s  %s\n' \
+        "${AOS_TEST_COSIGN_SHA256:-ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc}" \
+        "$1"
     fi
     ;;
   *) exec /usr/bin/shasum -a 256 "$1" ;;
@@ -268,6 +270,81 @@ test "$(stat -c '%a' "$work/home/.aos" 2>/dev/null || stat -f '%Lp' "$work/home/
 test "$(stat -c '%a' "$release_dir/release-manifest.json" 2>/dev/null || stat -f '%Lp' "$release_dir/release-manifest.json")" = 600
 test "$(stat -c '%a' "$release_dir/runtime/bin/astrid" 2>/dev/null || stat -f '%Lp' "$release_dir/runtime/bin/astrid")" = 700
 test "$(stat -c '%a' "$release_dir/capsules" 2>/dev/null || stat -f '%Lp' "$release_dir/capsules")" = 700
+
+darwin_fixture="$work/darwin-fixture"
+darwin_runtime_root="$work/astrid-$runtime_version-aarch64-apple-darwin"
+darwin_home="$work/darwin-home"
+mkdir "$darwin_fixture" "$darwin_runtime_root" "$darwin_home"
+for binary in \
+  astrid astrid-daemon astrid-build astrid-emit \
+  astrid-storage-provider-fskit
+do
+  source_binary=$binary
+  if [[ "$binary" == astrid-storage-provider-fskit ]]; then
+    source_binary=astrid
+  fi
+  cp "$runtime_root/$source_binary" "$darwin_runtime_root/$binary"
+  chmod 755 "$darwin_runtime_root/$binary"
+done
+COPYFILE_DISABLE=1 tar -czf "$work/darwin-runtime.tar.gz" \
+  -C "$work" "$(basename "$darwin_runtime_root")"
+bash "$repo_root/scripts/package-release.sh" \
+  aarch64-apple-darwin \
+  "$work/aos" \
+  "$work/darwin-runtime.tar.gz" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$work/capsules" \
+  "$darwin_fixture" >/dev/null
+darwin_asset="$darwin_fixture/unicity-aos-2026.9.0-aarch64-apple-darwin.tar.gz"
+darwin_sha256=$(shasum -a 256 "$darwin_asset" | awk '{print $1}')
+darwin_blake3=$(b3sum "$darwin_asset" | awk '{print $1}')
+darwin_size=$(wc -c < "$darwin_asset" | tr -d ' ')
+python3 - \
+  "$release_metadata" \
+  "$darwin_fixture/unicity-aos-2026.9.0-release.toml" \
+  "$darwin_sha256" \
+  "$darwin_blake3" \
+  "$darwin_size" <<'PY'
+import pathlib
+import sys
+
+source, destination, sha256, blake3, size = sys.argv[1:]
+lines = pathlib.Path(source).read_text(encoding="utf-8").splitlines()
+inside = False
+for index, line in enumerate(lines):
+    if line.startswith("["):
+        inside = line == "[targets.aarch64-apple-darwin]"
+    if not inside:
+        continue
+    if line.startswith("sha256 = "):
+        lines[index] = f'sha256 = "{sha256}"'
+    elif line.startswith("blake3 = "):
+        lines[index] = f'blake3 = "{blake3}"'
+    elif line.startswith("size = "):
+        lines[index] = f"size = {size}"
+pathlib.Path(destination).write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+cp "$good_bundle" "$darwin_fixture/unicity-aos-2026.9.0-release.toml.sigstore.json"
+cp "$good_bundle" "$darwin_asset.sigstore.json"
+cp "$good_bundle" "$darwin_fixture/valid.sigstore.json"
+cp "$fixture/cosign-linux-amd64" "$darwin_fixture/cosign-darwin-arm64"
+chmod 755 "$darwin_fixture/cosign-darwin-arm64"
+PATH="$fake_bin:$PATH" \
+HOME="$darwin_home" \
+AOS_TEST_FIXTURE="$darwin_fixture" \
+AOS_TEST_UNAME_S=Darwin \
+AOS_TEST_UNAME_M=arm64 \
+AOS_TEST_COSIGN_SHA256=94b42a9e697be95675f6160ab031a9a5f1ec1e646d6f648d7b2f5cd59ececbc5 \
+AOS_VERSION=2026.9.0 \
+sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
+darwin_release_dir="$darwin_home/.aos/releases/2026.9.0"
+for binary in \
+  astrid astrid-daemon astrid-build astrid-emit \
+  astrid-storage-provider-fskit
+do
+  test -x "$darwin_release_dir/runtime/bin/$binary"
+  test ! -e "$darwin_home/.aos/runtime/bin/$binary"
+done
 
 unsigned_asset="$work/unsigned-asset.tar.gz"
 unsigned_metadata="$work/release-unsigned.toml"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -360,6 +360,82 @@ assert manifest["verifier"] == {
 }
 PY
 
+darwin_target=aarch64-apple-darwin
+darwin_runtime_root="$work/astrid-$runtime_version-$darwin_target"
+darwin_output="$work/darwin-output"
+mkdir -p "$darwin_runtime_root" "$darwin_output"
+for binary in \
+  astrid astrid-daemon astrid-build astrid-emit \
+  astrid-storage-provider-fskit
+do
+  source_binary=$binary
+  if [[ "$binary" == astrid-storage-provider-fskit ]]; then
+    source_binary=astrid
+  fi
+  cp "$runtime_root/$source_binary" "$darwin_runtime_root/$binary"
+  chmod 755 "$darwin_runtime_root/$binary"
+done
+COPYFILE_DISABLE=1 tar -czf "$work/darwin-runtime.tar.gz" \
+  -C "$work" "$(basename "$darwin_runtime_root")"
+
+bash "$repo_root/scripts/package-release.sh" \
+  "$darwin_target" \
+  "$work/aos" \
+  "$work/darwin-runtime.tar.gz" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$work/capsules" \
+  "$darwin_output"
+
+darwin_archive="$darwin_output/unicity-aos-$product_version-$darwin_target.tar.gz"
+darwin_extract="$work/darwin-extract"
+mkdir "$darwin_extract"
+tar -xzf "$darwin_archive" -C "$darwin_extract"
+darwin_bundle="$darwin_extract/unicity-aos-$product_version-$darwin_target"
+darwin_provider="$darwin_bundle/runtime/bin/astrid-storage-provider-fskit"
+test -x "$darwin_provider"
+test "$(stat -c '%a' "$darwin_provider" 2>/dev/null || stat -f '%Lp' "$darwin_provider")" = 755
+python3 - "$darwin_bundle/release-manifest.json" "$darwin_provider" <<'PY'
+import json
+import pathlib
+import subprocess
+import sys
+
+manifest_path, provider_path = map(pathlib.Path, sys.argv[1:])
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+provider = "runtime/bin/astrid-storage-provider-fskit"
+assert manifest["executables"] == [
+    "bin/aos",
+    "runtime/bin/astrid",
+    "runtime/bin/astrid-daemon",
+    "runtime/bin/astrid-build",
+    "runtime/bin/astrid-emit",
+    provider,
+]
+record = manifest["release_files"][provider]
+assert record["mode"] == 0o755
+assert record["blake3"] == subprocess.check_output(
+    ["b3sum", "--", provider_path], text=True
+).split()[0]
+PY
+
+missing_provider_root="$work/missing-provider/astrid-$runtime_version-$darwin_target"
+mkdir -p "$missing_provider_root" "$work/missing-provider-output"
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  cp "$runtime_root/$binary" "$missing_provider_root/$binary"
+done
+COPYFILE_DISABLE=1 tar -czf "$work/missing-provider-runtime.tar.gz" \
+  -C "$work/missing-provider" "$(basename "$missing_provider_root")"
+if bash "$repo_root/scripts/package-release.sh" \
+  "$darwin_target" \
+  "$work/aos" \
+  "$work/missing-provider-runtime.tar.gz" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$work/capsules" \
+  "$work/missing-provider-output" >/dev/null 2>&1; then
+  echo "Darwin release composer accepted a runtime without the FSKit provider" >&2
+  exit 1
+fi
+
 fixture_distro="$work/FixtureDistro.toml"
 python3 - "$bundle_root/Distro.toml" "$fixture_distro" <<'PY'
 import pathlib

--- a/scripts/test-rehearsal-sign-workflow-contract.sh
+++ b/scripts/test-rehearsal-sign-workflow-contract.sh
@@ -108,7 +108,8 @@ if grep -Fiq 'install\.sh' "$workflow"; then
   echo "rehearsal workflow must not consume the installer" >&2
   exit 1
 fi
-if grep -Fiq 'fskit' "$workflow"; then
+if grep -Fq 'manage-macos-fskit.sh' "$workflow" || \
+   grep -Fq -- '--astrid-provider-stdio-v1' "$workflow"; then
   echo "rehearsal workflow must not dispatch or exercise native FSKit" >&2
   exit 1
 fi
@@ -206,6 +207,16 @@ if 'ASTRID_RUNTIME_VERSION: &str = "0.10.4"' not in compose:
 if 'runtime["version"] != "2026.9.0"' not in compose:
     raise SystemExit("compose job must validate runtime-compatibility version")
 
+darwin_runtime = sections.get("build-astrid-darwin")
+if darwin_runtime is None:
+    raise SystemExit("rehearsal workflow is missing build-astrid-darwin")
+for marker in (
+    "-p astrid-storage-provider-fskit",
+    "astrid-storage-provider-fskit",
+):
+    if marker not in darwin_runtime:
+        raise SystemExit(f"Darwin runtime job is missing {marker}")
+
 validator_call = 'python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py"'
 for step_name in ("Compose the GNU native sealer source", "Compose the Darwin candidate"):
     step = re.search(
@@ -219,6 +230,11 @@ for step_name in ("Compose the GNU native sealer source", "Compose the Darwin ca
         raise SystemExit(f"{step_name} must invoke the runtime archive validator exactly once")
     if re.search(rf"(?m)^\s*{re.escape(validator_call)}\s+\\\s*$", body) is None:
         raise SystemExit(f"{step_name} must invoke the validator with python3 and continued arguments")
+    has_fskit = "astrid-storage-provider-fskit" in body
+    if step_name == "Compose the Darwin candidate" and not has_fskit:
+        raise SystemExit("Darwin composition must require the FSKit provider")
+    if step_name == "Compose the GNU native sealer source" and has_fskit:
+        raise SystemExit("GNU composition must retain the four portable runtime binaries")
 
 if re.search(r'(?m)^\s*"\$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive\.py"', compose):
     raise SystemExit("compose job must not direct-exec the runtime archive validator")

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -131,7 +131,7 @@ snapshot_shipped_assets() {
   local release=$home/releases/2026.9.0
   : > "$output"
   printf '%s|bin/aos\n' "$(b3sum -- "$home/bin/aos" | awk '{print $1}')" >> "$output"
-  for name in astrid astrid-daemon astrid-build astrid-emit; do
+  for name in $runtime_binaries; do
     printf '%s|releases/2026.9.0/runtime/bin/%s\n' \
       "$(b3sum -- "$release/runtime/bin/$name" | awk '{print $1}')" \
       "$name" >> "$output"
@@ -180,7 +180,34 @@ for spec in source_contract():
     write_fixture(output / spec.asset, spec)
 PY
 
-target=x86_64-unknown-linux-gnu
+host_os=$(uname -s)
+host_arch=$(uname -m)
+runtime_binaries="astrid astrid-daemon astrid-build astrid-emit"
+case "$host_os:$host_arch" in
+  Darwin:arm64|Darwin:aarch64)
+    target=aarch64-apple-darwin
+    cosign_asset=cosign-darwin-arm64
+    cosign_sha256=94b42a9e697be95675f6160ab031a9a5f1ec1e646d6f648d7b2f5cd59ececbc5
+    runtime_binaries="$runtime_binaries astrid-storage-provider-fskit"
+    ;;
+  Darwin:x86_64)
+    target=x86_64-apple-darwin
+    cosign_asset=cosign-darwin-amd64
+    cosign_sha256=14d2678dfbfde18798151e86fbd91ebdadbb7424b18412a42a155dd8a2df4c7a
+    runtime_binaries="$runtime_binaries astrid-storage-provider-fskit"
+    ;;
+  Linux:aarch64|Linux:arm64)
+    target=aarch64-unknown-linux-gnu
+    cosign_asset=cosign-linux-arm64
+    cosign_sha256=2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11
+    ;;
+  Linux:x86_64|Linux:amd64)
+    target=x86_64-unknown-linux-gnu
+    cosign_asset=cosign-linux-amd64
+    cosign_sha256=ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc
+    ;;
+  *) echo "unsupported self-heal test host: $host_os/$host_arch" >&2; exit 1 ;;
+esac
 if ! read -r \
   runtime_version \
   runtime_tag \
@@ -222,7 +249,7 @@ if [[ "$runtime_metadata_available" != true ]]; then
 fi
 runtime_root=$work/astrid-$runtime_version-$target
 mkdir "$runtime_root"
-for name in astrid astrid-daemon astrid-build astrid-emit; do
+for name in $runtime_binaries; do
   printf '#!/bin/sh\necho packaged-%s\n' "$name" > "$runtime_root/$name"
   chmod 755 "$runtime_root/$name"
 done
@@ -288,11 +315,11 @@ EOF
 done
 cp "$fixture/valid.sigstore.json" "$release_metadata.sigstore.json"
 
-cat > "$fake_bin/uname" <<'EOF'
+cat > "$fake_bin/uname" <<EOF
 #!/bin/sh
-case "${1:-}" in
-  -s) echo Linux ;;
-  -m) echo x86_64 ;;
+case "\${1:-}" in
+  -s) echo "$host_os" ;;
+  -m) echo "$host_arch" ;;
   *) exit 2 ;;
 esac
 EOF
@@ -312,7 +339,7 @@ done
 [ -n "$url" ]
 cp "$AOS_TEST_FIXTURE/$(basename "$url")" "$output"
 EOF
-cat > "$fixture/cosign-linux-amd64" <<'EOF'
+cat > "$fixture/$cosign_asset" <<'EOF'
 #!/bin/sh
 set -eu
 [ "${1:-}" = verify-blob ]
@@ -329,18 +356,18 @@ done
 cmp "$AOS_TEST_FIXTURE/valid.sigstore.json" "$bundle"
 [ -f "$artifact" ]
 EOF
-cat > "$fake_bin/sha256sum" <<'EOF'
+cat > "$fake_bin/sha256sum" <<EOF
 #!/bin/sh
 set -eu
-case "$1" in
+case "\$1" in
   */cosign)
-    printf '%s  %s\n' ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc "$1"
+    printf '%s  %s\n' "$cosign_sha256" "\$1"
     ;;
-  *) exec /usr/bin/shasum -a 256 "$1" ;;
+  *) exec /usr/bin/shasum -a 256 "\$1" ;;
 esac
 EOF
 chmod 755 "$fake_bin/uname" "$fake_bin/curl" "$fake_bin/sha256sum" \
-  "$fixture/cosign-linux-amd64"
+  "$fixture/$cosign_asset"
 
 install_candidate() {
   PATH="$fake_bin:$PATH" \
@@ -360,7 +387,7 @@ test "$(find "$legacy/run" -type f | wc -l | tr -d ' ')" -eq 5
 install_candidate
 test -x "$aos_home/bin/aos"
 test -x "$aos_home/releases/2026.9.0/runtime/bin/astrid-daemon"
-for name in astrid astrid-daemon astrid-build astrid-emit; do
+for name in $runtime_binaries; do
   test ! -e "$aos_home/runtime/bin/$name"
 done
 HOME="$home" "$aos_home/bin/aos" migrate runtime --from "$legacy" > "$work/migrate.log"
@@ -417,7 +444,7 @@ test "$(b3sum -- "$receipt" | awk '{print $1}')" = "$receipt_before"
 shipped_before=$work/shipped-before
 shipped_after=$work/shipped-after
 snapshot_shipped_assets "$aos_home" "$shipped_before"
-for name in aos astrid astrid-daemon astrid-build astrid-emit; do
+for name in aos $runtime_binaries; do
   case "$name" in
     aos) destination=$aos_home/bin/aos ;;
     *) destination=$aos_home/releases/2026.9.0/runtime/bin/$name ;;


### PR DESCRIPTION
## Summary

- require `astrid-storage-provider-fskit` only for Darwin product composition
- inventory the provider as a schema-v2 executable with its exact BLAKE3 digest and executable mode
- install and manage the provider beside the bundled Astrid CLI on Darwin
- build and package the provider in the dispatch-only Darwin rehearsal without invoking FSKit

## Target boundaries

- Darwin archives contain the five runtime executables, including the FSKit provider
- GNU archives retain the four portable runtime executables
- the AOS release matrix and installer target set remain unchanged; Windows remains out
- production versions, runtime trust pins, Distro signing policy, and release identities are unchanged

## Proof

- `bash scripts/test-package-release.sh`
  - composes a Darwin archive, checks the provider mode and manifest digest against its bytes, and rejects a Darwin runtime missing the provider
  - retains the exact four-binary GNU executable manifest
- `bash scripts/test-install.sh`
  - installs a composed Darwin fixture into a disposable home and checks the provider is co-installed in the immutable release runtime directory
- `bash scripts/test-rehearsal-sign-workflow-contract.sh`
  - requires the Darwin provider build/package/validation path while forbidding FSKit lifecycle or provider-protocol execution
- `bash scripts/test-upgrade-self-heal.sh`
  - passes on the host-aligned target and preserves the Darwin provider through reinstall/self-heal
- `cargo test -p unicity-aos-bootstrap --locked`
- `cargo clippy -p unicity-aos-bootstrap --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `actionlint .github/workflows/rehearsal-sign-darwin.yml`
- `shellcheck -e SC2016 install.sh scripts/package-release.sh scripts/test-install.sh scripts/test-package-release.sh scripts/test-rehearsal-sign-workflow-contract.sh scripts/test-upgrade-self-heal.sh`

## Out of scope

No workflow dispatch, tag, release, version bump, live-home mutation, native FSKit activation, or Linux FUSE composition change.
