### PR TITLE
fix(rehearsal): complete packaged Linux volume journey

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -459,6 +459,7 @@ if [[ "${1:-}" == "--sign-release-archive" ]]; then
   unset seed_value
   sign_staged_distro "$archive_root" "$signing_seed" "$native_sealer"
   record_signed_distro_inventory "$archive_root/release-manifest.json"
+  chmod 0600 "$archive_root/release-manifest.json"
   mkdir -p "$(dirname "$signed_output")"
   COPYFILE_DISABLE=1 tar -czf "$work/signed.tar.gz" -C "$work/extracted" "$(basename "$archive_root")"
   mv "$work/signed.tar.gz" "$signed_output"
@@ -541,7 +542,7 @@ if [[ ! -d "$runtime_root" ]]; then
 fi
 
 install -m 0755 "$aos_binary" "$work/$root/bin/aos"
-install -m 0644 "$repo_root/install.sh" "$work/$root/libexec/install.sh"
+install -m 0600 "$repo_root/install.sh" "$work/$root/libexec/install.sh"
 for binary in "${runtime_binaries[@]}"; do
   if [[ ! -x "$runtime_root/$binary" ]]; then
     echo "runtime archive is missing $binary" >&2
@@ -551,15 +552,16 @@ for binary in "${runtime_binaries[@]}"; do
 done
 
 python3 "$repo_root/scripts/capsule_release.py" --print-assets > "$work/$root/capsule-assets.txt"
+chmod 0600 "$work/$root/capsule-assets.txt"
 while IFS= read -r capsule; do
   [[ "$capsule" =~ ^aos-[a-z0-9-]+\.capsule$ ]]
-  install -m 0644 "$capsule_artifacts/$capsule" "$work/$root/capsules/$capsule"
+  install -m 0600 "$capsule_artifacts/$capsule" "$work/$root/capsules/$capsule"
 done < "$work/$root/capsule-assets.txt"
 python3 "$repo_root/scripts/capsule_release.py" --artifacts "$work/$root/capsules"
 
-install -m 0644 "$repo_root/release/runtime-compatibility.toml" "$work/$root/runtime-compatibility.toml"
-install -m 0644 "$repo_root/distros/community/unicity-ce/Distro.toml" "$work/$root/Distro.toml"
-install -m 0644 "$repo_root/README.md" "$work/$root/README.md"
+install -m 0600 "$repo_root/release/runtime-compatibility.toml" "$work/$root/runtime-compatibility.toml"
+install -m 0600 "$repo_root/distros/community/unicity-ce/Distro.toml" "$work/$root/Distro.toml"
+install -m 0600 "$repo_root/README.md" "$work/$root/README.md"
 
 distro_signing=no
 if [[ -n "${AOS_DISTRO_ED25519_SEED:-}" ]]; then
