### PR TITLE
fix(release): emit machine-readable rehearsal checksums

### DIFF
--- a/.github/workflows/rehearsal-sign-darwin.yml
+++ b/.github/workflows/rehearsal-sign-darwin.yml
@@ -875,15 +875,15 @@ jobs:
           GNU_BLAKE3=$(b3sum -- "$gnu_asset" | awk '{print $1}')
           GNU_SHA256=$(sha256sum -- "$gnu_asset" | awk '{print $1}')
           {
-            echo "# REHEARSAL-ONLY digests; not publication checksums"
             b3sum -- "$darwin_asset"
             b3sum -- "$gnu_asset"
           } > REHEARSAL-BLAKE3SUMS.txt
+          b3sum --check REHEARSAL-BLAKE3SUMS.txt
           {
-            echo "# REHEARSAL-ONLY digests; not publication checksums"
             sha256sum -- "$darwin_asset"
             sha256sum -- "$gnu_asset"
           } > REHEARSAL-SHA256SUMS.txt
+          sha256sum --check REHEARSAL-SHA256SUMS.txt
           python3 - "$output/REHEARSAL-ONLY-identity.json" \
             "$SOURCE_COMMIT" \
             "$ASTRID_SOURCE_COMMIT" \
@@ -914,6 +914,10 @@ jobs:
               "schema_version": 1,
               "scope": "REHEARSAL-ONLY",
               "digest_scope": "REHEARSAL-ONLY",
+              "checksum_manifest_note": (
+                  "REHEARSAL-ONLY digests; not publication checksums. "
+                  "Checksum manifests contain machine-readable records only."
+              ),
               "publication_allowed": False,
               "aos": {
                   "repository": "unicity-aos/aos-ce",

--- a/scripts/test-rehearsal-sign-workflow-contract.sh
+++ b/scripts/test-rehearsal-sign-workflow-contract.sh
@@ -99,6 +99,37 @@ grep -Fq 'QA_SEED_FILE="$RUNNER_TEMP/rehearsal-qa-seed"' "$workflow"
 grep -Fq 'actions/upload-artifact@' "$workflow"
 grep -Fq 'REHEARSAL-ONLY' "$workflow"
 
+# The uploaded checksum manifest is consumed by b3sum itself. Keep the
+# manifest records-only: b3sum does not accept the explanatory comment that
+# older rehearsal output prepended. Exercise the real verifier rather than
+# relying on a text-only workflow assertion.
+checksum_fixture=$(mktemp -d "${TMPDIR:-/tmp}/rehearsal-checksum.XXXXXX")
+printf 'darwin rehearsal archive\n' > "$checksum_fixture/aarch64-apple-darwin.tar.gz"
+printf 'gnu rehearsal archive\n' > "$checksum_fixture/x86_64-unknown-linux-gnu.tar.gz"
+(
+  cd "$checksum_fixture"
+  b3sum -- aarch64-apple-darwin.tar.gz x86_64-unknown-linux-gnu.tar.gz > \
+    REHEARSAL-BLAKE3SUMS.txt
+  b3sum --check REHEARSAL-BLAKE3SUMS.txt
+)
+grep -Fq 'b3sum --check REHEARSAL-BLAKE3SUMS.txt' "$workflow"
+grep -Fq 'sha256sum --check REHEARSAL-SHA256SUMS.txt' "$workflow"
+if grep -Fq 'echo "# REHEARSAL-ONLY digests; not publication checksums"' "$workflow"; then
+  echo "rehearsal checksum manifests must contain records only; keep notes in identity JSON" >&2
+  exit 1
+fi
+
+python3 - "$workflow" <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+if '"checksum_manifest_note": (' not in text:
+    raise SystemExit("rehearsal identity must explain the records-only checksum scope")
+if '"Checksum manifests contain machine-readable records only."' not in text:
+    raise SystemExit("rehearsal identity must preserve the checksum format explanation")
+PY
+
 if grep -Eq '^(  )?(push|pull_request|schedule|workflow_call):' "$workflow"; then
   echo "rehearsal workflow must be dispatch-only" >&2
   exit 1


### PR DESCRIPTION
## Summary

Keep the dispatch-only Darwin rehearsal checksum files consumable by standard checksum tools. The manifests now contain only checksum records and are verified in the workflow; the rehearsal-only explanation remains in the signed identity JSON.

## Validation

- `bash scripts/test-rehearsal-sign-workflow-contract.sh`
- The contract test generates a two-archive fixture and validates it with `b3sum --check`.

## Scope

This changes rehearsal evidence only. It does not publish artifacts, tag a release, or alter release activation.