### PR TITLE
fix(rehearsal): derive native sealer target from archive

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -215,7 +215,6 @@ PY
 require_native_release_sealer() {
   local archive=$1
   local output=$2
-  local expected_target=x86_64-unknown-linux-gnu
   local work=$3
   local extracted="$work/native-sealer-extract"
   local product_version runtime_version runtime_tag runtime_repository runtime_identity
@@ -234,7 +233,29 @@ require_native_release_sealer() {
   runtime_repository=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime repository)
   runtime_identity=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime release-workflow-identity)
   mkdir -p "$extracted"
-  extract_safe_tar "$archive" "$extracted" "unicity-aos-${product_version}-${expected_target}"
+  extract_safe_tar "$archive" "$extracted" ""
+  expected_target=$(python3 - "$extracted" "$product_version" <<'PY'
+import json
+import pathlib
+import sys
+
+root, product_version = sys.argv[1:]
+entries = list(pathlib.Path(root).iterdir())
+if len(entries) != 1 or entries[0].is_symlink() or not entries[0].is_dir():
+    raise SystemExit("native sealer archive does not contain exactly one product root")
+manifest_path = entries[0] / "release-manifest.json"
+if manifest_path.is_symlink() or not manifest_path.is_file():
+    raise SystemExit("native sealer archive is missing a regular release-manifest.json")
+try:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as error:
+    raise SystemExit(f"native sealer release manifest is unreadable: {error}")
+target = manifest.get("target")
+if not isinstance(target, str) or not target:
+    raise SystemExit("native sealer release manifest target is missing")
+print(target)
+PY
+)
   validate_schema_v2_membership \
     "$extracted/unicity-aos-${product_version}-${expected_target}/release-manifest.json" \
     "$extracted/unicity-aos-${product_version}-${expected_target}"
@@ -266,7 +287,7 @@ except (OSError, json.JSONDecodeError) as error:
 if manifest.get("schema_version") != 2:
     raise SystemExit("native sealer release manifest schema is not supported")
 if manifest.get("target") != target:
-    raise SystemExit("native sealer release manifest target does not match x86_64-unknown-linux-gnu")
+    raise SystemExit(f"native sealer release manifest target does not match {target}")
 if manifest.get("product", {}).get("version") != product_version:
     raise SystemExit("native sealer release manifest product version does not match the checkout")
 runtime = manifest.get("runtime")

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -217,7 +217,7 @@ require_native_release_sealer() {
   local output=$2
   local work=$3
   local extracted="$work/native-sealer-extract"
-  local product_version runtime_version runtime_tag runtime_repository runtime_identity
+  local product_version runtime_version runtime_tag runtime_repository runtime_identity expected_target
 
   [[ -f "$archive" && ! -L "$archive" ]] || {
     echo "native sealer candidate is missing or not a regular file: $archive" >&2
@@ -227,35 +227,22 @@ require_native_release_sealer() {
     echo "native sealer output already exists: $output" >&2
     exit 1
   }
+  # The sealer target is bound by the operator-provided candidate filename,
+  # constrained to the supported GNU target allowlist. Archive contents can
+  # never choose the platform, root name, or a traversal path.
+  expected_target=$(printf '%s\n' "$(basename "$archive")" | sed -nE \
+    's/^unicity-aos-[0-9][0-9a-zA-Z.+_-]*-(x86_64-unknown-linux-gnu|aarch64-unknown-linux-gnu)\.tar\.gz$/\1/p')
+  [[ -n "$expected_target" ]] || {
+    echo "native sealer candidate filename does not bind a supported GNU target" >&2
+    exit 1
+  }
   product_version=$(toml_value "$repo_root/crates/unicity-aos-bootstrap/Cargo.toml" package version)
   runtime_version=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime version)
   runtime_tag=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime tag)
   runtime_repository=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime repository)
   runtime_identity=$(toml_value "$repo_root/release/runtime-compatibility.toml" runtime release-workflow-identity)
   mkdir -p "$extracted"