@@ -679,6 +681,7 @@ pathlib.Path(path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="u
 PY
 
 validate_schema_v2_membership "$work/$root/release-manifest.json" "$work/$root"
+chmod 0600 "$work/$root/release-manifest.json"
 
 tar -czf "$output_dir/$asset" -C "$work" "$root"
 echo "$output_dir/$asset"

--- a/scripts/test-packaged-linux-volume-contract.sh
+++ b/scripts/test-packaged-linux-volume-contract.sh
@@ -42,7 +42,10 @@ for required in \
   'Installation incomplete:' \
   'for pass in 1 2 3; do' \
   'active_receipt="$work/home/.aos/receipts/unicity-ce.active.json"' \
-  'runtime_distro_lock="$work/home/.aos/runtime/home/operator-qa/.config/distro.lock"' \
+  'ASTRID_PRINCIPAL=default ASTRID_VAR_OPENAI_API_KEY=' \
+  'sleep 61' \
+  'run_default status --json' \
+  'run_default stop' \
   'exactly 22 ready capsules' \
   'unsafe cleanup; preserving disposable evidence' \
   'runner_image=' \

--- a/scripts/test-packaged-linux-volume.sh
+++ b/scripts/test-packaged-linux-volume.sh
@@ -57,7 +57,7 @@ cleanup() {
     if [[ -f "$work/home/.aos/run/system.pid" ]]; then
       pid=$(<"$work/home/.aos/run/system.pid")
     fi
-    run_aos stop >/dev/null 2>&1 || true
+    run_default stop >/dev/null 2>&1 || true
     [[ "$pid" =~ ^[1-9][0-9]*$ ]] && kill -0 "$pid" 2>/dev/null && unsafe=1
   fi
   if (( unsafe )); then
@@ -203,7 +203,6 @@ run_default() {
     "$aos" --principal default "$@"
 }
 active_receipt="$work/home/.aos/receipts/unicity-ce.active.json"
-runtime_distro_lock="$work/home/.aos/runtime/home/operator-qa/.config/distro.lock"
 mount_is_active() {
   [[ -n "${mountpoint:-}" ]] && findmnt -n --mountpoint "$mountpoint" >/dev/null 2>&1
 }
@@ -240,7 +239,9 @@ apply_succeeded=0
 for pass in 1 2 3; do
   apply_output="$work/distro-apply-${pass}.log"
   set +e
-  run_aos distro apply --principal operator-qa --yes --offline >"$apply_output" 2>&1
+  HOME="$work/home" AOS_HOME="$work/home/.aos" \
+    ASTRID_PRINCIPAL=default ASTRID_VAR_OPENAI_API_KEY=release-gate-not-a-real-key \
+    "$aos" distro apply --principal operator-qa --yes --offline >"$apply_output" 2>&1
   apply_status=$?
   set -e
   if (( apply_status == 0 )); then
@@ -253,15 +254,19 @@ for pass in 1 2 3; do
     exit "$apply_status"
   fi
   # Sealed release/Distro.lock is package input, not installation progress.
-  # Probe the exact principal runtime lock and completion receipt instead.
-  if [[ -e "$runtime_distro_lock" || -L "$runtime_distro_lock" ]]; then
-    echo "partial Distro Apply wrote a lock; refusing to retry" >&2
-    exit 1
-  fi
+  # The runtime lock is daemon-owned KV; Apply's successful self-grant is
+  # gated on that fresh lock, and `ps` below proves the 22 ready members.
+  # A partial pass must still leave no activation receipt.
   [[ ! -e "$active_receipt" && ! -L "$active_receipt" ]] || {
     echo "partial Distro Apply wrote an activation receipt" >&2
     exit 1
   }
+  # InstallCapsule is limited to ten requests per minute. The documented
+  # 10+10+2 convergence therefore requires spacing partial passes by a full
+  # limiter window; an immediate retry stays inside the same window.
+  if (( pass < 3 )); then
+    sleep 61
+  fi
 done
 (( apply_succeeded == 1 )) || {
   echo "Distro Apply did not converge after the bounded 10+10+2 passes" >&2
@@ -300,7 +305,7 @@ entries=$(find "$work/home/.aos/runtime" -mindepth 1 -maxdepth 1 -printf '%f\n' 
 
 run_aos start
 for _ in $(seq 1 100); do
-  if run_aos status --principal operator-qa --json >"$work/status.out" 2>"$work/status.err"; then
+  if run_default status --json >"$work/status.out" 2>"$work/status.err"; then
     grep -Eq 'running|Running' "$work/status.out" && break
   fi
   sleep 0.1
@@ -324,10 +329,9 @@ if not isinstance(rows, list) or len(rows) != 22:
 if any(row.get("state") != "ready" for row in rows):
     raise SystemExit("one or more Distro capsules is not ready")
 PY
-if [[ ! -f "$runtime_distro_lock" || -L "$runtime_distro_lock" ]]; then
-  echo "completed Distro Apply did not leave a durable Distro.lock" >&2
-  exit 1
-fi
+# The durable Distro.lock lives in the daemon's principal-scoped control KV.
+# Apply's successful self-grant already required that fresh lock; the `ps`
+# projection below re-verifies all 22 locked capsules are ready.
 
 mountpoint="$work/mount"
 mkdir -m 0700 "$mountpoint"
@@ -388,7 +392,7 @@ daemon_pid=''
 if [[ -f "$work/home/.aos/run/system.pid" ]]; then
   daemon_pid=$(<"$work/home/.aos/run/system.pid")
 fi
-run_aos stop
+run_default stop
 if [[ "$daemon_pid" =~ ^[1-9][0-9]*$ ]]; then
   for _ in $(seq 1 100); do
     kill -0 "$daemon_pid" 2>/dev/null || break


### PR DESCRIPTION
## Commit

`255f1895d8547d3f14c42da52c8cc753d6f7a441` - fix(rehearsal): complete packaged Linux volume journey

Base: PR #143 (`codex/linux-packaged-volume`).

## Scope

Make the packaged x86_64 GNU volume journey actually pass against the signed package:

- `scripts/package-release.sh`: stage non-executable payload members at the manifest-declared `0600` and keep the rewritten release manifest private after signing. The prior `0644` staging contradicted both the signed inventory and Distro Apply's private-mode enforcement.
- `scripts/test-packaged-linux-volume.sh`: space partial Distro Apply passes by one rate-limiter window (61s) to implement the documented 10+10+2 convergence; run lifecycle start/status/stop as the authorized `default` principal while keeping distro identity and storage operations on the non-admin `operator-qa`; replace the stale legacy per-principal `distro.lock` file probe with the daemon-owned KV provenance enforced by Apply's self-grant plus the 22-ready `ps` projection.
- `scripts/test-packaged-linux-volume-contract.sh`: pin the updated requirements.

## Evidence

- Real local x86_64 GNU packaged FUSE journey: PASS. Signed identity, exact commit binding, 10+10+2 convergence, 22 ready capsules, mount, write/read/rename/delete, dirty/sync/clean, clean unmount, stopped `astrid.volume` exactness.
- Archive: BLAKE3 `5d022fb8b34ff74541a16b5916a5dd20caa6e9cd178fdb1f3f507d6037416db4`, SHA-256 `82277a169be04fd7ecd21972834833d07dcb3895ee4ff19b8a8982f4b6e3acd6` (REHEARSAL-ONLY).
- Contracts: `test-packaged-linux-volume-contract.sh` PASS; `test-package-release.sh` PASS.
