### PR TITLE
fix(install): persist versioned GNU FUSE runtime

### DIFF
--- a/changes/gnu-fuse-installer.fixed.md
+++ b/changes/gnu-fuse-installer.fixed.md
@@ -1,0 +1,1 @@
+- Select GNU runtime members from the signed runtime version during installation, persisting the `astrid-storage-provider-fuse` executable with immutable `0700` permissions for 2026.9.0 while preserving the 0.10.4 four-binary and Darwin FSKit contracts; installer and self-heal tests cover signed positives and fail-closed missing-provider transactions without activating a release.

--- a/install.sh
+++ b/install.sh
@@ -699,6 +699,14 @@ if [ -n "$release_metadata_sha256" ] && [ "$(sha256_file "$work/$release_metadat
 fi
 validate_release_metadata "$work/$release_metadata_asset" "$AOS_VERSION" "$release_identity"
 
+# The signed runtime tuple is the authority for GNU runtime membership. Keep
+# the historical 0.10.4 four-binary set stable, and require the FUSE provider
+# only for the versioned 2026.9.0 runtime contract. Darwin's FSKit member is
+# selected above and remains independent of this Linux-only rule.
+if [ "$os" = Linux ] && [ "$runtime_version" = 2026.9.0 ]; then
+  runtime_binaries="$runtime_binaries astrid-storage-provider-fuse"
+fi
+
 target_section="[targets.${target}]"
 asset=$(toml_value "$work/$release_metadata_asset" "$target_section" asset)
 asset_sha256=$(toml_value "$work/$release_metadata_asset" "$target_section" sha256)

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -249,10 +249,12 @@ sh "$repo_root/install.sh" --yes --no-migrate-prompt
 
 test -x "$work/home/.aos/bin/aos"
 release_dir="$work/home/.aos/releases/2026.9.0"
+test "$runtime_version" = 0.10.4
 for binary in astrid astrid-daemon astrid-build astrid-emit; do
   test -x "$release_dir/runtime/bin/$binary"
   test ! -e "$work/home/.aos/runtime/bin/$binary"
 done
+test ! -e "$release_dir/runtime/bin/astrid-storage-provider-fuse"
 test -f "$release_dir/release-manifest.json"
 test -f "$release_dir/Distro.toml"
 test -f "$release_dir/capsule-assets.txt"
@@ -345,6 +347,206 @@ do
   test -x "$darwin_release_dir/runtime/bin/$binary"
   test ! -e "$darwin_home/.aos/runtime/bin/$binary"
 done
+
+# Build a second package through the real composer with an isolated
+# compatibility overlay.  The checked-in 0.10.4 contract above remains the
+# historical control; this fixture exercises the versioned 2026.9.0 GNU
+# membership that requires the FUSE provider.
+fuse_repo="$work/aos-2026.9.0-contract"
+mkdir -p \
+  "$fuse_repo/scripts" \
+  "$fuse_repo/crates/unicity-aos-bootstrap" \
+  "$fuse_repo/distros/community/unicity-ce"
+cp "$repo_root/Cargo.toml" "$fuse_repo/Cargo.toml"
+cp "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" \
+  "$fuse_repo/crates/unicity-aos-bootstrap/Cargo.toml"
+cp -R "$repo_root/capsules" "$fuse_repo/"
+cp -R "$repo_root/release" "$fuse_repo/"
+cp "$repo_root/distros/community/unicity-ce/Distro.toml" \
+  "$fuse_repo/distros/community/unicity-ce/Distro.toml"
+cp "$repo_root/install.sh" "$repo_root/README.md" "$fuse_repo/"
+cp "$repo_root/scripts/capsule_release.py" \
+  "$repo_root/scripts/package-release.sh" \
+  "$repo_root/scripts/validate-runtime-archive.py" \
+  "$fuse_repo/scripts/"
+python3 - "$fuse_repo/release/runtime-compatibility.toml" \
+  "$fuse_repo/distros/community/unicity-ce/Distro.toml" <<'PY'
+import pathlib
+import sys
+
+runtime_path, distro_path = map(pathlib.Path, sys.argv[1:])
+runtime_lines = runtime_path.read_text(encoding="utf-8").splitlines()
+replacements = {
+    "version": 'version = "2026.9.0"',
+    "tag": 'tag = "v2026.9.0"',
+    "version-requirement": 'version-requirement = "=2026.9.0"',
+    "release-workflow-identity": 'release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v2026.9.0"',
+    "source-commit": 'source-commit = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"',
+    "release-metadata-asset": 'release-metadata-asset = "astrid-2026.9.0-release.toml"',
+    "release-metadata-blake3": 'release-metadata-blake3 = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"',
+}
+in_runtime = False
+for index, line in enumerate(runtime_lines):
+    if line == "[runtime]":
+        in_runtime = True
+        continue
+    if line.startswith("["):
+        in_runtime = False
+    if in_runtime and "=" in line:
+        key = line.split("=", 1)[0].strip()
+        if key in replacements:
+            runtime_lines[index] = replacements[key]
+runtime_path.write_text("\n".join(runtime_lines) + "\n", encoding="utf-8")
+distro_text = distro_path.read_text(encoding="utf-8")
+distro_path.write_text(
+    distro_text.replace('astrid-version = "=0.10.4"', 'astrid-version = "=2026.9.0"'),
+    encoding="utf-8",
+)
+PY
+
+fuse_runtime_root="$work/astrid-2026.9.0-x86_64-unknown-linux-gnu"
+fuse_runtime_archive="$work/runtime-2026.9.0.tar.gz"
+fuse_output="$work/output-2026.9.0"
+mkdir -p "$fuse_runtime_root" "$fuse_output"
+for binary in \
+  astrid astrid-daemon astrid-build astrid-emit \
+  astrid-storage-provider-fuse
+do
+  printf '#!/bin/sh\necho packaged-%s\n' "$binary" > "$fuse_runtime_root/$binary"
+  chmod 755 "$fuse_runtime_root/$binary"
+done
+COPYFILE_DISABLE=1 tar -czf "$fuse_runtime_archive" \
+  -C "$work" "$(basename "$fuse_runtime_root")"
+bash "$fuse_repo/scripts/package-release.sh" \
+  x86_64-unknown-linux-gnu \
+  "$work/aos" \
+  "$fuse_runtime_archive" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$work/capsules" \
+  "$fuse_output" >/dev/null
+fuse_asset_name=unicity-aos-2026.9.0-x86_64-unknown-linux-gnu.tar.gz
+fuse_asset="$fuse_output/$fuse_asset_name"
+fuse_fixture="$work/fuse-fixture"
+mkdir -p "$fuse_fixture"
+cp "$fuse_asset" "$fuse_fixture/$fuse_asset_name"
+fuse_asset_sha256=$(shasum -a 256 "$fuse_asset" | awk '{print $1}')
+fuse_asset_blake3=$(b3sum "$fuse_asset" | awk '{print $1}')
+fuse_asset_size=$(wc -c < "$fuse_asset" | tr -d ' ')
+fuse_release_metadata="$fuse_fixture/unicity-aos-2026.9.0-release.toml"
+cat > "$fuse_release_metadata" <<EOF
+schema-version = 1
+kind = "aos-release"
+product = "unicity-aos-ce"
+version = "2026.9.0"
+tag = "2026.9.0"
+source-commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+published-at = "2026-07-16T10:00:00Z"
+release-workflow-identity = "https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/2026.9.0"
+
+[runtime]
+repository = "astrid-runtime/astrid"
+version = "2026.9.0"
+tag = "v2026.9.0"
+release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v2026.9.0"
+release-metadata-available = true
+source-commit = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+release-metadata-asset = "astrid-2026.9.0-release.toml"
+release-metadata-blake3 = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+[contracts]
+repository = "astrid-runtime/wit"
+commit = "278dbca3e32f327d0f2358644fc86559779ba0fd"
+sdk-rust-version = "0.7.1"
+sdk-rust-commit = "bbbc61c8821d6c536fb25d2068b6b646e759ad35"
+
+[gates]
+release-ready = true
+upgrade-self-heal-ready = true
+EOF
+for metadata_target in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu; do
+  metadata_asset="unicity-aos-2026.9.0-${metadata_target}.tar.gz"
+  cat >> "$fuse_release_metadata" <<EOF
+
+[targets.${metadata_target}]
+asset = "${metadata_asset}"
+sha256 = "${fuse_asset_sha256}"
+blake3 = "${fuse_asset_blake3}"
+sigstore-bundle = "${metadata_asset}.sigstore.json"
+size = ${fuse_asset_size}
+EOF
+done
+cp "$good_bundle" "$fuse_fixture/valid.sigstore.json"
+cp "$good_bundle" "$fuse_fixture/$fuse_asset_name.sigstore.json"
+cp "$good_bundle" "$fuse_fixture/unicity-aos-2026.9.0-release.toml.sigstore.json"
+cp "$fixture/cosign-linux-amd64" "$fuse_fixture/cosign-linux-amd64"
+
+fuse_home="$work/fuse-home"
+mkdir -p "$fuse_home/.astrid"
+printf 'standalone-runtime-state\n' > "$fuse_home/.astrid/sentinel"
+PATH="$fake_bin:$PATH" HOME="$fuse_home" AOS_TEST_FIXTURE="$fuse_fixture" \
+  AOS_VERSION=2026.9.0 sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
+fuse_release_dir="$fuse_home/.aos/releases/2026.9.0"
+for binary in \
+  astrid astrid-daemon astrid-build astrid-emit \
+  astrid-storage-provider-fuse
+do
+  test -x "$fuse_release_dir/runtime/bin/$binary"
+  test ! -e "$fuse_home/.aos/runtime/bin/$binary"
+done
+test "$(find "$fuse_release_dir/runtime/bin" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 5
+test "$(stat -c '%a' "$fuse_release_dir/runtime/bin/astrid-storage-provider-fuse" 2>/dev/null || stat -f '%Lp' "$fuse_release_dir/runtime/bin/astrid-storage-provider-fuse")" = 700
+
+# Remove only the provider from an otherwise valid signed fixture.  The
+# metadata digest and size are updated for this fixture, so the installer gets
+# past signature/digest checks and fails closed on its versioned member list
+# before touching an existing release or channel pointer.
+fuse_missing_fixture="$work/fuse-missing-fixture"
+cp -R "$fuse_fixture" "$fuse_missing_fixture"
+fuse_missing_tree="$work/fuse-missing-tree"
+mkdir "$fuse_missing_tree"
+tar -xzf "$fuse_asset" -C "$fuse_missing_tree"
+rm "$fuse_missing_tree/unicity-aos-2026.9.0-x86_64-unknown-linux-gnu/runtime/bin/astrid-storage-provider-fuse"
+fuse_missing_archive="$fuse_missing_fixture/$fuse_asset_name"
+COPYFILE_DISABLE=1 tar -czf "$fuse_missing_archive" \
+  -C "$fuse_missing_tree" "unicity-aos-2026.9.0-x86_64-unknown-linux-gnu"
+fuse_missing_sha256=$(shasum -a 256 "$fuse_missing_archive" | awk '{print $1}')
+fuse_missing_blake3=$(b3sum "$fuse_missing_archive" | awk '{print $1}')
+fuse_missing_size=$(wc -c < "$fuse_missing_archive" | tr -d ' ')
+python3 - "$fuse_missing_fixture/unicity-aos-2026.9.0-release.toml" \
+  "$fuse_missing_sha256" "$fuse_missing_blake3" "$fuse_missing_size" <<'PY'
+import pathlib
+import sys
+
+path, sha256, blake3, size = sys.argv[1:]
+lines = pathlib.Path(path).read_text(encoding="utf-8").splitlines()
+inside = False
+for index, line in enumerate(lines):
+    if line.startswith("["):
+        inside = line == "[targets.x86_64-unknown-linux-gnu]"
+    if inside:
+        if line.startswith("sha256 = "):
+            lines[index] = f'sha256 = "{sha256}"'
+        elif line.startswith("blake3 = "):
+            lines[index] = f'blake3 = "{blake3}"'
+        elif line.startswith("size = "):
+            lines[index] = f"size = {size}"
+pathlib.Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+fuse_missing_home="$work/fuse-missing-home"
+mkdir -p "$fuse_missing_home/.aos/releases/2026.9.0" \
+  "$fuse_missing_home/.aos/update/channels/stable"
+printf 'preexisting release\n' > "$fuse_missing_home/.aos/releases/2026.9.0/release-manifest.json"
+printf '41\n' > "$fuse_missing_home/.aos/update/channels/stable/current"
+if PATH="$fake_bin:$PATH" HOME="$fuse_missing_home" \
+  AOS_TEST_FIXTURE="$fuse_missing_fixture" AOS_VERSION=2026.9.0 \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null 2>&1; then
+  echo "installer accepted a 2026.9.0 GNU archive missing the FUSE provider" >&2
+  exit 1
+fi
+test "$(cat "$fuse_missing_home/.aos/releases/2026.9.0/release-manifest.json")" = 'preexisting release'
+test "$(cat "$fuse_missing_home/.aos/update/channels/stable/current")" = 41
+test ! -e "$fuse_missing_home/.aos/runtime"
+test ! -e "$fuse_missing_home/.aos/update/install.lock"
 
 unsigned_asset="$work/unsigned-asset.tar.gz"
 unsigned_metadata="$work/release-unsigned.toml"

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -387,6 +387,7 @@ test "$(find "$legacy/run" -type f | wc -l | tr -d ' ')" -eq 5
 install_candidate
 test -x "$aos_home/bin/aos"
 test -x "$aos_home/releases/2026.9.0/runtime/bin/astrid-daemon"
+test ! -e "$aos_home/releases/2026.9.0/runtime/bin/astrid-storage-provider-fuse"
 for name in $runtime_binaries; do
   test ! -e "$aos_home/runtime/bin/$name"
 done
@@ -516,3 +517,203 @@ test "$(b3sum -- "$receipt" | awk '{print $1}')" = "$receipt_before"
 test ! -e "$aos_home/runtime/run"
 
 echo "sanitized packaged migration, reinstall, and self-heal checks passed"
+
+# Keep the historical 0.10.4 GNU control above, then perform an upgrade to a
+# real 2026.9.0 GNU package composed through an isolated compatibility overlay.
+# The strict provider is included in the shipped-asset snapshot so the
+# self-heal reinstall proves its immutable persistence rather than merely
+# checking an assertion beside the fixture.
+fuse_repo="$work/aos-2026.9.0-contract"
+mkdir -p \
+  "$fuse_repo/scripts" \
+  "$fuse_repo/crates/unicity-aos-bootstrap" \
+  "$fuse_repo/distros/community/unicity-ce"
+cp "$repo_root/Cargo.toml" "$fuse_repo/Cargo.toml"
+cp "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" \
+  "$fuse_repo/crates/unicity-aos-bootstrap/Cargo.toml"
+cp -R "$repo_root/capsules" "$fuse_repo/"
+cp -R "$repo_root/release" "$fuse_repo/"
+cp "$repo_root/distros/community/unicity-ce/Distro.toml" \
+  "$fuse_repo/distros/community/unicity-ce/Distro.toml"
+cp "$repo_root/install.sh" "$repo_root/README.md" "$fuse_repo/"
+cp "$repo_root/scripts/capsule_release.py" \
+  "$repo_root/scripts/package-release.sh" \
+  "$repo_root/scripts/validate-runtime-archive.py" \
+  "$fuse_repo/scripts/"
+python3 - "$fuse_repo/release/runtime-compatibility.toml" \
+  "$fuse_repo/distros/community/unicity-ce/Distro.toml" <<'PY'
+import pathlib
+import sys
+
+runtime_path, distro_path = map(pathlib.Path, sys.argv[1:])
+runtime_lines = runtime_path.read_text(encoding="utf-8").splitlines()
+replacements = {
+    "version": 'version = "2026.9.0"',
+    "tag": 'tag = "v2026.9.0"',
+    "version-requirement": 'version-requirement = "=2026.9.0"',
+    "release-workflow-identity": 'release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v2026.9.0"',
+    "source-commit": 'source-commit = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"',
+    "release-metadata-asset": 'release-metadata-asset = "astrid-2026.9.0-release.toml"',
+    "release-metadata-blake3": 'release-metadata-blake3 = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"',
+}
+in_runtime = False
+for index, line in enumerate(runtime_lines):
+    if line == "[runtime]":
+        in_runtime = True
+        continue
+    if line.startswith("["):
+        in_runtime = False
+    if in_runtime and "=" in line:
+        key = line.split("=", 1)[0].strip()
+        if key in replacements:
+            runtime_lines[index] = replacements[key]
+runtime_path.write_text("\n".join(runtime_lines) + "\n", encoding="utf-8")
+distro_text = distro_path.read_text(encoding="utf-8")
+distro_path.write_text(
+    distro_text.replace('astrid-version = "=0.10.4"', 'astrid-version = "=2026.9.0"'),
+    encoding="utf-8",
+)
+PY
+
+strict_provider=astrid-storage-provider-fuse
+if [[ "$target" == *-apple-darwin ]]; then
+  strict_provider=astrid-storage-provider-fskit
+fi
+fuse_runtime_root="$work/astrid-2026.9.0-$target"
+fuse_runtime_archive="$work/runtime-2026.9.0.tar.gz"
+fuse_output="$work/output-2026.9.0"
+mkdir -p "$fuse_runtime_root" "$fuse_output"
+for binary in \
+  astrid astrid-daemon astrid-build astrid-emit \
+  "$strict_provider"
+do
+  printf '#!/bin/sh\necho packaged-%s\n' "$binary" > "$fuse_runtime_root/$binary"
+  chmod 755 "$fuse_runtime_root/$binary"
+done
+COPYFILE_DISABLE=1 tar -czf "$fuse_runtime_archive" \
+  -C "$work" "$(basename "$fuse_runtime_root")"
+bash "$fuse_repo/scripts/package-release.sh" \
+  "$target" \
+  "$product_binary" \
+  "$fuse_runtime_archive" \
+  0000000000000000000000000000000000000000000000000000000000000000 \
+  "$capsules" \
+  "$fuse_output" >/dev/null
+fuse_asset_name="unicity-aos-2026.9.0-$target.tar.gz"
+fuse_asset="$fuse_output/$fuse_asset_name"
+fuse_asset_sha256=$(shasum -a 256 "$fuse_asset" | awk '{print $1}')
+fuse_asset_blake3=$(b3sum "$fuse_asset" | awk '{print $1}')
+fuse_asset_size=$(wc -c < "$fuse_asset" | tr -d ' ')
+fuse_fixture="$work/fuse-downloads"
+mkdir -p "$fuse_fixture"
+cp "$fuse_asset" "$fuse_fixture/$fuse_asset_name"
+cp "$fixture/valid.sigstore.json" "$fuse_fixture/valid.sigstore.json"
+cp "$fixture/$cosign_asset" "$fuse_fixture/$cosign_asset"
+cp "$fixture/valid.sigstore.json" "$fuse_fixture/$fuse_asset_name.sigstore.json"
+fuse_release_metadata="$fuse_fixture/unicity-aos-2026.9.0-release.toml"
+cat > "$fuse_release_metadata" <<EOF
+schema-version = 1
+kind = "aos-release"
+product = "unicity-aos-ce"
+version = "2026.9.0"
+tag = "2026.9.0"
+source-commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+published-at = "2026-07-16T10:00:00Z"
+release-workflow-identity = "https://github.com/unicity-aos/aos-ce/.github/workflows/release.yml@refs/tags/2026.9.0"
+
+[runtime]
+repository = "astrid-runtime/astrid"
+version = "2026.9.0"
+tag = "v2026.9.0"
+release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v2026.9.0"
+release-metadata-available = true
+source-commit = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+release-metadata-asset = "astrid-2026.9.0-release.toml"
+release-metadata-blake3 = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+[contracts]
+repository = "astrid-runtime/wit"
+commit = "278dbca3e32f327d0f2358644fc86559779ba0fd"
+sdk-rust-version = "0.7.1"
+sdk-rust-commit = "bbbc61c8821d6c536fb25d2068b6b646e759ad35"
+
+[gates]
+release-ready = true
+upgrade-self-heal-ready = true
+EOF
+for metadata_target in aarch64-apple-darwin x86_64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu; do
+  metadata_asset="unicity-aos-2026.9.0-${metadata_target}.tar.gz"
+  cat >> "$fuse_release_metadata" <<EOF
+
+[targets.${metadata_target}]
+asset = "${metadata_asset}"
+sha256 = "${fuse_asset_sha256}"
+blake3 = "${fuse_asset_blake3}"
+sigstore-bundle = "${metadata_asset}.sigstore.json"
+size = ${fuse_asset_size}
+EOF
+done
+cp "$fixture/valid.sigstore.json" "$fuse_fixture/unicity-aos-2026.9.0-release.toml.sigstore.json"
+
+fuse_runtime_binaries="astrid astrid-daemon astrid-build astrid-emit $strict_provider"
+fuse_install_candidate() {
+  PATH="$fake_bin:$PATH" \
+  HOME="$home" \
+  AOS_TEST_FIXTURE="$fuse_fixture" \
+  AOS_VERSION=2026.9.0 \
+  sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
+}
+
+fuse_install_candidate
+fuse_release="$aos_home/releases/2026.9.0"
+for name in $fuse_runtime_binaries; do
+  test -x "$fuse_release/runtime/bin/$name"
+  test ! -e "$aos_home/runtime/bin/$name"
+done
+test "$(find "$fuse_release/runtime/bin" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" -eq 5
+test "$(stat -c '%a' "$fuse_release/runtime/bin/$strict_provider" 2>/dev/null || stat -f '%Lp' "$fuse_release/runtime/bin/$strict_provider")" = 700
+
+runtime_binaries="$fuse_runtime_binaries"
+fuse_shipped_before=$work/fuse-shipped-before
+fuse_shipped_after=$work/fuse-shipped-after
+snapshot_shipped_assets "$aos_home" "$fuse_shipped_before"
+for name in aos $runtime_binaries; do
+  case "$name" in
+    aos) destination=$aos_home/bin/aos ;;
+    *) destination=$fuse_release/runtime/bin/$name ;;
+  esac
+  printf '#!/bin/sh\nexit 0\n' > "$destination"
+  chmod 755 "$destination"
+done
+while IFS= read -r capsule; do
+  printf 'tampered capsule\n' > "$fuse_release/capsules/$capsule"
+done < "$fuse_release/capsule-assets.txt"
+chmod 755 \
+  "$aos_home" \
+  "$aos_home/bin" \
+  "$aos_home/runtime" \
+  "$aos_home/releases" \
+  "$fuse_release" \
+  "$fuse_release/runtime" \
+  "$fuse_release/runtime/bin" \
+  "$fuse_release/capsules"
+
+fuse_install_candidate
+snapshot_shipped_assets "$aos_home" "$fuse_shipped_after"
+diff -u "$fuse_shipped_before" "$fuse_shipped_after"
+test -x "$fuse_release/runtime/bin/$strict_provider"
+test "$(stat -c '%a' "$fuse_release/runtime/bin/$strict_provider" 2>/dev/null || stat -f '%Lp' "$fuse_release/runtime/bin/$strict_provider")" = 700
+test ! -e "$aos_home/runtime/bin/$strict_provider"
+for directory in \
+  "$aos_home" \
+  "$aos_home/bin" \
+  "$aos_home/runtime" \
+  "$aos_home/releases" \
+  "$fuse_release" \
+  "$fuse_release/runtime" \
+  "$fuse_release/runtime/bin" \
+  "$fuse_release/capsules"; do
+  test "$(mode_of "$directory")" = 700
+done
+
+echo "historical 0.10.4 control and 2026.9.0 GNU FUSE self-heal checks passed"


### PR DESCRIPTION
Require and persist the GNU FUSE provider only for authenticated runtime 2026.9.0 installs. Preserve the historical 0.10.4 four-binary GNU contract, Darwin FSKit isolation, and fail before any release commit when strict FUSE membership is absent.

Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>