### PR TITLE
fix(rehearsal): bound volume journey socket path

### DIFF
--- a/scripts/test-packaged-linux-volume-contract.sh
+++ b/scripts/test-packaged-linux-volume-contract.sh
@@ -98,6 +98,8 @@ for required in \
   'sleep 61' \
   'run_default status --json' \
   'run_default stop' \
+  '${#work} > 34' \
+  'mktemp -d /tmp/aos-pv.XXXXXX' \
   'exactly 22 ready capsules' \
   'unsafe cleanup; preserving disposable evidence' \
   'runner_image=' \

--- a/scripts/test-packaged-linux-volume.sh
+++ b/scripts/test-packaged-linux-volume.sh
@@ -36,6 +36,16 @@ else
 fi
 
 work=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/aos-packaged-linux-volume.XXXXXX")
+# The FUSE provider binds a Unix domain socket at
+# $work/home/.aos/run/providers/fuse/<uuid>.sock. Keep the disposable work
+# root short enough for the 107-byte sun_path limit on every host; GitHub
+# runners use /home/runner/work/_temp, which overflows it by itself.
+if (( ${#work} > 34 )); then
+  short_work=$(mktemp -d /tmp/aos-pv.XXXXXX)
+  rmdir "$short_work"
+  mv "$work" "$short_work"
+  work=$short_work
+fi
 cleanup() {
   local status=$?
   local unsafe=0


### PR DESCRIPTION
The first protected-main rehearsal dispatch failed both packaged-volume jobs: GitHub's RUNNER_TEMP (/home/runner/work/_temp) pushes the FUSE provider's control socket past the 107-byte sun_path limit, so the provider exits before readiness. The journey now enforces a work-root length budget and falls back to a short /tmp path when needed; the contract pins the guard. This is the exact failure the post-merge dispatch existed to catch.