### PR TITLE
feat(rehearsal): matrix GNU packaged volume targets

### DIFF
--- a/.github/workflows/rehearsal-sign-darwin.yml
+++ b/.github/workflows/rehearsal-sign-darwin.yml
@@ -287,9 +287,15 @@ jobs:
     name: Build Astrid GNU runtime
     needs: verify-source
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
     env:
       SOURCE_COMMIT: ${{ needs.verify-source.outputs.source-commit }}
-      TARGET: x86_64-unknown-linux-gnu
+      TARGET: ${{ matrix.target }}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -313,10 +319,17 @@ jobs:
             "$LINUX_BUILD_IMAGE" \
             bash -ceu '
               packages=(cmake)
+              if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
+                rustup target add aarch64-unknown-linux-gnu
+                packages+=(gcc-aarch64-linux-gnu libc6-dev-arm64-cross)
+              fi
               apt-get update
               apt-get install -y --no-install-recommends "${packages[@]}"
               git config --global --add safe.directory /workspace
               [[ "$(git rev-parse --short=12 HEAD)" == "$SOURCE_SHA" ]]
+              if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
+                export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+              fi
               cargo build \
                 --locked \
                 --release \
@@ -418,9 +431,15 @@ jobs:
       - verify-source
       - prepare-rehearsal-identity
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
     env:
       SOURCE_COMMIT: ${{ needs.verify-source.outputs.source-commit }}
-      TARGET: x86_64-unknown-linux-gnu
+      TARGET: ${{ matrix.target }}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -457,6 +476,14 @@ jobs:
             --workdir /workspace \
             "$LINUX_BUILD_IMAGE" \
             bash -euxo pipefail -c '
+              if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
+                rustup target add aarch64-unknown-linux-gnu
+                apt-get update
+                apt-get install -y --no-install-recommends \
+                  gcc-aarch64-linux-gnu \
+                  libc6-dev-arm64-cross
+                export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+              fi
               export CARGO_TARGET_DIR=/workspace/target/glibc-2.31
               cargo build --locked --release --target "$TARGET" -p unicity-aos-bootstrap
             '
@@ -533,7 +560,8 @@ jobs:
     env:
       SOURCE_COMMIT: ${{ needs.verify-source.outputs.source-commit }}
       DARWIN_TARGET: aarch64-apple-darwin
-      LINUX_TARGET: x86_64-unknown-linux-gnu
+      X86_64_GNU_TARGET: x86_64-unknown-linux-gnu
+      AARCH64_GNU_TARGET: aarch64-unknown-linux-gnu
       QA_PUBKEY: ${{ needs.prepare-rehearsal-identity.outputs.pubkey }}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -556,16 +584,24 @@ jobs:
           path: astrid-darwin
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: astrid-${{ env.LINUX_TARGET }}
-          path: astrid-linux
+          name: astrid-${{ env.X86_64_GNU_TARGET }}
+          path: astrid-x86_64-gnu
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: astrid-${{ env.AARCH64_GNU_TARGET }}
+          path: astrid-aarch64-gnu
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aos-${{ env.DARWIN_TARGET }}-binary
           path: aos-darwin-binary
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: aos-${{ env.LINUX_TARGET }}-binary
-          path: aos-linux-binary
+          name: aos-${{ env.X86_64_GNU_TARGET }}-binary
+          path: aos-x86_64-gnu-binary
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: aos-${{ env.AARCH64_GNU_TARGET }}-binary
+          path: aos-aarch64-gnu-binary
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: aos-community-capsules
@@ -582,19 +618,25 @@ jobs:
         run: |
           set -euo pipefail
           DARWIN_RUNTIME_ARCHIVE="astrid-darwin/astrid-${ASTRID_RUNTIME_VERSION}-${DARWIN_TARGET}.tar.gz"
-          LINUX_RUNTIME_ARCHIVE="astrid-linux/astrid-${ASTRID_RUNTIME_VERSION}-${LINUX_TARGET}.tar.gz"
+          X86_64_RUNTIME_ARCHIVE="astrid-x86_64-gnu/astrid-${ASTRID_RUNTIME_VERSION}-${X86_64_GNU_TARGET}.tar.gz"
+          AARCH64_RUNTIME_ARCHIVE="astrid-aarch64-gnu/astrid-${ASTRID_RUNTIME_VERSION}-${AARCH64_GNU_TARGET}.tar.gz"
           DARWIN_AOS_BINARY="aos-darwin-binary/aos"
-          LINUX_AOS_BINARY="aos-linux-binary/aos"
+          X86_64_AOS_BINARY="aos-x86_64-gnu-binary/aos"
+          AARCH64_AOS_BINARY="aos-aarch64-gnu-binary/aos"
           bash scripts/bind-rehearsal-consumed-artifacts.sh \
             "$DARWIN_RUNTIME_ARCHIVE" \
-            "$LINUX_RUNTIME_ARCHIVE" \
+            "$X86_64_RUNTIME_ARCHIVE" \
+            "$AARCH64_RUNTIME_ARCHIVE" \
             "$DARWIN_AOS_BINARY" \
-            "$LINUX_AOS_BINARY"
+            "$X86_64_AOS_BINARY" \
+            "$AARCH64_AOS_BINARY"
           {
             echo "DARWIN_RUNTIME_ARCHIVE=$DARWIN_RUNTIME_ARCHIVE"
-            echo "LINUX_RUNTIME_ARCHIVE=$LINUX_RUNTIME_ARCHIVE"
+            echo "X86_64_RUNTIME_ARCHIVE=$X86_64_RUNTIME_ARCHIVE"
+            echo "AARCH64_RUNTIME_ARCHIVE=$AARCH64_RUNTIME_ARCHIVE"
             echo "DARWIN_AOS_BINARY=$DARWIN_AOS_BINARY"
-            echo "LINUX_AOS_BINARY=$LINUX_AOS_BINARY"
+            echo "X86_64_AOS_BINARY=$X86_64_AOS_BINARY"
+            echo "AARCH64_AOS_BINARY=$AARCH64_AOS_BINARY"
           } >> "$GITHUB_ENV"
       - name: Create disposable rehearsal checkout and overlays
         run: |
@@ -663,31 +705,53 @@ jobs:
         run: |
           set -euo pipefail
           python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py" \
-            "$LINUX_RUNTIME_ARCHIVE" \
-            "astrid-${ASTRID_RUNTIME_VERSION}-${LINUX_TARGET}" \
+            "$X86_64_RUNTIME_ARCHIVE" \
+            "astrid-${ASTRID_RUNTIME_VERSION}-${X86_64_GNU_TARGET}" \
             astrid astrid-daemon astrid-build astrid-emit \
             astrid-storage-provider-fuse
           python3 scripts/capsule_release.py --artifacts capsule-artifacts
           "$REHEARSAL_CHECKOUT/scripts/package-release.sh" \
