### PR TITLE
feat(release): export signed GNU rehearsal archive

### DIFF
--- a/.github/workflows/rehearsal-sign-darwin.yml
+++ b/.github/workflows/rehearsal-sign-darwin.yml
@@ -660,6 +660,7 @@ jobs:
           "$REHEARSAL_CHECKOUT/scripts/package-release.sh" \
             --extract-release-sealer "${candidates[0]}" "$sealer"
           {
+            echo "LINUX_ARCHIVE=${candidates[0]}"
             echo "NATIVE_SEALER=$sealer"
             echo "NATIVE_SEALER_ARCHIVE=${candidates[0]}"
           } >> "$GITHUB_ENV"
@@ -685,7 +686,7 @@ jobs:
           )
           [[ ${#candidates[@]} -eq 1 ]]
           echo "DARWIN_ARCHIVE=${candidates[0]}" >> "$GITHUB_ENV"
-      - name: Sign the Darwin rehearsal candidate
+      - name: Sign the Darwin and GNU rehearsal candidates
         id: sign
         env:
           ASTRID_SOURCE_COMMIT: ${{ env.ASTRID_SOURCE_COMMIT }}
@@ -727,21 +728,37 @@ jobs:
           PY
           )
           [[ "$DERIVED_PUBKEY" == "$QA_PUBKEY" ]]
-          signed="$RUNNER_TEMP/$(basename "$DARWIN_ARCHIVE")"
+          signed_darwin="$RUNNER_TEMP/$(basename "$DARWIN_ARCHIVE")"
           AOS_DISTRO_ED25519_SEED="$QA_SEED" \
             "$REHEARSAL_CHECKOUT/scripts/package-release.sh" \
             --sign-release-archive \
             "$DARWIN_ARCHIVE" \
-            "$signed" \
+            "$signed_darwin" \
             "$NATIVE_SEALER" \
             "$NATIVE_SEALER_ARCHIVE"
-          SIGNED_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-tar-listing.XXXXXX")
-          write_tar_listing "$signed" "$SIGNED_TAR_LISTING"
-          if ! grep -q '/Distro.sig$' "$SIGNED_TAR_LISTING"; then
-            echo "signed rehearsal archive has no Distro signature" >&2
+          SIGNED_DARWIN_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-darwin-tar-listing.XXXXXX")
+          write_tar_listing "$signed_darwin" "$SIGNED_DARWIN_TAR_LISTING"
+          if ! grep -q '/Distro.sig$' "$SIGNED_DARWIN_TAR_LISTING"; then
+            echo "signed Darwin rehearsal archive has no Distro signature" >&2
             exit 1
           fi
-          unlink "$SIGNED_TAR_LISTING"
+          unlink "$SIGNED_DARWIN_TAR_LISTING"
+          signed_gnu="$RUNNER_TEMP/$(basename "$LINUX_ARCHIVE")"
+          AOS_DISTRO_ED25519_SEED="$QA_SEED" \
+            "$REHEARSAL_CHECKOUT/scripts/package-release.sh" \
+            --sign-release-archive \
+            "$LINUX_ARCHIVE" \
+            "$signed_gnu" \
+            "$NATIVE_SEALER" \
+            "$NATIVE_SEALER_ARCHIVE"
+          SIGNED_GNU_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-gnu-tar-listing.XXXXXX")
+          write_tar_listing "$signed_gnu" "$SIGNED_GNU_TAR_LISTING"
+          if ! grep -q '/Distro.sig$' "$SIGNED_GNU_TAR_LISTING"; then
+            echo "signed GNU rehearsal archive has no Distro signature" >&2
+            exit 1
+          fi
+          unlink "$SIGNED_GNU_TAR_LISTING"
+          # Destroy the persistent QA seed only after both signed archives were verified.
           python3 - "$QA_SEED_FILE" <<'PY'
           import os
           import pathlib
@@ -754,7 +771,12 @@ jobs:
               os.fsync(file.fileno())
           path.unlink()
           PY
-          echo "SIGNED_ARCHIVE=$signed" >> "$GITHUB_ENV"
+          [[ ! -e "$QA_SEED_FILE" ]]
+          echo "ephemeral QA seed destroyed after both signed archive verifications"
+          {
+            echo "SIGNED_DARWIN_ARCHIVE=$signed_darwin"
+            echo "SIGNED_GNU_ARCHIVE=$signed_gnu"
+          } >> "$GITHUB_ENV"
       - name: Prove overlay-built GNU AOS accepts the signed Distro
         run: |
           set -euo pipefail
@@ -765,8 +787,8 @@ jobs:
           mkdir -m 0700 "$aos_home/releases"
           release_dir="$aos_home/releases/${AOS_PRODUCT_VERSION}"
           mkdir -m 0700 "$release_dir"
-          tar -xzf "$SIGNED_ARCHIVE" -C "$extract"
-          bundle="$extract/unicity-aos-${AOS_PRODUCT_VERSION}-${DARWIN_TARGET}"
+          tar -xzf "$SIGNED_GNU_ARCHIVE" -C "$extract"
+          bundle="$extract/unicity-aos-${AOS_PRODUCT_VERSION}-${LINUX_TARGET}"
           for member in Distro.toml Distro.lock Distro.sig release-manifest.json
           do
             [[ -f "$bundle/$member" && ! -L "$bundle/$member" ]]
@@ -826,39 +848,68 @@ jobs:
           set -euo pipefail
           output="$RUNNER_TEMP/rehearsal-darwin"
           mkdir -p "$output"
-          cp "$SIGNED_ARCHIVE" "$output/"
-          extract="$RUNNER_TEMP/signed-extract"
-          mkdir "$extract"
-          tar -xzf "$SIGNED_ARCHIVE" -C "$extract"
-          bundle="$extract/unicity-aos-${AOS_PRODUCT_VERSION}-${DARWIN_TARGET}"
-          cp "$bundle/release-manifest.json" "$output/"
-          cp "$bundle/runtime-compatibility.toml" "$output/"
-          cp "$bundle/Distro.toml" "$output/"
-          cp "$bundle/Distro.lock" "$output/"
-          cp "$bundle/Distro.sig" "$output/"
+          cp "$SIGNED_DARWIN_ARCHIVE" "$output/"
+          cp "$SIGNED_GNU_ARCHIVE" "$output/"
+          darwin_extract="$RUNNER_TEMP/signed-darwin-extract"
+          gnu_extract="$RUNNER_TEMP/signed-gnu-extract"
+          mkdir "$darwin_extract" "$gnu_extract"
+          tar -xzf "$SIGNED_DARWIN_ARCHIVE" -C "$darwin_extract"
+          tar -xzf "$SIGNED_GNU_ARCHIVE" -C "$gnu_extract"
+          darwin_bundle="$darwin_extract/unicity-aos-${AOS_PRODUCT_VERSION}-${DARWIN_TARGET}"
+          gnu_bundle="$gnu_extract/unicity-aos-${AOS_PRODUCT_VERSION}-${LINUX_TARGET}"
+          cp "$darwin_bundle/release-manifest.json" "$output/"
+          cp "$darwin_bundle/runtime-compatibility.toml" "$output/"
+          cp "$darwin_bundle/Distro.toml" "$output/"
+          cp "$darwin_bundle/Distro.lock" "$output/"
+          cp "$darwin_bundle/Distro.sig" "$output/"
+          cp "$gnu_bundle/release-manifest.json" "$output/release-manifest-${LINUX_TARGET}.json"
+          cp "$gnu_bundle/runtime-compatibility.toml" "$output/runtime-compatibility-${LINUX_TARGET}.toml"
+          cp "$gnu_bundle/Distro.toml" "$output/Distro-${LINUX_TARGET}.toml"
+          cp "$gnu_bundle/Distro.lock" "$output/Distro-${LINUX_TARGET}.lock"
+          cp "$gnu_bundle/Distro.sig" "$output/Distro-${LINUX_TARGET}.sig"
           cd "$output"
-          asset=$(basename "$SIGNED_ARCHIVE")
-          BLAKE3=$(b3sum -- "$asset" | awk '{print $1}')
-          SHA256=$(sha256sum -- "$asset" | awk '{print $1}')
+          darwin_asset=$(basename "$SIGNED_DARWIN_ARCHIVE")
+          gnu_asset=$(basename "$SIGNED_GNU_ARCHIVE")
+          DARWIN_BLAKE3=$(b3sum -- "$darwin_asset" | awk '{print $1}')
+          DARWIN_SHA256=$(sha256sum -- "$darwin_asset" | awk '{print $1}')
+          GNU_BLAKE3=$(b3sum -- "$gnu_asset" | awk '{print $1}')
+          GNU_SHA256=$(sha256sum -- "$gnu_asset" | awk '{print $1}')
           {
             echo "# REHEARSAL-ONLY digests; not publication checksums"
-            b3sum -- "$asset"
+            b3sum -- "$darwin_asset"
+            b3sum -- "$gnu_asset"
           } > REHEARSAL-BLAKE3SUMS.txt
           {
             echo "# REHEARSAL-ONLY digests; not publication checksums"
-            sha256sum -- "$asset"
+            sha256sum -- "$darwin_asset"
+            sha256sum -- "$gnu_asset"
           } > REHEARSAL-SHA256SUMS.txt
           python3 - "$output/REHEARSAL-ONLY-identity.json" \
             "$SOURCE_COMMIT" \
             "$ASTRID_SOURCE_COMMIT" \
             "$QA_PUBKEY" \
-            "$BLAKE3" \
-            "$SHA256" <<'PY'
+            "$darwin_asset" \
+            "$DARWIN_BLAKE3" \
+            "$DARWIN_SHA256" \
+            "$gnu_asset" \
+            "$GNU_BLAKE3" \
+            "$GNU_SHA256" <<'PY'
           import json
           import pathlib
           import sys
 
-          output, aos_commit, astrid_commit, pubkey, blake3, sha256 = sys.argv[1:]
+          (
+              output,
+              aos_commit,
+              astrid_commit,
+              pubkey,
+              darwin_archive,
+              darwin_blake3,
+              darwin_sha256,
+              gnu_archive,
+              gnu_blake3,
+              gnu_sha256,
+          ) = sys.argv[1:]
           identity = {
               "schema_version": 1,
               "scope": "REHEARSAL-ONLY",
@@ -873,14 +924,30 @@ jobs:
                   "source_commit": astrid_commit,
                   "runtime_version": "2026.9.0",
                   "runtime_target": "aarch64-apple-darwin",
+                  "runtime_targets": [
+                      "aarch64-apple-darwin",
+                      "x86_64-unknown-linux-gnu",
+                  ],
               },
               "distro_signing": {
                   "key_scope": "ephemeral-per-run-qa",
                   "public_key": pubkey,
               },
               "signed_archive_digests": {
-                  "blake3_rehearsal_only": f"blake3:{blake3}",
-                  "sha256_rehearsal_only": f"sha256:{sha256}",
+                  "aarch64-apple-darwin": {
+                      "archive": darwin_archive,
+                      "blake3_rehearsal_only": f"blake3:{darwin_blake3}",
+                      "sha256_rehearsal_only": f"sha256:{darwin_sha256}",
+                      "key_scope": "ephemeral-per-run-qa",
+                      "public_key": pubkey,
+                  },
+                  "x86_64-unknown-linux-gnu": {
+                      "archive": gnu_archive,
+                      "blake3_rehearsal_only": f"blake3:{gnu_blake3}",
+                      "sha256_rehearsal_only": f"sha256:{gnu_sha256}",
+                      "key_scope": "ephemeral-per-run-qa",
+                      "public_key": pubkey,
+                  },
               },
           }
           pathlib.Path(output).write_text(

--- a/scripts/test-rehearsal-sign-workflow-contract.sh
+++ b/scripts/test-rehearsal-sign-workflow-contract.sh
@@ -248,13 +248,23 @@ for marker in (
         raise SystemExit(f"compose job is missing shared-identity archive evidence marker: {marker}")
 darwin_verify = compose.index("signed Darwin rehearsal archive has no Distro signature")
 gnu_verify = compose.index("signed GNU rehearsal archive has no Distro signature")
-seed_destroy = compose.index(
-    "# Destroy the persistent QA seed only after both signed archives were verified."
-)
-if not (darwin_verify < gnu_verify < seed_destroy):
-    raise SystemExit("persistent QA seed must be destroyed only after both signed archives are verified")
-if '[[ ! -e "$QA_SEED_FILE" ]]' not in compose:
-    raise SystemExit("compose job must prove the persistent QA seed was destroyed")
+seed_zero = compose.index('file.write(b"\\0" * 32)')
+seed_flush = compose.index("file.flush()", seed_zero)
+seed_fsync = compose.index("os.fsync(file.fileno())", seed_flush)
+seed_unlink = compose.index("path.unlink()", seed_fsync)
+seed_absence = compose.index('[[ ! -e "$QA_SEED_FILE" ]]', seed_unlink)
+if not (
+    darwin_verify
+    < gnu_verify
+    < seed_zero
+    < seed_flush
+    < seed_fsync
+    < seed_unlink
+    < seed_absence
+):
+    raise SystemExit(
+        "persistent QA seed zero-write/fsync/unlink/absence proof must follow both archive verifications"
+    )
 
 darwin_runtime = sections.get("build-astrid-darwin")
 if darwin_runtime is None:

--- a/scripts/test-rehearsal-sign-workflow-contract.sh
+++ b/scripts/test-rehearsal-sign-workflow-contract.sh
@@ -22,11 +22,30 @@ grep -Fq 'ASTRID_RUNTIME_TARGET: aarch64-apple-darwin' "$workflow"
 grep -Fq 'submodules: recursive' "$workflow"
 grep -Fq -- '--extract-release-sealer' "$workflow"
 grep -Fq -- '--sign-release-archive' "$workflow"
+if [[ $(grep -Fc -- '--sign-release-archive' "$workflow") -ne 2 ]]; then
+  echo "rehearsal workflow must sign exactly one Darwin and one GNU archive" >&2
+  exit 1
+fi
+if [[ $(grep -Fc 'AOS_DISTRO_ED25519_SEED="$QA_SEED"' "$workflow") -ne 2 ]]; then
+  echo "Darwin and GNU rehearsal archives must share one ephemeral QA seed" >&2
+  exit 1
+fi
+if [[ $(grep -Fc '"$NATIVE_SEALER" \' "$workflow") -ne 2 ]] || \
+   [[ $(grep -Fc '"$NATIVE_SEALER_ARCHIVE"' "$workflow") -ne 2 ]]; then
+  echo "Darwin and GNU rehearsal archives must share the authenticated GNU native sealer" >&2
+  exit 1
+fi
 grep -Fq 'secrets.token_hex(32)' "$workflow"
 grep -Fq 'write_tar_listing' "$workflow"
 grep -Fq 'tar -tzf "$archive" > "$listing"' "$workflow"
-grep -Fq 'SIGNED_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-tar-listing.XXXXXX")' "$workflow"
-grep -Fq "grep -q '/Distro.sig$' \"\$SIGNED_TAR_LISTING\"" "$workflow"
+grep -Fq 'SIGNED_DARWIN_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-darwin-tar-listing.XXXXXX")' "$workflow"
+grep -Fq 'SIGNED_GNU_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-gnu-tar-listing.XXXXXX")' "$workflow"
+grep -Fq "grep -q '/Distro.sig$' \"\$SIGNED_DARWIN_TAR_LISTING\"" "$workflow"
+grep -Fq "grep -q '/Distro.sig$' \"\$SIGNED_GNU_TAR_LISTING\"" "$workflow"
+grep -Fq 'SIGNED_DARWIN_ARCHIVE=$signed_darwin' "$workflow"
+grep -Fq 'SIGNED_GNU_ARCHIVE=$signed_gnu' "$workflow"
+grep -Fq 'LINUX_ARCHIVE=${candidates[0]}' "$workflow"
+grep -Fq 'ephemeral QA seed destroyed after both signed archive verifications' "$workflow"
 if grep -Eq 'tar[[:space:]][^|]*\|[[:space:]]*grep[[:space:]]+(-q|--quiet)' "$workflow"; then
   echo "rehearsal workflow must not pipe tar into grep -q" >&2
   exit 1
@@ -207,6 +226,36 @@ if 'ASTRID_RUNTIME_VERSION: &str = "0.10.4"' not in compose:
 if 'runtime["version"] != "2026.9.0"' not in compose:
     raise SystemExit("compose job must validate runtime-compatibility version")
 
+sign_call_archives = re.findall(
+    r'AOS_DISTRO_ED25519_SEED="\$QA_SEED"\s+\\\s*'
+    r'"\$REHEARSAL_CHECKOUT/scripts/package-release\.sh"\s+\\\s*'
+    r'--sign-release-archive\s+\\\s*("\$[A-Z_]+")',
+    compose,
+)
+if sign_call_archives != ['"$DARWIN_ARCHIVE"', '"$LINUX_ARCHIVE"']:
+    raise SystemExit(
+        "rehearsal workflow must make exactly one shared-identity Darwin sign call followed by one GNU sign call"
+    )
+if compose.count('"$NATIVE_SEALER"') != 2 or compose.count('"$NATIVE_SEALER_ARCHIVE"') != 2:
+    raise SystemExit("both target sign calls must use the authenticated GNU native sealer")
+for marker in (
+    'SIGNED_DARWIN_ARCHIVE=$signed_darwin',
+    'SIGNED_GNU_ARCHIVE=$signed_gnu',
+    'grep -q \'/Distro.sig$\' "$SIGNED_DARWIN_TAR_LISTING"',
+    'grep -q \'/Distro.sig$\' "$SIGNED_GNU_TAR_LISTING"',
+):
+    if marker not in compose:
+        raise SystemExit(f"compose job is missing shared-identity archive evidence marker: {marker}")
+darwin_verify = compose.index("signed Darwin rehearsal archive has no Distro signature")
+gnu_verify = compose.index("signed GNU rehearsal archive has no Distro signature")
+seed_destroy = compose.index(
+    "# Destroy the persistent QA seed only after both signed archives were verified."
+)
+if not (darwin_verify < gnu_verify < seed_destroy):
+    raise SystemExit("persistent QA seed must be destroyed only after both signed archives are verified")
+if '[[ ! -e "$QA_SEED_FILE" ]]' not in compose:
+    raise SystemExit("compose job must prove the persistent QA seed was destroyed")
+
 darwin_runtime = sections.get("build-astrid-darwin")
 if darwin_runtime is None:
     raise SystemExit("rehearsal workflow is missing build-astrid-darwin")
@@ -259,6 +308,10 @@ if "Prove overlay-built GNU AOS accepts the signed Distro" not in compose:
 probe = '"$LINUX_AOS_BINARY" distro apply --principal operator-qa --yes'
 if probe not in compose:
     raise SystemExit("compose job must run overlay-built GNU AOS distro apply as the consume probe")
+if 'tar -xzf "$SIGNED_GNU_ARCHIVE"' not in compose:
+    raise SystemExit("GNU consume probe must consume the signed GNU archive")
+if 'bundle="$extract/unicity-aos-${AOS_PRODUCT_VERSION}-${LINUX_TARGET}"' not in compose:
+    raise SystemExit("GNU consume probe must select the signed GNU archive root")
 if "rehearsal-consume-aos" not in compose:
     raise SystemExit("compose job must plant the signed Distro into a disposable AOS_HOME")
 if "bundled Distro Apply verification failed" not in compose:
@@ -278,6 +331,21 @@ if not (
     < compose.index("Assemble rehearsal-only evidence")
 ):
     raise SystemExit("compose job must prove overlay-built AOS after signing and before evidence upload")
+
+for marker in (
+    'cp "$SIGNED_DARWIN_ARCHIVE" "$output/"',
+    'cp "$SIGNED_GNU_ARCHIVE" "$output/"',
+    'b3sum -- "$darwin_asset"',
+    'b3sum -- "$gnu_asset"',
+    'sha256sum -- "$darwin_asset"',
+    'sha256sum -- "$gnu_asset"',
+    '"aarch64-apple-darwin": {',
+    '"x86_64-unknown-linux-gnu": {',
+    '"publication_allowed": False',
+    '"key_scope": "ephemeral-per-run-qa"',
+):
+    if marker not in compose:
+        raise SystemExit(f"rehearsal evidence is missing: {marker}")
 
 if re.search(r"QA_SEED[^\n]*GITHUB_(?:ENV|OUTPUT)", text):
     raise SystemExit("ephemeral QA seed must never be emitted")


### PR DESCRIPTION
## Summary

- sign the already-composed `x86_64-unknown-linux-gnu` rehearsal archive alongside Darwin with the same ephemeral per-run QA Ed25519 identity and authenticated native GNU sealer
- require both archives to contain `Distro.sig` before destroying the persisted QA seed, then exercise the signed GNU archive through the disposable GNU AOS Distro Apply verification path
- export both signed archives with per-target rehearsal-only BLAKE3/SHA256 identity while retaining the existing artifact name

## Trust and release boundaries

- the workflow remains manual-dispatch-only, `contents: read`, and bound to an exact protected-`main` source commit
- `publication_allowed` remains `false`; the identity is explicitly `ephemeral-per-run-qa`
- production `.github/workflows/release.yml`, `scripts/package-release.sh`, Distro trust policy, signing secret, versions, tags, publishing, promotion, installers, and live homes are unchanged
- this PR does not dispatch the rehearsal workflow

## Proof

- `bash scripts/test-rehearsal-sign-workflow-contract.sh`
- `bash scripts/test-package-release.sh`
- `actionlint .github/workflows/rehearsal-sign-darwin.yml`
- `git diff --check 7bf5093a15b957dc9c2ef1747cbde29947491dc9..b6c0a87ff257221a9a9266e49ec4242f192024a4`
- independent exact-workflow review accepted blob `dd8fe28fba3487498f13b9b6c757561b1d6cb2fc`
- independent focused exact-head review accepted `b6c0a87ff257221a9a9266e49ec4242f192024a4`, including a mutation that moves the actual seed-destruction heredoc before GNU signing and must fail the contract

## Claim limits

This establishes source and contract evidence only. It does not claim a hosted rehearsal execution, exported artifact, production signing identity, tag, publication, promotion, or release readiness.
