### PR TITLE
fix(install): select authenticated musl product archives

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -553,8 +553,76 @@ validate_accepted_channel() {
   fi
 }
 
+validate_musl_release_metadata() {
+  musl_metadata=$1
+  legacy_metadata=$2
+  # Canonical output of musl_release_metadata.py; no Python is required by
+  # the bootstrap installer. Reject duplicate, missing and unknown fields.
+  awk '
+    BEGIN {
+      fields[""] = "schema-version kind product repository version tag source-commit release-workflow-identity"
+      fields["[legacy-release]"] = "metadata-asset metadata-sha256"
+      fields["[runtime-musl]"] = "repository version tag source-commit release-workflow-identity legacy-release-metadata-asset legacy-release-metadata-blake3 musl-release-metadata-asset musl-release-metadata-blake3"
+      fields["[targets.aarch64-unknown-linux-musl]"] = "asset sha256 blake3 sigstore-bundle size"
+      fields["[targets.x86_64-unknown-linux-musl]"] = "asset sha256 blake3 sigstore-bundle size"
+      for (s in fields) {
+        n = split(fields[s], keys, " ")
+        for (i = 1; i <= n; i++) required[s SUBSEP keys[i]] = 1
+      }
+    }
+    /^$/ { next }
+    /^\[/ {
+      section = $0
+      if (!(section in fields) || sections[section]++) bad = 1
+      next
+    }
+    {
+      key = section SUBSEP $1
+      if ($2 != "=" || !(key in required) || seen[key]++) bad = 1
+      value = substr($0, index($0, "=") + 1)
+      sub(/^[[:space:]]+/, "", value)
+      if ($1 == "schema-version") { if (value != "1") bad = 1 }
+      else if ($1 == "size") { if (value !~ /^[1-9][0-9]*$/) bad = 1 }
+      else if (value !~ /^"[^"\\]*"$/) bad = 1
+    }
+    END {
+      for (key in required) if (seen[key] != 1) bad = 1
+      exit bad ? 1 : 0
+    }
+  ' "$musl_metadata" || { echo "invalid signed musl extension schema" >&2; return 1; }
+  [ "$(toml_value "$musl_metadata" "" kind)" = aos-release-musl-extension ] || return 1
+  [ "$(toml_value "$musl_metadata" "" repository)" = "$AOS_TRUSTED_RELEASE_REPO" ] || return 1
+  for musl_key in product version tag source-commit release-workflow-identity; do
+    [ "$(toml_value "$musl_metadata" "" "$musl_key")" = "$(toml_value "$legacy_metadata" "" "$musl_key")" ] || return 1
+  done
+  [ "$(toml_value "$musl_metadata" '[legacy-release]' metadata-asset)" = "$release_metadata_asset" ] || return 1
+  [ "$(toml_value "$musl_metadata" '[legacy-release]' metadata-sha256)" = "$(sha256_file "$legacy_metadata")" ] || {
+    echo "musl extension does not bind the authenticated release" >&2; return 1
+  }
+  for musl_key in repository version tag source-commit release-workflow-identity; do
+    [ "$(toml_value "$musl_metadata" '[runtime-musl]' "$musl_key")" = "$(toml_value "$legacy_metadata" '[runtime]' "$musl_key")" ] || return 1
+  done
+  [ "$(toml_value "$musl_metadata" '[runtime-musl]' legacy-release-metadata-asset)" = "$runtime_metadata_asset" ] || return 1
+  [ "$(toml_value "$musl_metadata" '[runtime-musl]' legacy-release-metadata-blake3)" = "$runtime_metadata_blake3" ] || return 1
+  [ "$(toml_value "$musl_metadata" '[runtime-musl]' musl-release-metadata-asset)" = "astrid-${runtime_version}-musl-release.toml" ] || return 1
+  printf '%s\n' "$(toml_value "$musl_metadata" '[runtime-musl]' musl-release-metadata-blake3)" | grep -Eq '^[0-9a-f]{64}$' || return 1
+  for musl_target in aarch64-unknown-linux-musl x86_64-unknown-linux-musl; do
+    musl_section="[targets.$musl_target]"
+    musl_asset="unicity-aos-${AOS_VERSION}-${musl_target}.tar.gz"
+    [ "$(toml_value "$musl_metadata" "$musl_section" asset)" = "$musl_asset" ] || return 1
+    [ "$(toml_value "$musl_metadata" "$musl_section" sigstore-bundle)" = "$musl_asset.sigstore.json" ] || return 1
+    for musl_digest in sha256 blake3; do
+      printf '%s\n' "$(toml_value "$musl_metadata" "$musl_section" "$musl_digest")" | grep -Eq '^[0-9a-f]{64}$' || return 1
+    done
+  done
+}
+
 os=$(uname -s)
 arch=$(uname -m)
+libc=gnu
+if [ "$os" = Linux ] && ldd --version 2>&1 | grep -qi musl; then
+  libc=musl
+fi
 runtime_binaries="astrid astrid-daemon astrid-build astrid-emit"
 case "$os:$arch" in
   Darwin:arm64|Darwin:aarch64)