-            "$LINUX_TARGET" \
-            "$LINUX_AOS_BINARY" \
-            "$LINUX_RUNTIME_ARCHIVE" \
-            "$(b3sum -- "$LINUX_RUNTIME_ARCHIVE" | awk '{print $1}')" \
+            "$X86_64_GNU_TARGET" \
+            "$X86_64_AOS_BINARY" \
+            "$X86_64_RUNTIME_ARCHIVE" \
+            "$(b3sum -- "$X86_64_RUNTIME_ARCHIVE" | awk '{print $1}')" \
             capsule-artifacts \
             linux-artifacts
           mapfile -d '' candidates < <(
             find linux-artifacts -maxdepth 1 -type f \
-              -name "unicity-aos-${AOS_PRODUCT_VERSION}-${LINUX_TARGET}.tar.gz" -print0
+              -name "unicity-aos-${AOS_PRODUCT_VERSION}-${X86_64_GNU_TARGET}.tar.gz" -print0
           )
           [[ ${#candidates[@]} -eq 1 ]]
           sealer="$RUNNER_TEMP/aos-rehearsal-native-sealer"
           "$REHEARSAL_CHECKOUT/scripts/package-release.sh" \
             --extract-release-sealer "${candidates[0]}" "$sealer"
           {
-            echo "LINUX_ARCHIVE=${candidates[0]}"
+            echo "X86_64_GNU_ARCHIVE=${candidates[0]}"
             echo "NATIVE_SEALER=$sealer"
             echo "NATIVE_SEALER_ARCHIVE=${candidates[0]}"
           } >> "$GITHUB_ENV"
+      - name: Compose the additional GNU candidate
+        run: |
+          set -euo pipefail
+          python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py" \
+            "$AARCH64_RUNTIME_ARCHIVE" \
+            "astrid-${ASTRID_RUNTIME_VERSION}-${AARCH64_GNU_TARGET}" \
+            astrid astrid-daemon astrid-build astrid-emit \
+            astrid-storage-provider-fuse
+          python3 scripts/capsule_release.py --artifacts capsule-artifacts
+          "$REHEARSAL_CHECKOUT/scripts/package-release.sh" \
+            "$AARCH64_GNU_TARGET" \
+            "$AARCH64_AOS_BINARY" \
+            "$AARCH64_RUNTIME_ARCHIVE" \
+            "$(b3sum -- "$AARCH64_RUNTIME_ARCHIVE" | awk '{print $1}')" \
+            capsule-artifacts \
+            aarch64-gnu-artifacts
+          mapfile -d '' candidates < <(
+            find aarch64-gnu-artifacts -maxdepth 1 -type f \
+              -name "unicity-aos-${AOS_PRODUCT_VERSION}-${AARCH64_GNU_TARGET}.tar.gz" -print0
+          )
+          [[ ${#candidates[@]} -eq 1 ]]
+          echo "AARCH64_GNU_ARCHIVE=${candidates[0]}" >> "$GITHUB_ENV"
       - name: Compose the Darwin candidate
         run: |
           set -euo pipefail
@@ -710,7 +774,7 @@ jobs:
           )
           [[ ${#candidates[@]} -eq 1 ]]
           echo "DARWIN_ARCHIVE=${candidates[0]}" >> "$GITHUB_ENV"
-      - name: Sign the Darwin and GNU rehearsal candidates
+      - name: Sign the Darwin and both GNU rehearsal candidates
         id: sign
         env:
           ASTRID_SOURCE_COMMIT: ${{ env.ASTRID_SOURCE_COMMIT }}
@@ -767,22 +831,37 @@ jobs:
             exit 1
           fi
           unlink "$SIGNED_DARWIN_TAR_LISTING"
-          signed_gnu="$RUNNER_TEMP/$(basename "$LINUX_ARCHIVE")"
+          signed_x86_gnu="$RUNNER_TEMP/$(basename "$X86_64_GNU_ARCHIVE")"
           AOS_DISTRO_ED25519_SEED="$QA_SEED" \
             "$REHEARSAL_CHECKOUT/scripts/package-release.sh" \
             --sign-release-archive \
-            "$LINUX_ARCHIVE" \
-            "$signed_gnu" \
+            "$X86_64_GNU_ARCHIVE" \
+            "$signed_x86_gnu" \
             "$NATIVE_SEALER" \
             "$NATIVE_SEALER_ARCHIVE"
-          SIGNED_GNU_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-gnu-tar-listing.XXXXXX")
-          write_tar_listing "$signed_gnu" "$SIGNED_GNU_TAR_LISTING"
-          if ! grep -q '/Distro.sig$' "$SIGNED_GNU_TAR_LISTING"; then
-            echo "signed GNU rehearsal archive has no Distro signature" >&2
+          SIGNED_X86_64_GNU_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-x86_64-gnu-tar-listing.XXXXXX")
+          write_tar_listing "$signed_x86_gnu" "$SIGNED_X86_64_GNU_TAR_LISTING"
+          if ! grep -q '/Distro.sig$' "$SIGNED_X86_64_GNU_TAR_LISTING"; then
+            echo "signed x86_64 GNU rehearsal archive has no Distro signature" >&2
             exit 1
           fi
-          unlink "$SIGNED_GNU_TAR_LISTING"
-          # Destroy the persistent QA seed only after both signed archives were verified.
+          unlink "$SIGNED_X86_64_GNU_TAR_LISTING"
+          signed_aarch64_gnu="$RUNNER_TEMP/$(basename "$AARCH64_GNU_ARCHIVE")"
+          AOS_DISTRO_ED25519_SEED="$QA_SEED" \
+            "$REHEARSAL_CHECKOUT/scripts/package-release.sh" \
+            --sign-release-archive \
+            "$AARCH64_GNU_ARCHIVE" \
+            "$signed_aarch64_gnu" \
+            "$NATIVE_SEALER" \
+            "$NATIVE_SEALER_ARCHIVE"
+          SIGNED_AARCH64_GNU_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-aarch64-gnu-tar-listing.XXXXXX")
+          write_tar_listing "$signed_aarch64_gnu" "$SIGNED_AARCH64_GNU_TAR_LISTING"
+          if ! grep -q '/Distro.sig$' "$SIGNED_AARCH64_GNU_TAR_LISTING"; then
+            echo "signed aarch64 GNU rehearsal archive has no Distro signature" >&2
+            exit 1
+          fi
+          unlink "$SIGNED_AARCH64_GNU_TAR_LISTING"
+          # Destroy the persistent QA seed only after all signed archives were verified.
           python3 - "$QA_SEED_FILE" <<'PY'
           import os
           import pathlib
@@ -796,10 +875,11 @@ jobs:
           path.unlink()
           PY
           [[ ! -e "$QA_SEED_FILE" ]]
-          echo "ephemeral QA seed destroyed after both signed archive verifications"
+          echo "ephemeral QA seed destroyed after all signed archive verifications"
           {
             echo "SIGNED_DARWIN_ARCHIVE=$signed_darwin"
-            echo "SIGNED_GNU_ARCHIVE=$signed_gnu"
+            echo "SIGNED_X86_64_GNU_ARCHIVE=$signed_x86_gnu"
+            echo "SIGNED_AARCH64_GNU_ARCHIVE=$signed_aarch64_gnu"
           } >> "$GITHUB_ENV"
       - name: Prove overlay-built GNU AOS accepts the signed Distro
         run: |
@@ -811,8 +891,8 @@ jobs:
           mkdir -m 0700 "$aos_home/releases"
           release_dir="$aos_home/releases/${AOS_PRODUCT_VERSION}"
           mkdir -m 0700 "$release_dir"
-          tar -xzf "$SIGNED_GNU_ARCHIVE" -C "$extract"
-          bundle="$extract/unicity-aos-${AOS_PRODUCT_VERSION}-${LINUX_TARGET}"
+          tar -xzf "$SIGNED_X86_64_GNU_ARCHIVE" -C "$extract"
+          bundle="$extract/unicity-aos-${AOS_PRODUCT_VERSION}-${X86_64_GNU_TARGET}"
           for member in Distro.toml Distro.lock Distro.sig release-manifest.json
           do
             [[ -f "$bundle/$member" && ! -L "$bundle/$member" ]]
@@ -840,7 +920,7 @@ jobs:
           stderr="$RUNNER_TEMP/rehearsal-consume.err"
           set +e
           HOME="$user_home" AOS_HOME="$aos_home" \
-            "$LINUX_AOS_BINARY" distro apply --principal operator-qa --yes \
+            "$X86_64_AOS_BINARY" distro apply --principal operator-qa --yes \
             >"$RUNNER_TEMP/rehearsal-consume.out" 2>"$stderr"
           status=$?
           set -e
@@ -873,39 +953,53 @@ jobs:
           output="$RUNNER_TEMP/rehearsal-darwin"
           mkdir -p "$output"
           cp "$SIGNED_DARWIN_ARCHIVE" "$output/"
-          cp "$SIGNED_GNU_ARCHIVE" "$output/"
+          cp "$SIGNED_X86_64_GNU_ARCHIVE" "$output/"
+          cp "$SIGNED_AARCH64_GNU_ARCHIVE" "$output/"
           darwin_extract="$RUNNER_TEMP/signed-darwin-extract"
-          gnu_extract="$RUNNER_TEMP/signed-gnu-extract"
-          mkdir "$darwin_extract" "$gnu_extract"
+          x86_gnu_extract="$RUNNER_TEMP/signed-x86_64-gnu-extract"
+          aarch64_gnu_extract="$RUNNER_TEMP/signed-aarch64-gnu-extract"
+          mkdir "$darwin_extract" "$x86_gnu_extract" "$aarch64_gnu_extract"
           tar -xzf "$SIGNED_DARWIN_ARCHIVE" -C "$darwin_extract"
-          tar -xzf "$SIGNED_GNU_ARCHIVE" -C "$gnu_extract"
+          tar -xzf "$SIGNED_X86_64_GNU_ARCHIVE" -C "$x86_gnu_extract"
+          tar -xzf "$SIGNED_AARCH64_GNU_ARCHIVE" -C "$aarch64_gnu_extract"
           darwin_bundle="$darwin_extract/unicity-aos-${AOS_PRODUCT_VERSION}-${DARWIN_TARGET}"
-          gnu_bundle="$gnu_extract/unicity-aos-${AOS_PRODUCT_VERSION}-${LINUX_TARGET}"
+          x86_gnu_bundle="$x86_gnu_extract/unicity-aos-${AOS_PRODUCT_VERSION}-${X86_64_GNU_TARGET}"
+          aarch64_gnu_bundle="$aarch64_gnu_extract/unicity-aos-${AOS_PRODUCT_VERSION}-${AARCH64_GNU_TARGET}"
           cp "$darwin_bundle/release-manifest.json" "$output/"
           cp "$darwin_bundle/runtime-compatibility.toml" "$output/"
           cp "$darwin_bundle/Distro.toml" "$output/"
           cp "$darwin_bundle/Distro.lock" "$output/"
           cp "$darwin_bundle/Distro.sig" "$output/"
-          cp "$gnu_bundle/release-manifest.json" "$output/release-manifest-${LINUX_TARGET}.json"
-          cp "$gnu_bundle/runtime-compatibility.toml" "$output/runtime-compatibility-${LINUX_TARGET}.toml"
-          cp "$gnu_bundle/Distro.toml" "$output/Distro-${LINUX_TARGET}.toml"
-          cp "$gnu_bundle/Distro.lock" "$output/Distro-${LINUX_TARGET}.lock"
-          cp "$gnu_bundle/Distro.sig" "$output/Distro-${LINUX_TARGET}.sig"
+          cp "$x86_gnu_bundle/release-manifest.json" "$output/release-manifest-${X86_64_GNU_TARGET}.json"
+          cp "$x86_gnu_bundle/runtime-compatibility.toml" "$output/runtime-compatibility-${X86_64_GNU_TARGET}.toml"
+          cp "$x86_gnu_bundle/Distro.toml" "$output/Distro-${X86_64_GNU_TARGET}.toml"
+          cp "$x86_gnu_bundle/Distro.lock" "$output/Distro-${X86_64_GNU_TARGET}.lock"
+          cp "$x86_gnu_bundle/Distro.sig" "$output/Distro-${X86_64_GNU_TARGET}.sig"
+          cp "$aarch64_gnu_bundle/release-manifest.json" "$output/release-manifest-${AARCH64_GNU_TARGET}.json"
+          cp "$aarch64_gnu_bundle/runtime-compatibility.toml" "$output/runtime-compatibility-${AARCH64_GNU_TARGET}.toml"
+          cp "$aarch64_gnu_bundle/Distro.toml" "$output/Distro-${AARCH64_GNU_TARGET}.toml"
+          cp "$aarch64_gnu_bundle/Distro.lock" "$output/Distro-${AARCH64_GNU_TARGET}.lock"
+          cp "$aarch64_gnu_bundle/Distro.sig" "$output/Distro-${AARCH64_GNU_TARGET}.sig"
           cd "$output"
           darwin_asset=$(basename "$SIGNED_DARWIN_ARCHIVE")
-          gnu_asset=$(basename "$SIGNED_GNU_ARCHIVE")
+          x86_gnu_asset=$(basename "$SIGNED_X86_64_GNU_ARCHIVE")
+          aarch64_gnu_asset=$(basename "$SIGNED_AARCH64_GNU_ARCHIVE")
           DARWIN_BLAKE3=$(b3sum -- "$darwin_asset" | awk '{print $1}')
           DARWIN_SHA256=$(sha256sum -- "$darwin_asset" | awk '{print $1}')
-          GNU_BLAKE3=$(b3sum -- "$gnu_asset" | awk '{print $1}')
-          GNU_SHA256=$(sha256sum -- "$gnu_asset" | awk '{print $1}')
+          X86_64_GNU_BLAKE3=$(b3sum -- "$x86_gnu_asset" | awk '{print $1}')
+          X86_64_GNU_SHA256=$(sha256sum -- "$x86_gnu_asset" | awk '{print $1}')
+          AARCH64_GNU_BLAKE3=$(b3sum -- "$aarch64_gnu_asset" | awk '{print $1}')
+          AARCH64_GNU_SHA256=$(sha256sum -- "$aarch64_gnu_asset" | awk '{print $1}')
           {
             b3sum -- "$darwin_asset"
-            b3sum -- "$gnu_asset"
+            b3sum -- "$x86_gnu_asset"
+            b3sum -- "$aarch64_gnu_asset"
           } > REHEARSAL-BLAKE3SUMS.txt
           b3sum --check REHEARSAL-BLAKE3SUMS.txt
           {
             sha256sum -- "$darwin_asset"
-            sha256sum -- "$gnu_asset"
+            sha256sum -- "$x86_gnu_asset"
+            sha256sum -- "$aarch64_gnu_asset"
           } > REHEARSAL-SHA256SUMS.txt
           sha256sum --check REHEARSAL-SHA256SUMS.txt
           python3 - "$output/REHEARSAL-ONLY-identity.json" \
@@ -915,9 +1009,12 @@ jobs:
             "$darwin_asset" \
             "$DARWIN_BLAKE3" \
             "$DARWIN_SHA256" \
-            "$gnu_asset" \
-            "$GNU_BLAKE3" \
-            "$GNU_SHA256" <<'PY'
+            "$x86_gnu_asset" \
+            "$X86_64_GNU_BLAKE3" \
+            "$X86_64_GNU_SHA256" \
+            "$aarch64_gnu_asset" \
+            "$AARCH64_GNU_BLAKE3" \
+            "$AARCH64_GNU_SHA256" <<'PY'
           import json
           import pathlib
           import sys
@@ -930,9 +1027,12 @@ jobs:
               darwin_archive,
               darwin_blake3,
               darwin_sha256,
-              gnu_archive,
-              gnu_blake3,
-              gnu_sha256,
+              x86_gnu_archive,
+              x86_gnu_blake3,
+              x86_gnu_sha256,
+              aarch64_gnu_archive,
+              aarch64_gnu_blake3,
+              aarch64_gnu_sha256,
           ) = sys.argv[1:]
           identity = {
               "schema_version": 1,
@@ -955,6 +1055,7 @@ jobs:
                   "runtime_targets": [
                       "aarch64-apple-darwin",
                       "x86_64-unknown-linux-gnu",
+                      "aarch64-unknown-linux-gnu",
                   ],
               },
               "distro_signing": {
@@ -970,9 +1071,16 @@ jobs:
                       "public_key": pubkey,
                   },
                   "x86_64-unknown-linux-gnu": {
-                      "archive": gnu_archive,
-                      "blake3_rehearsal_only": f"blake3:{gnu_blake3}",
-                      "sha256_rehearsal_only": f"sha256:{gnu_sha256}",
+                      "archive": x86_gnu_archive,
+                      "blake3_rehearsal_only": f"blake3:{x86_gnu_blake3}",
+                      "sha256_rehearsal_only": f"sha256:{x86_gnu_sha256}",
+                      "key_scope": "ephemeral-per-run-qa",
+                      "public_key": pubkey,
+                  },
+                  "aarch64-unknown-linux-gnu": {
+                      "archive": aarch64_gnu_archive,
+                      "blake3_rehearsal_only": f"blake3:{aarch64_gnu_blake3}",
+                      "sha256_rehearsal_only": f"sha256:{aarch64_gnu_sha256}",
                       "key_scope": "ephemeral-per-run-qa",
                       "public_key": pubkey,
                   },
@@ -988,9 +1096,20 @@ jobs:
           path: ${{ runner.temp }}/rehearsal-darwin/**
 
   packaged-linux-volume:
-    name: Exercise packaged GNU FUSE volume
+    name: Exercise packaged GNU FUSE volume (${{ matrix.target }})
     needs: compose-and-sign
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -1026,7 +1145,7 @@ jobs:
           set -euo pipefail
           mapfile -d '' archives < <(
             find signed-rehearsal -type f \
-              -name 'unicity-aos-2026.9.0-x86_64-unknown-linux-gnu.tar.gz' -print0
+              -name "unicity-aos-2026.9.0-${{ matrix.target }}.tar.gz" -print0
           )
           [[ ${#archives[@]} -eq 1 ]]
           archive=${archives[0]}

--- a/scripts/bind-rehearsal-consumed-artifacts.sh
+++ b/scripts/bind-rehearsal-consumed-artifacts.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 4 ]]; then
-  echo "usage: bind-rehearsal-consumed-artifacts.sh DARWIN_RUNTIME LINUX_RUNTIME DARWIN_AOS LINUX_AOS" >&2
+if [[ $# -ne 6 ]]; then
+  echo "usage: bind-rehearsal-consumed-artifacts.sh DARWIN_RUNTIME X86_64_GNU_RUNTIME AARCH64_GNU_RUNTIME DARWIN_AOS X86_64_GNU_AOS AARCH64_GNU_AOS" >&2
   exit 1
 fi
 
@@ -29,24 +29,34 @@ print_stat() {
 }
 
 DARWIN_RUNTIME_ARCHIVE="$1"
-LINUX_RUNTIME_ARCHIVE="$2"
-DARWIN_AOS_BINARY="$3"
-LINUX_AOS_BINARY="$4"
+X86_64_GNU_RUNTIME_ARCHIVE="$2"
+AARCH64_GNU_RUNTIME_ARCHIVE="$3"
+DARWIN_AOS_BINARY="$4"
+X86_64_GNU_AOS_BINARY="$5"
+AARCH64_GNU_AOS_BINARY="$6"
 
 require_regular_file "$DARWIN_RUNTIME_ARCHIVE"
-require_regular_file "$LINUX_RUNTIME_ARCHIVE"
+require_regular_file "$X86_64_GNU_RUNTIME_ARCHIVE"
+require_regular_file "$AARCH64_GNU_RUNTIME_ARCHIVE"
 require_regular_file "$DARWIN_AOS_BINARY"
-require_regular_file "$LINUX_AOS_BINARY"
+require_regular_file "$X86_64_GNU_AOS_BINARY"
+require_regular_file "$AARCH64_GNU_AOS_BINARY"
 echo "rehearsal consumed artifacts before chmod"
 print_stat "$DARWIN_RUNTIME_ARCHIVE"
-print_stat "$LINUX_RUNTIME_ARCHIVE"
+print_stat "$X86_64_GNU_RUNTIME_ARCHIVE"
+print_stat "$AARCH64_GNU_RUNTIME_ARCHIVE"
 print_stat "$DARWIN_AOS_BINARY"
-print_stat "$LINUX_AOS_BINARY"
-chmod 0755 "$DARWIN_AOS_BINARY" "$LINUX_AOS_BINARY"
+print_stat "$X86_64_GNU_AOS_BINARY"
+print_stat "$AARCH64_GNU_AOS_BINARY"
+chmod 0755 \
+  "$DARWIN_AOS_BINARY" \
+  "$X86_64_GNU_AOS_BINARY" \
+  "$AARCH64_GNU_AOS_BINARY"
 echo "rehearsal AOS binaries after chmod 0755"
 print_stat "$DARWIN_AOS_BINARY"
-print_stat "$LINUX_AOS_BINARY"
-if [[ ! -x "$DARWIN_AOS_BINARY" || ! -x "$LINUX_AOS_BINARY" ]]; then
+print_stat "$X86_64_GNU_AOS_BINARY"
+print_stat "$AARCH64_GNU_AOS_BINARY"
+if [[ ! -x "$DARWIN_AOS_BINARY" || ! -x "$X86_64_GNU_AOS_BINARY" || ! -x "$AARCH64_GNU_AOS_BINARY" ]]; then
   echo "rehearsal AOS binaries are not executable after chmod 0755" >&2
   exit 1
 fi

--- a/scripts/test-bind-rehearsal-consumed-artifacts.sh
+++ b/scripts/test-bind-rehearsal-consumed-artifacts.sh
@@ -12,16 +12,28 @@ file_mode() {
 
 make_layout() {
   local root="$1"
-  mkdir -p "$root/astrid-darwin" "$root/astrid-linux" "$root/aos-darwin-binary" "$root/aos-linux-binary"
+  mkdir -p \
+    "$root/astrid-darwin" \
+    "$root/astrid-x86_64-gnu" \
+    "$root/astrid-aarch64-gnu" \
+    "$root/aos-darwin-binary" \
+    "$root/aos-x86_64-gnu-binary" \
+    "$root/aos-aarch64-gnu-binary"
   printf 'darwin-runtime\n' > "$root/astrid-darwin/astrid-2026.9.0-aarch64-apple-darwin.tar.gz"
-  printf 'linux-runtime\n' > "$root/astrid-linux/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz"
+  printf 'x86_64 GNU runtime\n' > \
+    "$root/astrid-x86_64-gnu/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz"
+  printf 'aarch64 GNU runtime\n' > \
+    "$root/astrid-aarch64-gnu/astrid-2026.9.0-aarch64-unknown-linux-gnu.tar.gz"
   printf 'darwin-aos\n' > "$root/aos-darwin-binary/aos"
-  printf 'linux-aos\n' > "$root/aos-linux-binary/aos"
+  printf 'x86_64 GNU AOS\n' > "$root/aos-x86_64-gnu-binary/aos"
+  printf 'aarch64 GNU AOS\n' > "$root/aos-aarch64-gnu-binary/aos"
   chmod 0644 \
     "$root/astrid-darwin/astrid-2026.9.0-aarch64-apple-darwin.tar.gz" \
-    "$root/astrid-linux/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz" \
+    "$root/astrid-x86_64-gnu/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz" \
+    "$root/astrid-aarch64-gnu/astrid-2026.9.0-aarch64-unknown-linux-gnu.tar.gz" \
     "$root/aos-darwin-binary/aos" \
-    "$root/aos-linux-binary/aos"
+    "$root/aos-x86_64-gnu-binary/aos" \
+    "$root/aos-aarch64-gnu-binary/aos"
 }
 
 bind() {
@@ -30,9 +42,11 @@ bind() {
     cd "$root"
     bash "$binder" \
       astrid-darwin/astrid-2026.9.0-aarch64-apple-darwin.tar.gz \
-      astrid-linux/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz \
+      astrid-x86_64-gnu/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz \
+      astrid-aarch64-gnu/astrid-2026.9.0-aarch64-unknown-linux-gnu.tar.gz \
       aos-darwin-binary/aos \
-      aos-linux-binary/aos
+      aos-x86_64-gnu-binary/aos \
+      aos-aarch64-gnu-binary/aos
   )
 }
 
@@ -42,21 +56,24 @@ trap 'rm -rf "$scratch"' EXIT
 happy="$scratch/happy"
 make_layout "$happy"
 [[ "$(file_mode "$happy/aos-darwin-binary/aos")" == "0o644" ]]
-[[ "$(file_mode "$happy/aos-linux-binary/aos")" == "0o644" ]]
-if [[ -x "$happy/aos-darwin-binary/aos" || -x "$happy/aos-linux-binary/aos" ]]; then
+[[ "$(file_mode "$happy/aos-x86_64-gnu-binary/aos")" == "0o644" ]]
+[[ "$(file_mode "$happy/aos-aarch64-gnu-binary/aos")" == "0o644" ]]
+if [[ -x "$happy/aos-darwin-binary/aos" || -x "$happy/aos-x86_64-gnu-binary/aos" || -x "$happy/aos-aarch64-gnu-binary/aos" ]]; then
   echo "fixture AOS binaries must start non-executable (mode 0644)" >&2
   exit 1
 fi
 bind "$happy"
 [[ "$(file_mode "$happy/aos-darwin-binary/aos")" == "0o755" ]]
-[[ "$(file_mode "$happy/aos-linux-binary/aos")" == "0o755" ]]
-[[ -x "$happy/aos-darwin-binary/aos" && -x "$happy/aos-linux-binary/aos" ]]
+[[ "$(file_mode "$happy/aos-x86_64-gnu-binary/aos")" == "0o755" ]]
+[[ "$(file_mode "$happy/aos-aarch64-gnu-binary/aos")" == "0o755" ]]
+[[ -x "$happy/aos-darwin-binary/aos" && -x "$happy/aos-x86_64-gnu-binary/aos" && -x "$happy/aos-aarch64-gnu-binary/aos" ]]
 [[ "$(file_mode "$happy/astrid-darwin/astrid-2026.9.0-aarch64-apple-darwin.tar.gz")" == "0o644" ]]
-[[ "$(file_mode "$happy/astrid-linux/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz")" == "0o644" ]]
+[[ "$(file_mode "$happy/astrid-x86_64-gnu/astrid-2026.9.0-x86_64-unknown-linux-gnu.tar.gz")" == "0o644" ]]
+[[ "$(file_mode "$happy/astrid-aarch64-gnu/astrid-2026.9.0-aarch64-unknown-linux-gnu.tar.gz")" == "0o644" ]]
 
 missing="$scratch/missing"
 make_layout "$missing"
-rm -f "$missing/aos-linux-binary/aos"
+rm -f "$missing/aos-aarch64-gnu-binary/aos"
 if bind "$missing"; then
   echo "missing AOS binary must fail closed" >&2
   exit 1
@@ -80,8 +97,8 @@ fi
 
 directory="$scratch/directory"
 make_layout "$directory"
-rm -f "$directory/aos-linux-binary/aos"
-mkdir "$directory/aos-linux-binary/aos"
+rm -f "$directory/aos-aarch64-gnu-binary/aos"
+mkdir "$directory/aos-aarch64-gnu-binary/aos"
 if bind "$directory"; then
   echo "directory AOS path must fail closed" >&2
   exit 1

--- a/scripts/test-packaged-linux-volume-contract.sh
+++ b/scripts/test-packaged-linux-volume-contract.sh
@@ -12,8 +12,15 @@ for required in \
   'packaged-linux-volume:' \
   'needs: compose-and-sign' \
   'runs-on: ubuntu-latest' \
+  'runs-on: ${{ matrix.runner }}' \
+  'strategy:' \
+  'fail-fast: false' \
+  '- x86_64-unknown-linux-gnu' \
+  '- aarch64-unknown-linux-gnu' \
+  'runner: ubuntu-latest' \
+  'runner: ubuntu-24.04-arm' \
   'name: rehearsal-sign-darwin' \
-  "-name 'unicity-aos-2026.9.0-x86_64-unknown-linux-gnu.tar.gz'" \
+  '-name "unicity-aos-2026.9.0-${{ matrix.target }}.tar.gz"' \
   'mapfile -d' \
   'bash scripts/test-packaged-linux-volume.sh' \
   'sudo apt-get install -y --no-install-recommends fuse3 util-linux' \
@@ -26,6 +33,48 @@ do
     exit 1
   }
 done
+
+python3 - "$workflow" <<'PY'
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+matches = list(re.finditer(r"(?m)^  ([A-Za-z0-9_-]+):\n", text))
+sections = {
+    match.group(1): text[match.start(): (
+        matches[index + 1].start() if index + 1 < len(matches) else len(text)
+    )]
+    for index, match in enumerate(matches)
+}
+job = sections.get("packaged-linux-volume")
+if job is None:
+    raise SystemExit("packaged Linux volume job is missing")
+
+matrix_match = re.search(r"(?ms)^    strategy:\n.*?^    steps:\n", job)
+if matrix_match is None:
+    raise SystemExit("packaged Linux volume job is not matrixed")
+matrix = matrix_match.group(0)
+for required in (
+    "fail-fast: false",
+    "target:",
+    "- x86_64-unknown-linux-gnu",
+    "- aarch64-unknown-linux-gnu",
+    "include:",
+    "- target: x86_64-unknown-linux-gnu",
+    "runner: ubuntu-latest",
+    "- target: aarch64-unknown-linux-gnu",
+    "runner: ubuntu-24.04-arm",
+):
+    if required not in matrix:
+        raise SystemExit(f"packaged Linux volume matrix is missing: {required}")
+for required in (
+    "runs-on: ${{ matrix.runner }}",
+    '-name "unicity-aos-2026.9.0-${{ matrix.target }}.tar.gz"',
+):
+    if required not in job:
+        raise SystemExit(f"packaged Linux volume job is missing: {required}")
+PY
 
 for required in \
   'x86_64) target=x86_64-unknown-linux-gnu ;;' \

--- a/scripts/test-packaged-linux-volume.sh
+++ b/scripts/test-packaged-linux-volume.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 umask 077
 archive=${1:-}
 if [[ -z "$archive" || $# -ne 1 ]]; then
-  echo "usage: $0 SIGNED_X86_64_GNU_AOS_ARCHIVE" >&2
+  echo "usage: $0 SIGNED_GNU_AOS_ARCHIVE" >&2
   exit 2
 fi
 [[ -f "$archive" && ! -L "$archive" ]] || {

--- a/scripts/test-rehearsal-sign-workflow-contract.sh
+++ b/scripts/test-rehearsal-sign-workflow-contract.sh
@@ -28,30 +28,34 @@ grep -Fq 'ASTRID_RUNTIME_TARGET: aarch64-apple-darwin' "$workflow"
 grep -Fq 'submodules: recursive' "$workflow"
 grep -Fq -- '--extract-release-sealer' "$workflow"
 grep -Fq -- '--sign-release-archive' "$workflow"
-if [[ $(grep -Fc -- '--sign-release-archive' "$workflow") -ne 2 ]]; then
-  echo "rehearsal workflow must sign exactly one Darwin and one GNU archive" >&2
+if [[ $(grep -Fc -- '--sign-release-archive' "$workflow") -ne 3 ]]; then
+  echo "rehearsal workflow must sign exactly one Darwin and two GNU archives" >&2
   exit 1
 fi
-if [[ $(grep -Fc 'AOS_DISTRO_ED25519_SEED="$QA_SEED"' "$workflow") -ne 2 ]]; then
-  echo "Darwin and GNU rehearsal archives must share one ephemeral QA seed" >&2
+if [[ $(grep -Fc 'AOS_DISTRO_ED25519_SEED="$QA_SEED"' "$workflow") -ne 3 ]]; then
+  echo "Darwin and both GNU rehearsal archives must share one ephemeral QA seed" >&2
   exit 1
 fi
-if [[ $(grep -Fc '"$NATIVE_SEALER" \' "$workflow") -ne 2 ]] || \
-   [[ $(grep -Fc '"$NATIVE_SEALER_ARCHIVE"' "$workflow") -ne 2 ]]; then
-  echo "Darwin and GNU rehearsal archives must share the authenticated GNU native sealer" >&2
+if [[ $(grep -Fc '"$NATIVE_SEALER" \' "$workflow") -ne 3 ]] || \
+   [[ $(grep -Fc '"$NATIVE_SEALER_ARCHIVE"' "$workflow") -ne 3 ]]; then
+  echo "Darwin and both GNU rehearsal archives must share the authenticated GNU native sealer" >&2
   exit 1
 fi
 grep -Fq 'secrets.token_hex(32)' "$workflow"
 grep -Fq 'write_tar_listing' "$workflow"
 grep -Fq 'tar -tzf "$archive" > "$listing"' "$workflow"
 grep -Fq 'SIGNED_DARWIN_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-darwin-tar-listing.XXXXXX")' "$workflow"
-grep -Fq 'SIGNED_GNU_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-gnu-tar-listing.XXXXXX")' "$workflow"
+grep -Fq 'SIGNED_X86_64_GNU_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-x86_64-gnu-tar-listing.XXXXXX")' "$workflow"
+grep -Fq 'SIGNED_AARCH64_GNU_TAR_LISTING=$(mktemp "$RUNNER_TEMP/rehearsal-aarch64-gnu-tar-listing.XXXXXX")' "$workflow"
 grep -Fq "grep -q '/Distro.sig$' \"\$SIGNED_DARWIN_TAR_LISTING\"" "$workflow"
-grep -Fq "grep -q '/Distro.sig$' \"\$SIGNED_GNU_TAR_LISTING\"" "$workflow"
+grep -Fq "grep -q '/Distro.sig$' \"\$SIGNED_X86_64_GNU_TAR_LISTING\"" "$workflow"
+grep -Fq "grep -q '/Distro.sig$' \"\$SIGNED_AARCH64_GNU_TAR_LISTING\"" "$workflow"
 grep -Fq 'SIGNED_DARWIN_ARCHIVE=$signed_darwin' "$workflow"
-grep -Fq 'SIGNED_GNU_ARCHIVE=$signed_gnu' "$workflow"
-grep -Fq 'LINUX_ARCHIVE=${candidates[0]}' "$workflow"
-grep -Fq 'ephemeral QA seed destroyed after both signed archive verifications' "$workflow"
+grep -Fq 'SIGNED_X86_64_GNU_ARCHIVE=$signed_x86_gnu' "$workflow"
+grep -Fq 'SIGNED_AARCH64_GNU_ARCHIVE=$signed_aarch64_gnu' "$workflow"
+grep -Fq 'X86_64_GNU_ARCHIVE=${candidates[0]}' "$workflow"
+grep -Fq 'AARCH64_GNU_ARCHIVE=${candidates[0]}' "$workflow"
+grep -Fq 'ephemeral QA seed destroyed after all signed archive verifications' "$workflow"
 if grep -Eq 'tar[[:space:]][^|]*\|[[:space:]]*grep[[:space:]]+(-q|--quiet)' "$workflow"; then
   echo "rehearsal workflow must not pipe tar into grep -q" >&2
   exit 1
@@ -69,9 +73,11 @@ do
 done
 for scalar_binding in \
   'DARWIN_RUNTIME_ARCHIVE=$DARWIN_RUNTIME_ARCHIVE' \
-  'LINUX_RUNTIME_ARCHIVE=$LINUX_RUNTIME_ARCHIVE' \
+  'X86_64_RUNTIME_ARCHIVE=$X86_64_RUNTIME_ARCHIVE' \
+  'AARCH64_RUNTIME_ARCHIVE=$AARCH64_RUNTIME_ARCHIVE' \
   'DARWIN_AOS_BINARY=$DARWIN_AOS_BINARY' \
-  'LINUX_AOS_BINARY=$LINUX_AOS_BINARY'
+  'X86_64_AOS_BINARY=$X86_64_AOS_BINARY' \
+  'AARCH64_AOS_BINARY=$AARCH64_AOS_BINARY'
 do
   grep -Fq "$scalar_binding" "$workflow"
 done
@@ -84,8 +90,8 @@ validator_harness="$repo_root/scripts/test-invoke-runtime-archive-validator.sh"
 [[ -f "$validator_harness" ]]
 bash -n "$validator_harness"
 bash "$validator_harness"
-if [[ $(grep -Fc 'python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py"' "$workflow") -ne 2 ]]; then
-  echo "rehearsal workflow must invoke the runtime archive validator with python3 at both compose sites" >&2
+if [[ $(grep -Fc 'python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py"' "$workflow") -ne 3 ]]; then
+  echo "rehearsal workflow must invoke the runtime archive validator with python3 at all three compose sites" >&2
   exit 1
 fi
 if grep -Eq '^[[:space:]]*"\$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive\.py"' "$workflow"; then
@@ -96,7 +102,8 @@ if grep -Fq '[[ -f "$DARWIN_AOS_BINARY" && -x "$DARWIN_AOS_BINARY" ]]' "$workflo
   echo "rehearsal workflow must not assert execute bits before chmod" >&2
   exit 1
 fi
-if grep -Fq '[[ -f "$LINUX_AOS_BINARY" && -x "$LINUX_AOS_BINARY" ]]' "$workflow"; then
+if grep -Fq '[[ -f "$X86_64_AOS_BINARY" && -x "$X86_64_AOS_BINARY" ]]' "$workflow" || \
+   grep -Fq '[[ -f "$AARCH64_AOS_BINARY" && -x "$AARCH64_AOS_BINARY" ]]'; then
   echo "rehearsal workflow must not assert execute bits before chmod" >&2
   exit 1
 fi
@@ -112,9 +119,12 @@ grep -Fq 'REHEARSAL-ONLY' "$workflow"
 checksum_fixture=$(mktemp -d "${TMPDIR:-/tmp}/rehearsal-checksum.XXXXXX")
 printf 'darwin rehearsal archive\n' > "$checksum_fixture/aarch64-apple-darwin.tar.gz"
 printf 'gnu rehearsal archive\n' > "$checksum_fixture/x86_64-unknown-linux-gnu.tar.gz"
+printf 'aarch64 GNU rehearsal archive\n' > \
+  "$checksum_fixture/aarch64-unknown-linux-gnu.tar.gz"
 (
   cd "$checksum_fixture"
-  b3sum -- aarch64-apple-darwin.tar.gz x86_64-unknown-linux-gnu.tar.gz > \
+  b3sum -- aarch64-apple-darwin.tar.gz x86_64-unknown-linux-gnu.tar.gz \
+    aarch64-unknown-linux-gnu.tar.gz > \
     REHEARSAL-BLAKE3SUMS.txt
   b3sum --check REHEARSAL-BLAKE3SUMS.txt
 )
@@ -254,6 +264,28 @@ for job_name in ("build-aos-darwin-binary", "build-aos-linux-gnu-binary"):
     ):
         raise SystemExit(f"{job_name} must install runtime, Distro, Astrid client, and ASTRID_RUNTIME_VERSION overlays before compiling AOS")
 
+aos_gnu_matrix = re.search(
+    r"(?ms)^    strategy:\n.*?^    steps:\n",
+    sections["build-aos-linux-gnu-binary"],
+)
+if aos_gnu_matrix is None:
+    raise SystemExit("GNU AOS job is missing its target matrix")
+for marker in (
+    "fail-fast: false",
+    "- x86_64-unknown-linux-gnu",
+    "- aarch64-unknown-linux-gnu",
+    "TARGET: ${{ matrix.target }}",
+):
+    if marker not in aos_gnu_matrix.group(0):
+        raise SystemExit(f"GNU AOS job matrix is missing {marker}")
+for marker in (
+    "rustup target add aarch64-unknown-linux-gnu",
+    "gcc-aarch64-linux-gnu",
+    "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc",
+):
+    if marker not in sections["build-aos-linux-gnu-binary"]:
+        raise SystemExit(f"GNU AOS job is missing {marker}")
+
 compose = sections.get("compose-and-sign")
 if compose is None:
     raise SystemExit("rehearsal workflow is missing compose-and-sign")
@@ -272,25 +304,28 @@ if 'runtime["version"] != "2026.9.0"' not in compose:
 sign_call_archives = re.findall(
     r'AOS_DISTRO_ED25519_SEED="\$QA_SEED"\s+\\\s*'
     r'"\$REHEARSAL_CHECKOUT/scripts/package-release\.sh"\s+\\\s*'
-    r'--sign-release-archive\s+\\\s*("\$[A-Z_]+")',
+    r'--sign-release-archive\s+\\\s*("\$[A-Z0-9_]+")',
     compose,
 )
-if sign_call_archives != ['"$DARWIN_ARCHIVE"', '"$LINUX_ARCHIVE"']:
+if sign_call_archives != ['"$DARWIN_ARCHIVE"', '"$X86_64_GNU_ARCHIVE"', '"$AARCH64_GNU_ARCHIVE"']:
     raise SystemExit(
-        "rehearsal workflow must make exactly one shared-identity Darwin sign call followed by one GNU sign call"
+        "rehearsal workflow must make one shared-identity Darwin sign call followed by x86_64 and aarch64 GNU sign calls"
     )
-if compose.count('"$NATIVE_SEALER"') != 2 or compose.count('"$NATIVE_SEALER_ARCHIVE"') != 2:
-    raise SystemExit("both target sign calls must use the authenticated GNU native sealer")
+if compose.count('"$NATIVE_SEALER"') != 3 or compose.count('"$NATIVE_SEALER_ARCHIVE"') != 3:
+    raise SystemExit("all three target sign calls must use the authenticated GNU native sealer")
 for marker in (
     'SIGNED_DARWIN_ARCHIVE=$signed_darwin',
-    'SIGNED_GNU_ARCHIVE=$signed_gnu',
+    'SIGNED_X86_64_GNU_ARCHIVE=$signed_x86_gnu',
+    'SIGNED_AARCH64_GNU_ARCHIVE=$signed_aarch64_gnu',
     'grep -q \'/Distro.sig$\' "$SIGNED_DARWIN_TAR_LISTING"',
-    'grep -q \'/Distro.sig$\' "$SIGNED_GNU_TAR_LISTING"',
+    'grep -q \'/Distro.sig$\' "$SIGNED_X86_64_GNU_TAR_LISTING"',
+    'grep -q \'/Distro.sig$\' "$SIGNED_AARCH64_GNU_TAR_LISTING"',
 ):
     if marker not in compose:
         raise SystemExit(f"compose job is missing shared-identity archive evidence marker: {marker}")
 darwin_verify = compose.index("signed Darwin rehearsal archive has no Distro signature")
-gnu_verify = compose.index("signed GNU rehearsal archive has no Distro signature")
+x86_verify = compose.index("signed x86_64 GNU rehearsal archive has no Distro signature")
+aarch64_verify = compose.index("signed aarch64 GNU rehearsal archive has no Distro signature")
 seed_zero = compose.index('file.write(b"\\0" * 32)')
 seed_flush = compose.index("file.flush()", seed_zero)
 seed_fsync = compose.index("os.fsync(file.fileno())", seed_flush)
@@ -298,7 +333,8 @@ seed_unlink = compose.index("path.unlink()", seed_fsync)
 seed_absence = compose.index('[[ ! -e "$QA_SEED_FILE" ]]', seed_unlink)
 if not (
     darwin_verify
-    < gnu_verify
+    < x86_verify
+    < aarch64_verify
     < seed_zero
     < seed_flush
     < seed_fsync
@@ -306,7 +342,7 @@ if not (
     < seed_absence
 ):
     raise SystemExit(
-        "persistent QA seed zero-write/fsync/unlink/absence proof must follow both archive verifications"
+        "persistent QA seed zero-write/fsync/unlink/absence proof must follow all archive verifications"
     )
 
 darwin_runtime = sections.get("build-astrid-darwin")
@@ -328,9 +364,34 @@ for marker in (
 ):
     if marker not in gnu_runtime:
         raise SystemExit(f"GNU runtime job is missing {marker}")
+gnu_matrix = re.search(
+    r"(?ms)^    strategy:\n.*?^    steps:\n",
+    gnu_runtime,
+)
+if gnu_matrix is None:
+    raise SystemExit("GNU runtime job is missing its target matrix")
+for marker in (
+    "fail-fast: false",
+    "- x86_64-unknown-linux-gnu",
+    "- aarch64-unknown-linux-gnu",
+    "TARGET: ${{ matrix.target }}",
+):
+    if marker not in gnu_matrix.group(0):
+        raise SystemExit(f"GNU runtime job matrix is missing {marker}")
+for marker in (
+    "rustup target add aarch64-unknown-linux-gnu",
+    "gcc-aarch64-linux-gnu",
+    "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc",
+):
+    if marker not in gnu_runtime:
+        raise SystemExit(f"GNU runtime job is missing {marker}")
 
 validator_call = 'python3 "$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive.py"'
-for step_name in ("Compose the GNU native sealer source", "Compose the Darwin candidate"):
+for step_name in (
+    "Compose the GNU native sealer source",
+    "Compose the additional GNU candidate",
+    "Compose the Darwin candidate",
+):
     step = re.search(
         rf"(?ms)^      - name: {re.escape(step_name)}\n(?P<body>.*?)(?=^      - name:|\Z)",
         compose,
@@ -346,10 +407,25 @@ for step_name in ("Compose the GNU native sealer source", "Compose the Darwin ca
     has_fskit = "astrid-storage-provider-fskit" in body
     if step_name == "Compose the Darwin candidate" and not has_fskit:
         raise SystemExit("Darwin composition must require the FSKit provider")
-    if step_name == "Compose the GNU native sealer source" and not has_fuse:
+    if step_name.endswith("GNU candidate") and not has_fuse:
         raise SystemExit("GNU composition must require the FUSE provider")
-    if step_name == "Compose the GNU native sealer source" and has_fskit:
+    if step_name.endswith("GNU candidate") and has_fskit:
         raise SystemExit("GNU composition must not require the Darwin FSKit provider")
+additional = re.search(
+    r"(?ms)^      - name: Compose the additional GNU candidate\n.*?(?=^      - name:|\Z)",
+    compose,
+)
+if additional is None:
+    raise SystemExit("compose job is missing the additional GNU composition body")
+for marker in (
+    '"$AARCH64_RUNTIME_ARCHIVE"',
+    '"$AARCH64_AOS_BINARY"',
+    '"$AARCH64_GNU_TARGET"',
+    "aarch64-gnu-artifacts",
+    "AARCH64_GNU_ARCHIVE=${candidates[0]}",
+):
+    if marker not in additional.group(0):
+        raise SystemExit(f"additional GNU composition is missing {marker}")
 
 if re.search(r'(?m)^\s*"\$REHEARSAL_CHECKOUT/scripts/validate-runtime-archive\.py"', compose):
     raise SystemExit("compose job must not direct-exec the runtime archive validator")
@@ -371,12 +447,12 @@ for index, line in enumerate(lines):
 
 if "Prove overlay-built GNU AOS accepts the signed Distro" not in compose:
     raise SystemExit("compose job must execute overlay-built AOS against the signed Distro")
-probe = '"$LINUX_AOS_BINARY" distro apply --principal operator-qa --yes'
+probe = '"$X86_64_AOS_BINARY" distro apply --principal operator-qa --yes'
 if probe not in compose:
     raise SystemExit("compose job must run overlay-built GNU AOS distro apply as the consume probe")
-if 'tar -xzf "$SIGNED_GNU_ARCHIVE"' not in compose:
+if 'tar -xzf "$SIGNED_X86_64_GNU_ARCHIVE"' not in compose:
     raise SystemExit("GNU consume probe must consume the signed GNU archive")
-if 'bundle="$extract/unicity-aos-${AOS_PRODUCT_VERSION}-${LINUX_TARGET}"' not in compose:
+if 'bundle="$extract/unicity-aos-${AOS_PRODUCT_VERSION}-${X86_64_GNU_TARGET}"' not in compose:
     raise SystemExit("GNU consume probe must select the signed GNU archive root")
 if "rehearsal-consume-aos" not in compose:
     raise SystemExit("compose job must plant the signed Distro into a disposable AOS_HOME")
@@ -400,13 +476,17 @@ if not (
 
 for marker in (
     'cp "$SIGNED_DARWIN_ARCHIVE" "$output/"',
-    'cp "$SIGNED_GNU_ARCHIVE" "$output/"',
+    'cp "$SIGNED_X86_64_GNU_ARCHIVE" "$output/"',
+    'cp "$SIGNED_AARCH64_GNU_ARCHIVE" "$output/"',
     'b3sum -- "$darwin_asset"',
-    'b3sum -- "$gnu_asset"',
+    'b3sum -- "$x86_gnu_asset"',
+    'b3sum -- "$aarch64_gnu_asset"',
     'sha256sum -- "$darwin_asset"',
-    'sha256sum -- "$gnu_asset"',
+    'sha256sum -- "$x86_gnu_asset"',
+    'sha256sum -- "$aarch64_gnu_asset"',
     '"aarch64-apple-darwin": {',
     '"x86_64-unknown-linux-gnu": {',
+    '"aarch64-unknown-linux-gnu": {',
     '"publication_allowed": False',
     '"key_scope": "ephemeral-per-run-qa"',
 ):
@@ -429,6 +509,8 @@ required = [
     "ASTRID_RUNTIME_VERSION: '2026.9.0'",
     'runs-on: macos-latest',
     'runs-on: ubuntu-latest',
+    'runs-on: ${{ matrix.runner }}',
+    'runner: ubuntu-24.04-arm',
     'name: astrid-${{ env.ASTRID_RUNTIME_TARGET }}',
     'name: aos-community-capsules',
     'name: rehearsal-sign-darwin',


### PR DESCRIPTION
## Scope

Matrix both GNU targets (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`) through packaged rehearsal builds, composition, signing, evidence, and the packaged Linux volume journey. The aarch64 builds use the same digest-pinned Bullseye image and cross-linker setup as CI to preserve the glibc 2.31 baseline. The x86_64 GNU archive remains the authenticated native-sealer source.

The rehearsal identity and both checksum manifests now carry Darwin plus both GNU archives. The packaged-volume job uses an x86_64 lane on `ubuntu-latest` and an aarch64 lane on `ubuntu-24.04-arm`; each lane selects its target archive and derives the target from `uname -m`.

## Evidence limits

- The workflow remains `workflow_dispatch`-only, so this PR does not execute the build, signing, compose, or packaged-volume journey.
- Static contracts prove the target matrix, pinned targets, runners, artifact selection, three shared-seed signatures, digest coverage, and native-sealer boundary.
- The x86_64 compose probe checks signed-Distro verification up to the expected pre-runtime failure only; it does not complete Distro Apply.
- The aarch64 archive is validated, composed, signed, and digest-bound, but has no compose-time executable Distro Apply probe.
- A successful dispatched rehearsal is required to prove either target's packaged FUSE journey end to end.

## Verification

- `bash -n` passed for every touched script.
- `bash scripts/test-bind-rehearsal-consumed-artifacts.sh` passed.
- `bash scripts/test-packaged-linux-volume-contract.sh` passed.
- `bash scripts/test-rehearsal-sign-workflow-contract.sh` passed.
- `actionlint .github/workflows/rehearsal-sign-darwin.yml` passed.
- Commit signature verified for `335906bd3668dd736d786d1bcb6a751ca8a44726`.