-  extract_safe_tar "$archive" "$extracted" ""
-  expected_target=$(python3 - "$extracted" "$product_version" <<'PY'
-import json
-import pathlib
-import sys
-
-root, product_version = sys.argv[1:]
-entries = list(pathlib.Path(root).iterdir())
-if len(entries) != 1 or entries[0].is_symlink() or not entries[0].is_dir():
-    raise SystemExit("native sealer archive does not contain exactly one product root")
-manifest_path = entries[0] / "release-manifest.json"
-if manifest_path.is_symlink() or not manifest_path.is_file():
-    raise SystemExit("native sealer archive is missing a regular release-manifest.json")
-try:
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-except (OSError, json.JSONDecodeError) as error:
-    raise SystemExit(f"native sealer release manifest is unreadable: {error}")
-target = manifest.get("target")
-if not isinstance(target, str) or not target:
-    raise SystemExit("native sealer release manifest target is missing")
-print(target)
-PY
-)
+  extract_safe_tar "$archive" "$extracted" "unicity-aos-${product_version}-${expected_target}"
   validate_schema_v2_membership \
     "$extracted/unicity-aos-${product_version}-${expected_target}/release-manifest.json" \
     "$extracted/unicity-aos-${product_version}-${expected_target}"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -582,7 +582,7 @@ if source.count(official) != 1:
 pathlib.Path(sys.argv[2]).write_text(source.replace(official, fixture), encoding="utf-8")
 PY
 cp "$fixture_distro" "$bundle_root/Distro.toml"
-fixture_archive="$work/fixture-aos.tar.gz"
+fixture_archive="$work/unicity-aos-2026.9.0-x86_64-unknown-linux-gnu.tar.gz"
 COPYFILE_DISABLE=1 tar -czf "$fixture_archive" -C "$work" "$(basename "$bundle_root")"
 
 membership_mutations="$work/membership-mutations"
@@ -614,7 +614,7 @@ else:
     raise SystemExit(f"unknown mutation: {mutation}")
 pathlib.Path(path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 PY
-  mutation_archive="$mutation_dir/$mutation.tar.gz"
+  mutation_archive="$mutation_dir/unicity-aos-2026.9.0-x86_64-unknown-linux-gnu.tar.gz"
   COPYFILE_DISABLE=1 tar -czf "$mutation_archive" -C "$mutation_dir" "$(basename "$mutation_root")"
   if bash "$repo_root/scripts/package-release.sh" \
     --extract-release-sealer "$mutation_archive" "$mutation_dir/native-sealer" >/dev/null 2>&1; then


### PR DESCRIPTION
## Commit

`c900aecefda03d4d1bd2d6327be934e425f30ea9` - fix(rehearsal): derive native sealer target from archive

Base: PR for `36d0b81` (`codex/aarch64-volume-journey`).

## Scope

Remove the last x86_64 assumption from package signing:

- `require_native_release_sealer` no longer hard-codes `x86_64-unknown-linux-gnu`. It safely extracts the archive, requires exactly one product root with a regular release manifest, derives the expected target from that manifest, and binds root name, manifest target, runtime tuple, digest, inventory mode, and executable mode to the discovered target.
- Every existing consistency check remains; only the source of the expected target changed.

## Evidence

- Clean-room aarch64 package build, sign, and full volume journey at this exact head: PASS.
- Archive: BLAKE3 `64848bdcff373bfb14706de24f4587544bf9b34cd9fd4107ca3b30b482735d3c`, SHA-256 `6cdb60eed2be017e0016a08a039e19fd794c8727eb71228d669f078893a64d98` (REHEARSAL-ONLY).
- CI green at this head (run `34004633526`).

## Amendment fecd58b

Independent review reproduced a malicious-archive path: the archive's own manifest chose the sealer target, so a self-consistent fake-target archive could install an arbitrary executable as the sealer. The expected target is now bound by the operator-provided candidate filename against a strict GNU-target allowlist before any path use; extraction re-binds to that expected root. The reproduced attack is rejected, canonical fixtures pass test-package-release.sh, and the volume contract stays green.

## Amendment e0016b9

Second independent re-review found the filename parser matched per-line (sed), so a multiline basename could smuggle junk past the allowlist, and the version segment was unbound. The binding is now a whole-string case match against the checkout's exact product version and the two supported GNU targets; multiline, junk-prefixed, wrong-version, and double-target names are all rejected, with adversarial cases added to test-package-release.sh. CI green at e0016b9 (run 34007785246).