### PR TITLE
fix(release): include GNU FUSE provider

### DIFF
--- a/.github/workflows/rehearsal-sign-darwin.yml
+++ b/.github/workflows/rehearsal-sign-darwin.yml
@@ -316,13 +316,17 @@ jobs:
                 --release \
                 --target "$TARGET" \
                 --target-dir target/glibc-2.31 \
-                -p astrid
+                -p astrid \
+                -p astrid-storage-provider-fuse
             '
       - name: Package the rehearsal runtime archive
         run: |
           root="astrid-${ASTRID_RUNTIME_VERSION}-${TARGET}"
           mkdir -p "$RUNNER_TEMP/runtime-stage/$root"
-          for binary in astrid astrid-daemon astrid-build astrid-emit; do
+          for binary in \
+            astrid astrid-daemon astrid-build astrid-emit \
+            astrid-storage-provider-fuse
+          do
             install -m 0755 \
               "target/glibc-2.31/${TARGET}/release/$binary" \
               "$RUNNER_TEMP/runtime-stage/$root/$binary"
@@ -331,7 +335,8 @@ jobs:
             "$RUNNER_TEMP/runtime-stage/$root/astrid" \
             "$RUNNER_TEMP/runtime-stage/$root/astrid-daemon" \
             "$RUNNER_TEMP/runtime-stage/$root/astrid-build" \
-            "$RUNNER_TEMP/runtime-stage/$root/astrid-emit"
+            "$RUNNER_TEMP/runtime-stage/$root/astrid-emit" \
+            "$RUNNER_TEMP/runtime-stage/$root/astrid-storage-provider-fuse"
           MTIME=$(git log -1 --format=%ct)
           python3 scripts/package_release_archive.py \
             --root "$RUNNER_TEMP/runtime-stage/$root" \
@@ -642,7 +647,8 @@ jobs:
           python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py" \
             "$LINUX_RUNTIME_ARCHIVE" \
             "astrid-${ASTRID_RUNTIME_VERSION}-${LINUX_TARGET}" \
-            astrid astrid-daemon astrid-build astrid-emit
+            astrid astrid-daemon astrid-build astrid-emit \
+            astrid-storage-provider-fuse
           python3 scripts/capsule_release.py --artifacts capsule-artifacts
           "$REHEARSAL_CHECKOUT/scripts/package-release.sh" \
             "$LINUX_TARGET" \

--- a/changes/gnu-fuse-artifact.fixed.md
+++ b/changes/gnu-fuse-artifact.fixed.md
@@ -1,0 +1,1 @@
+- Require authenticated GNU 2026.9.0 rehearsal archives to carry the `astrid-storage-provider-fuse` runtime member while preserving the historical GNU 0.10.4 four-binary portable contract; this archive-only rehearsal requirement does not imply installer persistence or release shipment.

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -154,7 +154,15 @@ runtime_executables = [
     "astrid-emit",
 ]
 target = manifest.get("target")