@@ -570,12 +638,12 @@ case "$os:$arch" in
     runtime_binaries="$runtime_binaries astrid-storage-provider-fskit"
     ;;
   Linux:aarch64|Linux:arm64)
-    target=aarch64-unknown-linux-gnu
+    target=aarch64-unknown-linux-$libc
     cosign_asset=cosign-linux-arm64
     cosign_sha256=2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11
     ;;
   Linux:x86_64|Linux:amd64)
-    target=x86_64-unknown-linux-gnu
+    target=x86_64-unknown-linux-$libc
     cosign_asset=cosign-linux-amd64
     cosign_sha256=ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc
     ;;
@@ -698,6 +766,20 @@ if [ -n "$release_metadata_sha256" ] && [ "$(sha256_file "$work/$release_metadat
   exit 1
 fi
 validate_release_metadata "$work/$release_metadata_asset" "$AOS_VERSION" "$release_identity"
+target_metadata="$work/$release_metadata_asset"
+if [ "$libc" = musl ]; then
+  musl_metadata_asset="unicity-aos-${AOS_VERSION}-musl-release.toml"
+  curl --proto '=https' --tlsv1.2 -fsSL "$release_base/$musl_metadata_asset" -o "$work/$musl_metadata_asset"
+  curl --proto '=https' --tlsv1.2 -fsSL "$release_base/$musl_metadata_asset.sigstore.json" -o "$work/$musl_metadata_asset.sigstore.json"
+  "$COSIGN_BIN" verify-blob \
+    --bundle "$work/$musl_metadata_asset.sigstore.json" \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-identity "$release_identity" \
+    --use-signed-timestamps \
+    "$work/$musl_metadata_asset" >/dev/null
+  validate_musl_release_metadata "$work/$musl_metadata_asset" "$target_metadata"
+  target_metadata="$work/$musl_metadata_asset"
+fi
 
 # The signed runtime tuple is the authority for GNU runtime membership. Keep
 # the historical 0.10.4 four-binary set stable, and require the FUSE provider
@@ -708,10 +790,10 @@ if [ "$os" = Linux ] && [ "$runtime_version" = 2026.9.0 ]; then
 fi
 
 target_section="[targets.${target}]"
-asset=$(toml_value "$work/$release_metadata_asset" "$target_section" asset)
-asset_sha256=$(toml_value "$work/$release_metadata_asset" "$target_section" sha256)
-asset_blake3=$(toml_value "$work/$release_metadata_asset" "$target_section" blake3)
-asset_bundle=$(toml_value "$work/$release_metadata_asset" "$target_section" sigstore-bundle)
+asset=$(toml_value "$target_metadata" "$target_section" asset)
+asset_sha256=$(toml_value "$target_metadata" "$target_section" sha256)
+asset_blake3=$(toml_value "$target_metadata" "$target_section" blake3)
+asset_bundle=$(toml_value "$target_metadata" "$target_section" sigstore-bundle)
 expected_asset="unicity-aos-${AOS_VERSION}-${target}.tar.gz"
 [ "$asset" = "$expected_asset" ] || { echo "release metadata selected a non-canonical target asset" >&2; exit 1; }
 [ "$asset_bundle" = "$asset.sigstore.json" ] || { echo "release metadata selected a non-canonical signature bundle" >&2; exit 1; }
@@ -736,12 +818,16 @@ if [ -f "$work/channel.toml" ]; then
     echo "signed channel source commit does not match immutable release metadata" >&2
     exit 1
   }
