### PR TITLE
fix(release): correct Community capsule count

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -589,7 +589,7 @@ jobs:
 
           This product release bundles Astrid Runtime ${RUNTIME_TAG}. The exact runtime release identity, WIT commit, and compatibility pins are published in \`runtime-compatibility.toml\` and in every archive's \`release-manifest.json\`.
 
-          The release also contains the 19 signed, installable capsule artifacts selected by Community Edition. Published \`astrid-capsule-*\` identities remain unchanged.
+          The release also contains the 22 signed, installable capsule artifacts selected by Community Edition. Published \`astrid-capsule-*\` identities remain unchanged.
 
           Install this exact release:
 

--- a/scripts/test-channel-workflow-contract.sh
+++ b/scripts/test-channel-workflow-contract.sh
@@ -48,6 +48,26 @@ grep -Fq 'b3sum --check BLAKE3SUMS.txt' "$release_workflow"
 grep -Fq "repos/\$GITHUB_REPOSITORY/immutable-releases" "$release_workflow"
 grep -Fq '.immutable == true' "$release_workflow"
 grep -Fq 'AOS_RELEASE_ADMIN_TOKEN' "$release_workflow"
+
+python3 - "$repo_root" "$release_workflow" <<'PY'
+import pathlib
+import sys
+
+repo_root = pathlib.Path(sys.argv[1])
+sys.path.insert(0, str(repo_root / "scripts"))
+
+from capsule_release import source_contract
+
+text = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+expected = len(source_contract())
+claim = (
+    f"The release also contains the {expected} signed, installable capsule artifacts "
+    "selected by Community Edition."
+)
+if claim not in text:
+    raise SystemExit("release notes must state the capsule count enforced by source_contract")
+PY
+
 grep -Fq 'actions: read' "$workflow"
 grep -Fq 'actions/runs/$GITHUB_RUN_ID' "$release_workflow"
 grep -Fq -- "- '!20[0-9][0-9].*-nightly.*'" "$release_workflow"


### PR DESCRIPTION
Correct the generated release-note count to the 22 Community Edition capsules enforced by `Distro.toml` and `capsule_release.py`. Add a workflow contract test that derives the claim from the source contract.

Tests: `bash scripts/test-channel-workflow-contract.sh`; `python3 scripts/capsule_release.py`; `python3 scripts/test_capsule_release.py`.