-if isinstance(target, str) and target.endswith("-apple-darwin"):
+runtime = manifest.get("runtime")
+runtime_version = runtime.get("version") if isinstance(runtime, dict) else None
+if (
+    isinstance(target, str)
+    and target.endswith("-unknown-linux-gnu")
+    and runtime_version == "2026.9.0"
+):
+    runtime_executables.append("astrid-storage-provider-fuse")
+elif isinstance(target, str) and target.endswith("-apple-darwin"):
     runtime_executables.append("astrid-storage-provider-fskit")
 expected_executables = [
     "bin/aos",
@@ -493,7 +501,9 @@ fi
 python3 "$repo_root/scripts/capsule_release.py" --artifacts "$capsule_artifacts"
 
 runtime_binaries=(astrid astrid-daemon astrid-build astrid-emit)
-if [[ "$target" == *-apple-darwin ]]; then
+if [[ "$target" == *-unknown-linux-gnu && "$runtime_version" == "2026.9.0" ]]; then
+  runtime_binaries+=(astrid-storage-provider-fuse)
+elif [[ "$target" == *-apple-darwin ]]; then
   runtime_binaries+=(astrid-storage-provider-fskit)
 fi
 
@@ -585,22 +595,22 @@ release_files = {}
 for line in pathlib.Path(inventory_path).read_text(encoding="utf-8").splitlines():
     relative, mode, file_digest = line.split("\t")
     release_files[relative] = {"blake3": file_digest, "mode": int(mode, 8)}
+runtime_executables = [
+    "bin/aos",
+    "runtime/bin/astrid",
+    "runtime/bin/astrid-daemon",
+    "runtime/bin/astrid-build",
+    "runtime/bin/astrid-emit",
+]
+if target.endswith("-unknown-linux-gnu") and runtime == "2026.9.0":
+    runtime_executables.append("runtime/bin/astrid-storage-provider-fuse")
+elif target.endswith("-apple-darwin"):
+    runtime_executables.append("runtime/bin/astrid-storage-provider-fskit")
 manifest = {
     "schema_version": 2,
     "product": {"name": "Unicity AOS Community Edition", "version": product},
     "target": target,
-    "executables": [
-        "bin/aos",
-        "runtime/bin/astrid",
-        "runtime/bin/astrid-daemon",
-        "runtime/bin/astrid-build",
-        "runtime/bin/astrid-emit",
-        *(
-            ["runtime/bin/astrid-storage-provider-fskit"]
-            if target.endswith("-apple-darwin")
-            else []
-        ),
-    ],
+    "executables": runtime_executables,
     "layout": {
         "release_directory": f"releases/{product}",
         "runtime_executables": "runtime/bin",

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -276,6 +276,10 @@ tar -tzf "$archive" > "$work/files"
 grep -q '/bin/aos$' "$work/files"
 grep -q '/libexec/install.sh$' "$work/files"
 grep -q '/runtime/bin/astrid-daemon$' "$work/files"
+if grep -q '/runtime/bin/astrid-storage-provider-fuse$' "$work/files"; then
+  echo "0.10.4 GNU release archive unexpectedly contains the FUSE provider" >&2
+  exit 1
+fi
 grep -q '/runtime-compatibility.toml$' "$work/files"
 test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 22
 grep -q '/capsule-assets.txt$' "$work/files"
@@ -359,6 +363,128 @@ assert manifest["verifier"] == {
     "sha256": "ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc",
 }
 PY
+
+# Rehearsal runtime 2026.9.0 has an explicit GNU FUSE provider contract while
+# the stable 0.10.4 GNU archive above remains the four portable binaries.
+versioned_repo="$work/aos-2026.9.0-contract"
+mkdir -p \
+  "$versioned_repo/scripts" \
+  "$versioned_repo/crates/unicity-aos-bootstrap" \
+  "$versioned_repo/distros/community/unicity-ce"
+cp "$repo_root/Cargo.toml" "$versioned_repo/Cargo.toml"
+cp "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" \
+  "$versioned_repo/crates/unicity-aos-bootstrap/Cargo.toml"
+cp -R "$repo_root/capsules" "$versioned_repo/"
+cp -R "$repo_root/release" "$versioned_repo/"
+cp "$repo_root/distros/community/unicity-ce/Distro.toml" \
+  "$versioned_repo/distros/community/unicity-ce/Distro.toml"
+cp "$repo_root/install.sh" "$repo_root/README.md" "$versioned_repo/"
+cp "$repo_root/scripts/capsule_release.py" \
+  "$repo_root/scripts/package-release.sh" \
+  "$repo_root/scripts/validate-runtime-archive.py" \
+  "$versioned_repo/scripts/"
+python3 - "$versioned_repo/release/runtime-compatibility.toml" \
+  "$versioned_repo/distros/community/unicity-ce/Distro.toml" <<'PY'
+import pathlib
+import sys
+
+runtime_path, distro_path = map(pathlib.Path, sys.argv[1:])
+runtime_lines = runtime_path.read_text(encoding="utf-8").splitlines()
+replacements = {
+    "version": 'version = "2026.9.0"',
+    "tag": 'tag = "rehearsal-only-2026.9.0"',
+    "version-requirement": 'version-requirement = "=2026.9.0"',
+    "release-workflow-identity": 'release-workflow-identity = "rehearsal-only:test"',
+}
+in_runtime = False
+for index, line in enumerate(runtime_lines):
+    if line == "[runtime]":
+        in_runtime = True
+        continue
+    if line.startswith("["):
+        in_runtime = False
+    if in_runtime and "=" in line:
+        key = line.split("=", 1)[0].strip()
+        if key in replacements:
+            runtime_lines[index] = replacements[key]
+runtime_path.write_text("\n".join(runtime_lines) + "\n", encoding="utf-8")
+distro_text = distro_path.read_text(encoding="utf-8")
+distro_path.write_text(
+    distro_text.replace('astrid-version = "=0.10.4"', 'astrid-version = "=2026.9.0"'),
+    encoding="utf-8",
+)
+PY
+
+versioned_runtime_root="$work/astrid-2026.9.0-$target"
+versioned_runtime_archive="$work/runtime-2026.9.0.tar.gz"
+versioned_output="$work/output-2026.9.0"
+mkdir -p "$versioned_runtime_root" "$versioned_output"
+for binary in astrid astrid-daemon astrid-build astrid-emit astrid-storage-provider-fuse; do
+  printf '#!/bin/sh\nexit 0\n' > "$versioned_runtime_root/$binary"
+  chmod 755 "$versioned_runtime_root/$binary"
+done
+COPYFILE_DISABLE=1 tar -czf "$versioned_runtime_archive" \
+  -C "$work" "$(basename "$versioned_runtime_root")"
+bash "$versioned_repo/scripts/package-release.sh" \
+  "$target" \
+  "$work/aos" \
+  "$versioned_runtime_archive" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$work/capsules" \
+  "$versioned_output" >/dev/null
+versioned_archive="$versioned_output/unicity-aos-$product_version-$target.tar.gz"
+versioned_files="$work/versioned-files"
+tar -tzf "$versioned_archive" > "$versioned_files"
+grep -q '/runtime/bin/astrid-storage-provider-fuse$' "$versioned_files"
+mkdir "$work/versioned-extract"
+tar -xzf "$versioned_archive" -C "$work/versioned-extract"
+versioned_bundle="$work/versioned-extract/unicity-aos-$product_version-$target"
+versioned_provider="$versioned_bundle/runtime/bin/astrid-storage-provider-fuse"
+test -x "$versioned_provider"
+test "$(stat -c '%a' "$versioned_provider" 2>/dev/null || stat -f '%Lp' "$versioned_provider")" = 755
+python3 - "$versioned_bundle/release-manifest.json" "$versioned_provider" <<'PY'
+import json
+import pathlib
+import subprocess
+import sys
+
+manifest_path, provider_path = map(pathlib.Path, sys.argv[1:])
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+provider = "runtime/bin/astrid-storage-provider-fuse"
+assert manifest["runtime"]["version"] == "2026.9.0"
+assert manifest["executables"] == [
+    "bin/aos",
+    "runtime/bin/astrid",
+    "runtime/bin/astrid-daemon",
+    "runtime/bin/astrid-build",
+    "runtime/bin/astrid-emit",
+    provider,
+]
+record = manifest["release_files"][provider]
+assert record == {
+    "blake3": subprocess.check_output(["b3sum", "--", str(provider_path)], text=True).split()[0],
+    "mode": 0o755,
+}
+PY
+
+versioned_runtime_name=$(basename "$versioned_runtime_root")
+missing_versioned_root="$work/missing-2026.9.0-fuse/$versioned_runtime_name"
+mkdir -p "$missing_versioned_root" "$work/missing-2026.9.0-output"
+for binary in astrid astrid-daemon astrid-build astrid-emit; do
+  cp "$versioned_runtime_root/$binary" "$missing_versioned_root/$binary"
+done
+COPYFILE_DISABLE=1 tar -czf "$work/missing-2026.9.0-runtime.tar.gz" \
+  -C "$work/missing-2026.9.0-fuse" "$(basename "$versioned_runtime_root")"
+if bash "$versioned_repo/scripts/package-release.sh" \
+  "$target" \
+  "$work/aos" \
+  "$work/missing-2026.9.0-runtime.tar.gz" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$work/capsules" \
+  "$work/missing-2026.9.0-output" >/dev/null 2>&1; then
+  echo "2026.9.0 GNU package accepted a runtime without the FUSE provider" >&2
+  exit 1
+fi
 
 darwin_target=aarch64-apple-darwin
 darwin_runtime_root="$work/astrid-$runtime_version-$darwin_target"
@@ -550,8 +676,8 @@ for archive_target in "${targets[@]}"; do
   rm -f "$target_root/Distro.lock" "$target_root/Distro.sig"
   cat > "$target_root/runtime/bin/astrid" <<'SENTINEL'
 #!/bin/sh
-touch "${AOS_TEST_SENTINEL:?}"
-exit 97
+  touch "${AOS_TEST_SENTINEL:?}"
+  exit 97
 SENTINEL
   chmod 755 "$target_root/runtime/bin/astrid"
   sentinel_digest=$(b3sum -- "$target_root/runtime/bin/astrid" | awk '{print $1}')

--- a/scripts/test-rehearsal-sign-workflow-contract.sh
+++ b/scripts/test-rehearsal-sign-workflow-contract.sh
@@ -307,6 +307,16 @@ for marker in (
     if marker not in darwin_runtime:
         raise SystemExit(f"Darwin runtime job is missing {marker}")
 
+gnu_runtime = sections.get("build-astrid-linux-gnu")
+if gnu_runtime is None:
+    raise SystemExit("rehearsal workflow is missing build-astrid-linux-gnu")
+for marker in (
+    "-p astrid-storage-provider-fuse",
+    "astrid-storage-provider-fuse",
+):
+    if marker not in gnu_runtime:
+        raise SystemExit(f"GNU runtime job is missing {marker}")
+
 validator_call = 'python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py"'
 for step_name in ("Compose the GNU native sealer source", "Compose the Darwin candidate"):
     step = re.search(
@@ -320,11 +330,14 @@ for step_name in ("Compose the GNU native sealer source", "Compose the Darwin ca
         raise SystemExit(f"{step_name} must invoke the runtime archive validator exactly once")
     if re.search(rf"(?m)^\s*{re.escape(validator_call)}\s+\\\s*$", body) is None:
         raise SystemExit(f"{step_name} must invoke the validator with python3 and continued arguments")
+    has_fuse = "astrid-storage-provider-fuse" in body
     has_fskit = "astrid-storage-provider-fskit" in body
     if step_name == "Compose the Darwin candidate" and not has_fskit:
         raise SystemExit("Darwin composition must require the FSKit provider")
+    if step_name == "Compose the GNU native sealer source" and not has_fuse:
+        raise SystemExit("GNU composition must require the FUSE provider")
     if step_name == "Compose the GNU native sealer source" and has_fskit:
-        raise SystemExit("GNU composition must retain the four portable runtime binaries")
+        raise SystemExit("GNU composition must not require the Darwin FSKit provider")
 
 if re.search(r'(?m)^\s*"\$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive\.py"', compose):
     raise SystemExit("compose job must not direct-exec the runtime archive validator")


### PR DESCRIPTION
## Summary

Require `astrid-storage-provider-fuse` in GNU rehearsal archives built against the 2026.9.0 runtime overlay. The archive member is executable and bound in the release manifest with a BLAKE3 digest.

The shared package contract remains versioned: the checked-in 0.10.4 runtime continues to require four portable GNU binaries, while 2026.9.0 requires FUSE and rejects a missing provider. Darwin remains FSKit-only.

## Validation

- `python3 scripts/test_validate_runtime_archive.py`
- `bash scripts/test-invoke-runtime-archive-validator.sh`
- `bash scripts/test-package-release.sh`
- `bash scripts/test-rehearsal-sign-workflow-contract.sh`
- `bash scripts/test-install.sh`
- `bash scripts/test-upgrade-self-heal.sh`

## Scope

This is rehearsal/archive membership only. It does not publish, tag, activate a release, or claim installed GNU FUSE persistence; that installer/self-heal slice remains separate.