-  for key in asset sha256 blake3 sigstore-bundle size; do
-    [ "$(toml_value "$work/channel.toml" "$target_section" "$key")" = "$(toml_value "$work/$release_metadata_asset" "$target_section" "$key")" ] || {
-      echo "signed channel target does not match immutable release metadata: $key" >&2
-      exit 1
-    }
-  done
+  # The immutable musl extension binds the complete channel-selected release
+  # metadata by SHA-256. Legacy channels intentionally carry GNU/Darwin only.
+  if [ "$libc" != musl ]; then
+    for key in asset sha256 blake3 sigstore-bundle size; do
+      [ "$(toml_value "$work/channel.toml" "$target_section" "$key")" = "$(toml_value "$work/$release_metadata_asset" "$target_section" "$key")" ] || {
+        echo "signed channel target does not match immutable release metadata: $key" >&2
+        exit 1
+      }
+    done
+  fi
 fi
 
 echo "Downloading Unicity AOS $AOS_VERSION for $target..."

--- a/scripts/test-install-musl.sh
+++ b/scripts/test-install-musl.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Sourced by test-install.sh to reuse its package and signed-transport fixtures.
+# All fake executables and trust fixtures remain test-only.
+
+for m_target in x86_64-unknown-linux-musl aarch64-unknown-linux-musl; do
+  m_root="$work/astrid-$runtime_version-$m_target"
+  mkdir -p "$m_root"
+  cp "$runtime_root"/* "$m_root/"
+  COPYFILE_DISABLE=1 tar -czf "$work/$m_target-runtime.tar.gz" -C "$work" "$(basename "$m_root")"
+  bash "$repo_root/scripts/package-release.sh" "$m_target" "$work/aos" \
+    "$work/$m_target-runtime.tar.gz" "$(printf '%064d' 0)" "$work/capsules" "$fixture" >/dev/null
+  cp "$good_bundle" "$fixture/unicity-aos-2026.9.0-$m_target.tar.gz.sigstore.json"
+done
+cp "$fixture/cosign-linux-amd64" "$fixture/cosign-linux-arm64"
+m_metadata="$fixture/unicity-aos-2026.9.0-musl-release.toml"
+PYTHONPATH="$repo_root/scripts" python3 - "$fixture" "$release_metadata" "$repo_root/release/runtime-musl-compatibility.toml" <<'PY'
+import hashlib
+import pathlib
+import subprocess
+import sys
+import tomllib
+import musl_release_metadata as musl
+
+root, legacy_path, pin_path = map(pathlib.Path, sys.argv[1:])
+legacy_bytes = legacy_path.read_bytes()
+legacy = tomllib.loads(legacy_bytes.decode())
+runtime = tomllib.loads(pin_path.read_text())["runtime"]
+runtime.pop("release-ready")
+runtime["musl-release-metadata-asset"] = f"astrid-{runtime['version']}-musl-release.toml"
+runtime["musl-release-metadata-blake3"] = "d" * 64
+targets = {}
+for target in musl.MUSL_TARGETS:
+    path = root / f"unicity-aos-{legacy['version']}-{target}.tar.gz"
+    targets[target] = {
+        "asset": path.name,
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "blake3": subprocess.check_output(["b3sum", str(path)], text=True).split()[0],
+        "sigstore-bundle": path.name + ".sigstore.json",
+        "size": path.stat().st_size,
+    }
+extension = {
+    "schema-version": 1, "kind": musl.KIND,
+    "repository": "unicity-aos/aos-ce",
+    **{key: legacy[key] for key in ("product", "version", "tag", "source-commit", "release-workflow-identity")},
+    "legacy-release": {"metadata-asset": legacy_path.name, "metadata-sha256": hashlib.sha256(legacy_bytes).hexdigest()},
+    "runtime-musl": runtime,
+    "targets": targets,
+}
+musl.validate_extension(extension, legacy=legacy, legacy_bytes=legacy_bytes)
+(root / f"unicity-aos-{legacy['version']}-musl-release.toml").write_text(musl.render_extension(extension))
+PY
+cp "$good_bundle" "$m_metadata.sigstore.json"
+cp "$m_metadata" "$work/musl-good.toml"
+
+for m_arch in x86_64 aarch64; do
+  m_verifier=ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc
+  if [[ "$m_arch" == aarch64 ]]; then
+    m_verifier=2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11
+  fi
+  PATH="$fake_bin:$PATH" HOME="$work/musl-$m_arch-home" AOS_TEST_FIXTURE="$fixture" \
+    AOS_TEST_UNAME_M="$m_arch" AOS_TEST_LIBC=musl AOS_TEST_COSIGN_SHA256="$m_verifier" \
+    AOS_VERSION=2026.9.0 sh "$repo_root/install.sh" --yes --no-migrate-prompt
+  test -x "$work/musl-$m_arch-home/.aos/bin/aos"
+done
+
+for m_failure in signature binding duplicate missing; do
+  cp "$work/musl-good.toml" "$m_metadata"
+  cp "$good_bundle" "$m_metadata.sigstore.json"
+  case "$m_failure" in
+    signature) printf 'invalid signature\n' > "$m_metadata.sigstore.json" ;;
+    binding) sed 's/^metadata-sha256 = .*/metadata-sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"/' "$m_metadata" > "$work/musl-invalid.toml"; cp "$work/musl-invalid.toml" "$m_metadata" ;;
+    duplicate) printf '\nsize = 1\n' >> "$m_metadata" ;;
+    missing) rm "$m_metadata" ;;
+  esac
+  if PATH="$fake_bin:$PATH" HOME="$work/musl-$m_failure-home" AOS_TEST_FIXTURE="$fixture" \
+    AOS_TEST_LIBC=musl AOS_VERSION=2026.9.0 \
+    sh "$repo_root/install.sh" --yes --no-migrate-prompt > "$work/musl-$m_failure.log" 2>&1; then
+    echo "musl installer accepted $m_failure extension" >&2; exit 1
+  fi
+  test ! -e "$work/musl-$m_failure-home/.aos"
+done
+cp "$work/musl-good.toml" "$m_metadata"
+cp "$good_bundle" "$m_metadata.sigstore.json"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -160,6 +160,12 @@ if [ "$#" -eq 2 ] && [ "$1" = -u ]; then
 fi
 exec /bin/date "$@"
 EOF
