### PR TITLE
feat(rehearsal): support musl packaged volume targets

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -158,7 +158,7 @@ runtime = manifest.get("runtime")
 runtime_version = runtime.get("version") if isinstance(runtime, dict) else None
 if (
     isinstance(target, str)
-    and target.endswith("-unknown-linux-gnu")
+    and (target.endswith("-unknown-linux-gnu") or target.endswith("-unknown-linux-musl"))
     and runtime_version == "2026.9.0"
 ):
     runtime_executables.append("astrid-storage-provider-fuse")
@@ -238,6 +238,12 @@ require_native_release_sealer() {
       ;;
     "unicity-aos-${product_version}-aarch64-unknown-linux-gnu.tar.gz")
       expected_target=aarch64-unknown-linux-gnu
+      ;;
+    "unicity-aos-${product_version}-x86_64-unknown-linux-musl.tar.gz")
+      expected_target=x86_64-unknown-linux-musl
+      ;;
+    "unicity-aos-${product_version}-aarch64-unknown-linux-musl.tar.gz")
+      expected_target=aarch64-unknown-linux-musl
       ;;
     *)
       echo "native sealer candidate filename does not bind this checkout's version and a supported GNU target" >&2
@@ -527,7 +533,7 @@ fi
 python3 "$repo_root/scripts/capsule_release.py" --artifacts "$capsule_artifacts"
 
 runtime_binaries=(astrid astrid-daemon astrid-build astrid-emit)
-if [[ "$target" == *-unknown-linux-gnu && "$runtime_version" == "2026.9.0" ]]; then
+if [[ ( "$target" == *-unknown-linux-gnu || "$target" == *-unknown-linux-musl ) && "$runtime_version" == "2026.9.0" ]]; then
   runtime_binaries+=(astrid-storage-provider-fuse)
 elif [[ "$target" == *-apple-darwin ]]; then
   runtime_binaries+=(astrid-storage-provider-fskit)
@@ -636,7 +642,7 @@ runtime_executables = [
     "runtime/bin/astrid-build",
     "runtime/bin/astrid-emit",
 ]
-if target.endswith("-unknown-linux-gnu") and runtime == "2026.9.0":
+if (target.endswith("-unknown-linux-gnu") or target.endswith("-unknown-linux-musl")) and runtime == "2026.9.0":
     runtime_executables.append("runtime/bin/astrid-storage-provider-fuse")
 elif target.endswith("-apple-darwin"):
     runtime_executables.append("runtime/bin/astrid-storage-provider-fskit")
@@ -685,6 +691,14 @@ verifiers = {
         "sha256": "2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11",
     },
     "x86_64-unknown-linux-gnu": {
+        "asset": "cosign-linux-amd64",
+        "sha256": "ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc",
+    },
+    "aarch64-unknown-linux-musl": {
+        "asset": "cosign-linux-arm64",
+        "sha256": "2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11",
+    },
+    "x86_64-unknown-linux-musl": {
         "asset": "cosign-linux-amd64",
         "sha256": "ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc",
     },

--- a/scripts/test-packaged-linux-volume-contract.sh
+++ b/scripts/test-packaged-linux-volume-contract.sh
@@ -79,6 +79,9 @@ PY
 for required in \
   'x86_64) target=x86_64-unknown-linux-gnu ;;' \
   'aarch64) target=aarch64-unknown-linux-gnu ;;' \
+  'AOS_PACKAGED_TARGET' \
+  'x86_64-unknown-linux-gnu | x86_64-unknown-linux-musl' \
+  'aarch64-unknown-linux-gnu | aarch64-unknown-linux-musl' \
   'expected_root=unicity-aos-2026.9.0-${target}' \
   'REHEARSAL_TARGET=$target' \
   'REHEARSAL-ONLY-identity.json' \
@@ -104,6 +107,7 @@ for required in \
   'unsafe cleanup; preserving disposable evidence' \
   'runner_image=' \
   'command -v fusermount3' \
+  'apk info -e fuse3' \
   'storage mount --as operator-qa --read-write' \
   'findmnt -n -o FSTYPE --mountpoint' \
   'mount_is_active' \

--- a/scripts/test-packaged-linux-volume.sh
+++ b/scripts/test-packaged-linux-volume.sh
@@ -30,6 +30,8 @@ if command -v dpkg-query >/dev/null; then
   }
 elif command -v rpm >/dev/null; then
   rpm -q fuse3 >/dev/null || { echo "Linux packaged-volume rehearsal requires fuse3" >&2; exit 1; }
+elif command -v apk >/dev/null; then
+  apk info -e fuse3 >/dev/null || { echo "Linux packaged-volume rehearsal requires the fuse3 package" >&2; exit 1; }
 else
   echo "unable to verify the fuse3 package manager state" >&2
   exit 1
@@ -91,13 +93,34 @@ mkdir -m 0700 "$work/home" "$work/extract"
   printf 'fusermount3_mode=%s\n' "$(stat -c '%a' "$fusermount3" 2>/dev/null || stat -f '%Lp' "$fusermount3")"
   "$fusermount3" --version 2>&1 || true
 } | tee "$work/runner-fuse.txt"
-case "$(uname -m)" in
-  x86_64) target=x86_64-unknown-linux-gnu ;;
-  aarch64) target=aarch64-unknown-linux-gnu ;;
+# The package target is explicit when the host cannot infer it: musl-static
+# artifacts certify on glibc hosts, so uname carries only the architecture.
+# An explicit target must be one of the supported triples and must match the
+# host architecture; without one, a GNU host runs its own GNU target.
+case "${AOS_PACKAGED_TARGET:-}" in
+  x86_64-unknown-linux-gnu | x86_64-unknown-linux-musl) target_arch=x86_64 ;;
+  aarch64-unknown-linux-gnu | aarch64-unknown-linux-musl) target_arch=aarch64 ;;
+  "")
+    target_arch=$(uname -m)
+    ;;
   *)
-    echo "unsupported packaged-volume architecture: $(uname -m)" >&2
+    echo "unsupported AOS_PACKAGED_TARGET: ${AOS_PACKAGED_TARGET}" >&2
     exit 1
     ;;
+esac
+case "$(uname -m):$target_arch" in
+  x86_64:x86_64 | aarch64:aarch64) ;;
+  *)
+    echo "packaged-volume target architecture ($target_arch) does not match the host ($(uname -m))" >&2
+    exit 1
+    ;;
+esac
+case "${AOS_PACKAGED_TARGET:-}" in
+  x86_64-* | aarch64-*) target=$AOS_PACKAGED_TARGET ;;
+  *) case "$target_arch" in
+       x86_64) target=x86_64-unknown-linux-gnu ;;
+       aarch64) target=aarch64-unknown-linux-gnu ;;
+     esac ;;
 esac
 expected_root=unicity-aos-2026.9.0-${target}
 # Bind the exact package bytes to the REHEARSAL-ONLY identity and checksum


### PR DESCRIPTION
## Summary
Extend existing Linux package composition and packaged-volume rehearsal to both musl targets. Include the FUSE companion and matching pinned verifier, accept explicit architecture-bound targets, and recognize Alpine fuse3 installation.

Related to #63. This is package/rehearsal support only; publication and installer wiring remain separate.

## Validation
- Packaged Linux volume workflow contract passed.
- Package-release suite passed, including malformed executable inventory refusal cases.
- Musl metadata tests: 12 passed.
- Native aarch64 Alpine full package/volume run is in progress; no completed musl journey is claimed by this PR.

The signed commit adds DCO metadata to the previously tested local tree; product files are unchanged.