+cat > "$fake_bin/ldd" <<'EOF'
+#!/bin/sh
+echo "${AOS_TEST_LIBC:-GNU libc}" >&2
+exit 1
+EOF
+chmod 755 "$fake_bin/ldd"
 
 cat > "$fake_bin/curl" <<'EOF'
 #!/bin/sh
@@ -248,6 +254,7 @@ AOS_VERSION=2026.9.0 \
 sh "$repo_root/install.sh" --yes --no-migrate-prompt
 
 test -x "$work/home/.aos/bin/aos"
+source "$repo_root/scripts/test-install-musl.sh"
 release_dir="$work/home/.aos/releases/2026.9.0"
 test "$runtime_version" = 0.10.4
 for binary in astrid astrid-daemon astrid-build astrid-emit; do
@@ -772,6 +779,11 @@ python=${PYTHON3:-python3}
   --output "$fixture/channel.toml"
 cp "$good_bundle" "$fixture/channel.toml.sigstore.json"
 cp "$fixture/channel.toml" "$fixture/channel-good.toml"
+
+PATH="$fake_bin:$PATH" HOME="$work/musl-channel-home" AOS_TEST_FIXTURE="$fixture" \
+  AOS_TEST_LIBC=musl sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
+test -x "$work/musl-channel-home/.aos/bin/aos"
+test "$(cat "$work/musl-channel-home/.aos/update/channels/stable/current")" = 2
 
 PATH="$fake_bin:$PATH" HOME="$work/channel-home" AOS_TEST_FIXTURE="$fixture" \
   sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null


### PR DESCRIPTION
## Summary
Detect Linux musl and select the matching product archive through the existing signed musl extension. Bind the extension to the authenticated legacy release bytes and runtime tuple before using its target table. Preserve GNU/Darwin and channel-generation validation without requiring Python on the installing host.

Related to #63. Publication of the musl archives/extension remains separate.

## Validation
Full scripts/test-install.sh passes. New coverage exercises explicit-version installs on both musl architectures, a stable-channel musl install, and refusal of missing, invalid-signature, duplicate-field and mismatched-release extensions before AOS home creation. ShellCheck, shell syntax and diff checks pass.

Transport/signature fixtures test the real installer but are not production signing evidence. Native ARM64 packaged runtime/FUSE rehearsal passed separately; x86 package rehearsal is still running.