### PR TITLE
feat(release): produce authenticated native musl archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
       - run: python3 scripts/test_validate_release_contract.py
       - run: python3 scripts/test_release_metadata.py
       - run: python3 scripts/test_musl_release_metadata.py
+      - run: python3 scripts/test_check_static_elf.py
+      - run: python3 scripts/test_musl_release_workflow.py
       - run: python3 scripts/test_nightly_version.py
       - run: python3 scripts/test_channel_transaction.py
       - run: python3 scripts/test_channel_publication.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,10 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-24.04
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
@@ -169,7 +173,7 @@ jobs:
           toolchain: '1.95.0'
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: ${{ !endsWith(matrix.target, 'linux-gnu') }}
+        if: ${{ endsWith(matrix.target, 'apple-darwin') }}
         with:
           key: aos-release-${{ matrix.target }}
       - name: Install pinned BLAKE3 checksum tool
@@ -186,7 +190,7 @@ jobs:
           print(f"RUNTIME_IDENTITY={metadata['release-workflow-identity']}")
           PY
       - name: Build product binary
-        if: ${{ !endsWith(matrix.target, 'linux-gnu') }}
+        if: ${{ endsWith(matrix.target, 'apple-darwin') }}
         run: |
           cargo build --locked --release --target "${{ matrix.target }}" -p unicity-aos-bootstrap
           echo "AOS_BINARY=target/${{ matrix.target }}/release/aos" >> "$GITHUB_ENV"
@@ -215,6 +219,22 @@ jobs:
             '
           AOS_BINARY="target/glibc-2.31/${{ matrix.target }}/release/aos"
           python3 scripts/check_glibc.py --max-version 2.34 "$AOS_BINARY"
+          echo "AOS_BINARY=$AOS_BINARY" >> "$GITHUB_ENV"
+      - name: Build native static musl product binary
+        if: ${{ endsWith(matrix.target, 'linux-musl') }}
+        env:
+          MUSL_BUILD_IMAGE: docker.io/library/rust:1.95.0-alpine3.23@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2
+          TARGET: ${{ matrix.target }}
+        run: |
+          docker run --rm -e TARGET -v "$PWD:/workspace" -w /workspace \
+            "$MUSL_BUILD_IMAGE" sh -euxc '
+              test "$(uname -m)" = "${TARGET%%-*}"
+              apk add --no-cache build-base cmake pkgconf openssl perl git zlib-dev
+              cargo build --locked --release --target "$TARGET" -p unicity-aos-bootstrap
+              "target/$TARGET/release/aos" --help >/dev/null
+            '
+          AOS_BINARY="target/$TARGET/release/aos"
+          python3 scripts/check_static_elf.py --architecture "${TARGET%%-*}" "$AOS_BINARY"
           echo "AOS_BINARY=$AOS_BINARY" >> "$GITHUB_ENV"
       - name: Download pinned runtime release
         run: |
@@ -252,6 +272,21 @@ jobs:
             "$CHECK_ROOT/$RUNTIME_ROOT/astrid-daemon" \
             "$CHECK_ROOT/$RUNTIME_ROOT/astrid-build" \
             "$CHECK_ROOT/$RUNTIME_ROOT/astrid-emit"
+      - name: Verify static musl runtime executables
+        if: ${{ endsWith(matrix.target, 'linux-musl') }}
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          RUNTIME_ROOT="astrid-${RUNTIME_VERSION}-$TARGET"
+          CHECK_ROOT="$RUNNER_TEMP/runtime-musl-check"
+          python3 scripts/validate-runtime-archive.py "$RUNTIME_ASSET" "$RUNTIME_ROOT" \
+            astrid astrid-daemon astrid-build astrid-emit astrid-storage-provider-fuse
+          mkdir "$CHECK_ROOT"
+          tar -xzf "$RUNTIME_ASSET" -C "$CHECK_ROOT"
+          python3 scripts/check_static_elf.py --architecture "${TARGET%%-*}" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid" "$CHECK_ROOT/$RUNTIME_ROOT/astrid-daemon" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid-build" "$CHECK_ROOT/$RUNTIME_ROOT/astrid-emit" \
+            "$CHECK_ROOT/$RUNTIME_ROOT/astrid-storage-provider-fuse"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: capsule-artifacts
@@ -500,6 +535,12 @@ jobs:
             --output "$RELEASE_METADATA"
           python3 scripts/release_metadata.py validate-release \
             --require-ready "$RELEASE_METADATA"
+          python3 scripts/musl_release_metadata.py render \
+            --legacy-release "$RELEASE_METADATA" \
+            --runtime-pin release/runtime-musl-compatibility.toml \
+            --artifacts artifacts --sha256 artifacts/SHA256SUMS.txt \
+            --blake3 artifacts/BLAKE3SUMS.txt \
+            --output "artifacts/unicity-aos-${GITHUB_REF_NAME}-musl-release.toml"
           echo "RELEASE_METADATA=$RELEASE_METADATA" >> "$GITHUB_ENV"
       - name: Authenticate the remote tag before candidate publication
         env:
@@ -643,6 +684,7 @@ jobs:
             --dir "$EXISTING_ASSETS"
           PAYLOADS="$RUNNER_TEMP/existing-release-payloads.txt"
           python3 scripts/release_publication.py \
+            --require-musl \
             --artifacts "$EXISTING_ASSETS" \
             --version "$GITHUB_REF_NAME" \
             --source-commit "$EXPECTED_SOURCE" > "$PAYLOADS"
@@ -751,6 +793,7 @@ jobs:
             --dir "$FINAL"
           PAYLOADS="$RUNNER_TEMP/final-release-payloads.txt"
           python3 scripts/release_publication.py \
+            --require-musl \
             --artifacts "$FINAL" \
             --version "$GITHUB_REF_NAME" \
             --source-commit "$EXPECTED_SOURCE" > "$PAYLOADS"

--- a/scripts/check_static_elf.py
+++ b/scripts/check_static_elf.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Validate a statically linked ELF release binary for the expected machine."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+
+
+MACHINES = {
+    "x86_64": "Advanced Micro Devices X86-64",
+    "aarch64": "AArch64",
+}
+GLIBC_SYMBOL_VERSION = re.compile(r"\bGLIBC_[A-Za-z0-9_.]+")
+
+
+def validate_readelf(
+    architecture: str,
+    file_header: str,
+    program_headers: str,
+    dynamic_section: str,
+    version_info: str,
+) -> None:
+    expected = MACHINES.get(architecture)
+    if expected is None:
+        raise ValueError(f"unsupported ELF architecture {architecture!r}")
+    machine = next(
+        (
+            line.split(":", 1)[1].strip()
+            for line in file_header.splitlines()
+            if line.lstrip().startswith("Machine:")
+        ),
+        None,
+    )
+    if machine != expected:
+        raise ValueError(
+            f"ELF machine is {machine or 'missing'}, expected {expected}"
+        )
+    if any(line.split()[:1] == ["INTERP"] for line in program_headers.splitlines()):
+        raise ValueError("ELF has a program interpreter and is not static")
+    if "(NEEDED)" in dynamic_section:
+        raise ValueError("ELF has dynamic shared-library dependencies")
+    if GLIBC_SYMBOL_VERSION.search(version_info):
+        raise ValueError("ELF contains a glibc symbol-version requirement")
+
+
+def readelf(path: pathlib.Path, *arguments: str) -> str:
+    try:
+        result = subprocess.run(
+            ["readelf", *arguments, "--wide", "--", str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise ValueError("readelf is required to validate static ELF binaries") from error
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() if error.stderr else "unknown readelf error"
+        raise ValueError(f"could not inspect {path}: {stderr}") from error
+    return result.stdout
+
+
+def check_binary(path: pathlib.Path, architecture: str) -> None:
+    if not path.is_file() or path.is_symlink():
+        raise ValueError(f"binary is missing or not a regular file: {path}")
+    validate_readelf(
+        architecture,
+        readelf(path, "--file-header"),
+        readelf(path, "--program-headers"),
+        readelf(path, "--dynamic"),
+        readelf(path, "--version-info"),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--architecture", choices=sorted(MACHINES), required=True)
+    parser.add_argument("binary", nargs="+", type=pathlib.Path)
+    args = parser.parse_args()
+
+    try:
+        for binary in args.binary:
+            check_binary(binary, args.architecture)
+    except ValueError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/musl_release_metadata.py
+++ b/scripts/musl_release_metadata.py
@@ -352,6 +352,13 @@ def render_extension(value: dict[str, Any]) -> str:
 def parser() -> argparse.ArgumentParser:
     root = argparse.ArgumentParser(description=__doc__)
     commands = root.add_subparsers(dest="command", required=True)
+    render = commands.add_parser("render")
+    render.add_argument("--legacy-release", type=Path, required=True)
+    render.add_argument("--runtime-pin", type=Path, required=True)
+    render.add_argument("--artifacts", type=Path, required=True)
+    render.add_argument("--sha256", type=Path, required=True)
+    render.add_argument("--blake3", type=Path, required=True)
+    render.add_argument("--output", type=Path, required=True)
     validate = commands.add_parser("validate")
     validate.add_argument("path", type=Path)
     validate.add_argument(
@@ -362,8 +369,65 @@ def parser() -> argparse.ArgumentParser:
     return root
 
 
+def compose_extension(
+    legacy: dict[str, Any], legacy_bytes: bytes, runtime_pin: dict[str, Any],
+    artifacts: Path, sha256: dict[str, str], blake3: dict[str, str],
+) -> dict[str, Any]:
+    """Bind the two packaged targets to the same immutable AOS release."""
+    legacy = release_metadata.validate_release(legacy)
+    runtime = validate_runtime_pin(runtime_pin, require_ready=True)
+    for key in ("repository", "version", "tag", "source-commit", "release-workflow-identity"):
+        release_metadata.require(
+            runtime[key] == legacy["runtime"][key],
+            f"musl runtime {key} differs from the base release",
+        )
+    for musl_key, legacy_key in (
+        ("legacy-release-metadata-asset", "release-metadata-asset"),
+        ("legacy-release-metadata-blake3", "release-metadata-blake3"),
+    ):
+        release_metadata.require(
+            runtime[musl_key] == legacy["runtime"][legacy_key],
+            f"musl runtime {musl_key} differs from the base release",
+        )
+    version = legacy["version"]
+    targets = {}
+    for target in MUSL_TARGETS:
+        asset = f"unicity-aos-{version}-{target}.tar.gz"
+        path = artifacts / asset
+        release_metadata.require(path.is_file() and not path.is_symlink(), f"missing regular musl archive: {asset}")
+        release_metadata.require(asset in sha256 and asset in blake3, f"missing checksums for {asset}")
+        with path.open("rb") as stream:
+            actual_sha256 = hashlib.file_digest(stream, "sha256").hexdigest()
+        release_metadata.require(actual_sha256 == sha256[asset], f"musl archive SHA-256 mismatch: {asset}")
+        targets[target] = {
+            "asset": asset, "sha256": sha256[asset], "blake3": blake3[asset],
+            "sigstore-bundle": f"{asset}.sigstore.json", "size": path.stat().st_size,
+        }
+    extension = {
+        "schema-version": 1, "kind": KIND, "repository": release_metadata.REPOSITORY,
+        **{key: legacy[key] for key in ("product", "version", "tag", "source-commit", "release-workflow-identity")},
+        "legacy-release": {
+            "metadata-asset": f"unicity-aos-{version}-release.toml",
+            "metadata-sha256": hashlib.sha256(legacy_bytes).hexdigest(),
+        },
+        "runtime-musl": {key: value for key, value in runtime.items() if key != "release-ready"},
+        "targets": targets,
+    }
+    return validate_extension(extension, legacy=legacy, legacy_bytes=legacy_bytes)
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parser().parse_args(argv)
+    if args.command == "render":
+        legacy_bytes = args.legacy_release.read_bytes()
+        extension = compose_extension(
+            release_metadata.load(args.legacy_release), legacy_bytes,
+            release_metadata.load(args.runtime_pin), args.artifacts,
+            release_metadata.checksum_manifest(args.sha256),
+            release_metadata.checksum_manifest(args.blake3),
+        )
+        args.output.write_text(render_extension(extension), encoding="utf-8")
+        return 0
     extension = release_metadata.load(args.path)
     if args.legacy_release is None:
         validate_extension(extension)

--- a/scripts/release_publication.py
+++ b/scripts/release_publication.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import capsule_release
 import release_metadata
+import musl_release_metadata
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -40,6 +41,8 @@ def validate_release_assets(
     version: str,
     source_commit: str,
     compatibility_path: Path | None = None,
+    musl_compatibility_path: Path | None = None,
+    require_musl: bool = False,
 ) -> list[str]:
     require(directory.is_dir() and not directory.is_symlink(), "release assets must be a directory")
     entries = list(directory.iterdir())
@@ -64,9 +67,29 @@ def validate_release_assets(
 
     specs = capsule_release.source_contract()
     capsules = {spec.asset for spec in specs}
-    targets = {item["asset"] for item in metadata["targets"].values()}
+    target_records = list(metadata["targets"].values())
+    extension_name = f"unicity-aos-{version}-musl-release.toml"
+    extension_path = directory / extension_name
+    require(not require_musl or extension_path.is_file(), "required musl extension is missing")
+    extension_payloads = set()
+    if extension_path.is_file():
+        extension = musl_release_metadata.validate_extension(
+            release_metadata.load(extension_path), legacy=metadata,
+            legacy_bytes=metadata_path.read_bytes(),
+        )
+        musl_compatibility_path = musl_compatibility_path or ROOT / "release/runtime-musl-compatibility.toml"
+        pin = musl_release_metadata.validate_runtime_pin(
+            release_metadata.load(musl_compatibility_path), require_ready=True,
+        )
+        require(
+            extension["runtime-musl"] == {key: value for key, value in pin.items() if key != "release-ready"},
+            "musl runtime pin differs from the tagged source",
+        )
+        target_records.extend(extension["targets"].values())
+        extension_payloads.add(extension_name)
+    targets = {item["asset"] for item in target_records}
     checksummed = targets | capsules
-    payloads = checksummed | set(FIXED_PAYLOADS) | {metadata_name}
+    payloads = checksummed | set(FIXED_PAYLOADS) | {metadata_name} | extension_payloads
     expected = payloads | {f"{name}.sigstore.json" for name in payloads}
     actual = {path.name for path in entries}
     require(
@@ -86,7 +109,7 @@ def validate_release_assets(
             f"SHA-256 mismatch for {name}",
         )
 
-    for item in metadata["targets"].values():
+    for item in target_records:
         name = item["asset"]
         require(item["sha256"] == sha256[name], f"release metadata SHA-256 mismatch for {name}")
         require(item["blake3"] == blake3[name], f"release metadata BLAKE3 mismatch for {name}")
@@ -133,6 +156,7 @@ def parser() -> argparse.ArgumentParser:
     root.add_argument("--artifacts", type=Path, required=True)
     root.add_argument("--version", required=True)
     root.add_argument("--source-commit", required=True)
+    root.add_argument("--require-musl", action="store_true")
     return root
 
 
@@ -142,6 +166,7 @@ def main(argv: list[str] | None = None) -> int:
         args.artifacts,
         version=args.version,
         source_commit=args.source_commit,
+        require_musl=args.require_musl,
     ):
         print(payload)
     return 0

--- a/scripts/test_check_static_elf.py
+++ b/scripts/test_check_static_elf.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import unittest
+
+import check_static_elf
+
+
+class StaticElfTests(unittest.TestCase):
+    def validate(
+        self,
+        *,
+        architecture: str = "x86_64",
+        machine: str = "Advanced Micro Devices X86-64",
+        programs: str = "LOAD 0x000000",
+        dynamic: str = "There is no dynamic section in this file.",
+        versions: str = "No version information found in this file.",
+    ) -> None:
+        check_static_elf.validate_readelf(
+            architecture,
+            f"ELF Header:\n  Machine: {machine}\n",
+            programs,
+            dynamic,
+            versions,
+        )
+
+    def test_accepts_static_x86_64_and_aarch64(self) -> None:
+        self.validate()
+        self.validate(architecture="aarch64", machine="AArch64")
+
+    def test_rejects_wrong_machine(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ELF machine"):
+            self.validate(machine="AArch64")
+
+    def test_rejects_program_interpreter(self) -> None:
+        with self.assertRaisesRegex(ValueError, "program interpreter"):
+            self.validate(programs=" INTERP 0x000000\n LOAD 0x001000")
+
+    def test_rejects_dynamic_dependency(self) -> None:
+        with self.assertRaisesRegex(ValueError, "shared-library"):
+            self.validate(dynamic="0x0000000000000001 (NEEDED) Shared library: [libc.so]")
+
+    def test_rejects_glibc_symbol_version(self) -> None:
+        with self.assertRaisesRegex(ValueError, "glibc"):
+            self.validate(versions="Name: GLIBC_2.34")
+        with self.assertRaisesRegex(ValueError, "glibc"):
+            self.validate(versions="Name: GLIBC_PRIVATE")
+
+    def test_rejects_unknown_architecture(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported ELF architecture"):
+            self.validate(architecture="riscv64")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_musl_release_metadata.py
+++ b/scripts/test_musl_release_metadata.py
@@ -75,7 +75,7 @@ def extension_fixture() -> tuple[dict[str, object], dict[str, object], bytes]:
     return extension, legacy, legacy_bytes
 
 
-class RuntimePinTests(unittest.TestCase):
+class RuntimeReadinessTests(unittest.TestCase):
     def test_unready_pin_is_admitted_but_require_ready_rejects_it(self) -> None:
         pin = runtime_pin_fixture(release_ready=False)
         runtime = MUSL.validate_runtime_pin(pin, require_ready=False)
@@ -83,6 +83,73 @@ class RuntimePinTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "release-ready gate is false"):
             MUSL.validate_runtime_pin(pin, require_ready=True)
 
+
+class CompositionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.legacy = release_fixture()
+        self.pin = runtime_pin_fixture(release_ready=True)
+        runtime = self.pin["runtime"]
+        self.legacy["runtime"] = {
+            key: runtime[key] for key in
+            ("repository", "version", "tag", "source-commit", "release-workflow-identity")
+        }
+        self.legacy["runtime"].update({
+            "release-metadata-available": True,
+            "release-metadata-asset": runtime["legacy-release-metadata-asset"],
+            "release-metadata-blake3": runtime["legacy-release-metadata-blake3"],
+        })
+        self.sha256 = {}
+        self.blake3 = {}
+        for target in MUSL.MUSL_TARGETS:
+            asset = f"unicity-aos-{VERSION}-{target}.tar.gz"
+            payload = target.encode()
+            (self.root / asset).write_bytes(payload)
+            self.sha256[asset] = hashlib.sha256(payload).hexdigest()
+            self.blake3[asset] = "e" * 64
+
+    def compose(self):
+        return MUSL.compose_extension(
+            self.legacy, b"authenticated base metadata", self.pin,
+            self.root, self.sha256, self.blake3,
+        )
+
+    def test_composes_exact_archives_and_base_digest(self) -> None:
+        result = self.compose()
+        self.assertEqual(set(result["targets"]), set(MUSL.MUSL_TARGETS))
+        self.assertEqual(result["legacy-release"]["metadata-sha256"], hashlib.sha256(b"authenticated base metadata").hexdigest())
+        for target, item in result["targets"].items():
+            self.assertEqual(item["size"], len(target))
+        self.assertIn("[targets.x86_64-unknown-linux-musl]", MUSL.render_extension(result))
+
+    def test_refuses_unready_runtime(self) -> None:
+        self.pin["runtime"]["release-ready"] = False
+        with self.assertRaisesRegex(ValueError, "gate is false"):
+            self.compose()
+
+    def test_refuses_different_runtime_source(self) -> None:
+        self.pin["runtime"]["source-commit"] = "f" * 40
+        with self.assertRaisesRegex(ValueError, "differs from the base"):
+            self.compose()
+
+    def test_refuses_missing_archive(self) -> None:
+        (self.root / next(iter(self.sha256))).unlink()
+        with self.assertRaisesRegex(ValueError, "missing regular musl archive"):
+            self.compose()
+
+    def test_refuses_changed_archive(self) -> None:
+        (self.root / next(iter(self.sha256))).write_bytes(b"changed")
+        with self.assertRaisesRegex(ValueError, "SHA-256 mismatch"):
+            self.compose()
+
+    def test_refuses_missing_checksum(self) -> None:
+        self.blake3.pop(next(iter(self.blake3)))
+        with self.assertRaisesRegex(ValueError, "missing checksums"):
+            self.compose()
+
+class RuntimePinTests(unittest.TestCase):
     def test_rejects_unknown_keys(self) -> None:
         pin = runtime_pin_fixture(release_ready=False)
         pin["runtime"]["surprise"] = True

--- a/scripts/test_musl_release_workflow.py
+++ b/scripts/test_musl_release_workflow.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Keep native musl production connected to signing and publication."""
+
+from pathlib import Path
+import re
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class MuslReleaseWorkflowTests(unittest.TestCase):
+    def setUp(self):
+        self.workflow = (ROOT / ".github/workflows/release.yml").read_text()
+
+    def test_native_architecture_matrix(self):
+        build = self.workflow.split("\n  build:", 1)[1].split("\n  capsules:", 1)[0]
+        for architecture, runner in (
+            ("x86_64", "ubuntu-24.04"),
+            ("aarch64", "ubuntu-24.04-arm"),
+        ):
+            self.assertIn(
+                f"- target: {architecture}-unknown-linux-musl\n            os: {runner}\n",
+                build,
+            )
+        self.assertIn('test "$(uname -m)" = "${TARGET%%-*}"', build)
+        self.assertIn('python3 scripts/check_static_elf.py', build)
+        self.assertIn('astrid-storage-provider-fuse', build)
+        self.assertLess(build.index("Verify runtime release identity"),
+                        build.index("Verify static musl runtime executables"))
+
+    def test_metadata_and_publication_require_both_archives(self):
+        text = self.workflow
+        self.assertIn("python3 scripts/musl_release_metadata.py render", text)
+        self.assertIn("--runtime-pin release/runtime-musl-compatibility.toml", text)
+        self.assertIn('artifacts/unicity-aos-${GITHUB_REF_NAME}-musl-release.toml', text)
+        calls = text.split("python3 scripts/release_publication.py ")[1:]
+        self.assertEqual(len(calls), 2)
+        for call in calls:
+            self.assertIn("--require-musl", call.split("--artifacts", 1)[0])
+        # Existing globs include the extension in both signing and upload.
+        self.assertIn("runtime-compatibility.toml unicity-aos-*-release.toml; do", text)
+        self.assertIn("artifacts/unicity-aos-*-release.toml", text)
+
+    def test_embedded_run_blocks_have_valid_shell_syntax(self):
+        lines = self.workflow.splitlines()
+        for index, line in enumerate(lines):
+            if line == "        run: |":
+                block = []
+                for following in lines[index + 1:]:
+                    if following and not following.startswith("          "):
+                        break
+                    block.append(following[10:])
+                script = re.sub(r"\$\{\{.*?\}\}", "workflow_value", "\n".join(block))
+                result = subprocess.run(["bash", "-n"], input=script, text=True,
+                                        capture_output=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import capsule_release
 import release_metadata
 import release_publication
+import musl_release_metadata
 from test_capsule_release import write_fixture
 
 
@@ -49,6 +50,53 @@ EXPECTED_CAPSULE_ASSETS = frozenset(
 
 
 class ReleasePublicationTests(unittest.TestCase):
+    def test_musl_inventory_and_required_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            artifacts, compatibility = self.fixture(root)
+            with self.assertRaisesRegex(ValueError, "required musl extension"):
+                release_publication.validate_release_assets(
+                    artifacts, version=VERSION, source_commit=SOURCE_COMMIT,
+                    compatibility_path=compatibility, require_musl=True,
+                )
+            pin_path = root / "runtime-musl-compatibility.toml"
+            pin_path.write_text(
+                (release_publication.ROOT / "release/runtime-musl-compatibility.toml").read_text()
+                .replace("release-ready = false", "release-ready = true")
+                .replace('musl-release-metadata-asset = ""', 'musl-release-metadata-asset = "astrid-0.10.4-musl-release.toml"')
+                .replace('musl-release-metadata-blake3 = ""', 'musl-release-metadata-blake3 = "' + "d" * 64 + '"')
+            )
+            for target in musl_release_metadata.MUSL_TARGETS:
+                asset = f"unicity-aos-{VERSION}-{target}.tar.gz"
+                payload = target.encode()
+                (artifacts / asset).write_bytes(payload)
+                for manifest in ("SHA256SUMS.txt", "BLAKE3SUMS.txt"):
+                    with (artifacts / manifest).open("a") as stream:
+                        stream.write(f"{hashlib.sha256(payload).hexdigest()}  {asset}\n")
+                (artifacts / f"{asset}.sigstore.json").write_text("{}\n")
+            output = artifacts / f"unicity-aos-{VERSION}-musl-release.toml"
+            musl_release_metadata.main([
+                "render", "--legacy-release", str(artifacts / f"unicity-aos-{VERSION}-release.toml"),
+                "--runtime-pin", str(pin_path), "--artifacts", str(artifacts),
+                "--sha256", str(artifacts / "SHA256SUMS.txt"),
+                "--blake3", str(artifacts / "BLAKE3SUMS.txt"), "--output", str(output),
+            ])
+            (artifacts / f"{output.name}.sigstore.json").write_text("{}\n")
+            payloads = release_publication.validate_release_assets(
+                artifacts, version=VERSION, source_commit=SOURCE_COMMIT,
+                compatibility_path=compatibility, musl_compatibility_path=pin_path,
+                require_musl=True,
+            )
+            self.assertIn(output.name, payloads)
+            self.assertIn(f"unicity-aos-{VERSION}-x86_64-unknown-linux-musl.tar.gz", payloads)
+            output.write_text(output.read_text().replace('metadata-sha256 = "', 'metadata-sha256 = "a', 1))
+            with self.assertRaises(ValueError):
+                release_publication.validate_release_assets(
+                    artifacts, version=VERSION, source_commit=SOURCE_COMMIT,
+                    compatibility_path=compatibility, musl_compatibility_path=pin_path,
+                    require_musl=True,
+                )
+
     def fixture(self, root: Path) -> tuple[Path, Path]:
         artifacts = root / "artifacts"
         artifacts.mkdir()

--- a/scripts/test_validate_release_contract.py
+++ b/scripts/test_validate_release_contract.py
@@ -146,10 +146,13 @@ class ReleaseReadinessTests(unittest.TestCase):
         runtime = VALIDATOR.readiness_metadata(
             ROOT / "release/runtime-compatibility.toml"
         )["runtime"]
-        if runtime["release-ready"] and runtime["upgrade-self-heal-ready"]:
+        musl = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-musl-compatibility.toml"
+        )["runtime"]
+        if runtime["release-ready"] and runtime["upgrade-self-heal-ready"] and musl["release-ready"]:
             self.assertEqual(VALIDATOR.main(["--require-release-ready"]), 0)
         else:
-            with self.assertRaisesRegex(ValueError, "refusing to publish"):
+            with self.assertRaisesRegex(ValueError, "refusing to publish|musl runtime"):
                 VALIDATOR.main(["--require-release-ready"])
 
     def test_main_admits_checked_in_false_ready_musl_pin(self) -> None:
@@ -162,7 +165,7 @@ class ReleaseReadinessTests(unittest.TestCase):
         self.assertFalse(runtime["release-ready"])
         self.assertEqual(VALIDATOR.main([]), 0)
 
-    def test_require_release_ready_follows_the_gnu_gate_only(self) -> None:
+    def test_require_release_ready_also_requires_musl(self) -> None:
         gnu = VALIDATOR.readiness_metadata(
             ROOT / "release/runtime-compatibility.toml"
         )["runtime"]
@@ -171,7 +174,8 @@ class ReleaseReadinessTests(unittest.TestCase):
         )["runtime"]
         self.assertTrue(gnu["release-ready"])
         self.assertFalse(musl["release-ready"])
-        self.assertEqual(VALIDATOR.main(["--require-release-ready"]), 0)
+        with self.assertRaisesRegex(ValueError, "musl runtime compatibility release-ready"):
+            VALIDATOR.main(["--require-release-ready"])
 
     def test_musl_pin_rejects_identity_extra_keys_and_empty_ready_fields(self) -> None:
         pin = VALIDATOR.readiness_metadata(
@@ -216,11 +220,14 @@ class ReleaseReadinessTests(unittest.TestCase):
             capture_output=True,
             check=False,
         )
-        if runtime["release-ready"] and runtime["upgrade-self-heal-ready"]:
+        musl = VALIDATOR.readiness_metadata(
+            ROOT / "release/runtime-musl-compatibility.toml"
+        )["runtime"]
+        if runtime["release-ready"] and runtime["upgrade-self-heal-ready"] and musl["release-ready"]:
             self.assertEqual(strict.returncode, 0, strict.stderr)
         else:
             self.assertEqual(strict.returncode, 1)
-            self.assertIn("refusing to publish", strict.stderr)
+            self.assertRegex(strict.stderr, "refusing to publish|musl runtime")
 
 
 if __name__ == "__main__":

--- a/scripts/validate-release-contract.py
+++ b/scripts/validate-release-contract.py
@@ -148,7 +148,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     musl_runtime = musl_release_metadata.validate_runtime_pin(
         readiness_metadata("release/runtime-musl-compatibility.toml"),
-        require_ready=False,
+        require_ready=args.require_release_ready,
     )
     gnu_runtime = compatibility_metadata["runtime"]
     for key in ("repository", "version", "tag", "source-commit"):


### PR DESCRIPTION
## Summary

Related to #63. Completes the production side of musl support after #151 and #152.

- Build x86_64 and aarch64 musl AOS binaries on matching native Linux runners using pinned Alpine Rust; execute the binary and reject dynamic/glibc or wrong-architecture ELF output.
- Verify the existing pinned runtime archive signature, then check all five musl runtime executables before composition.
- Render the existing musl metadata extension from the final signed product archive checksums, bound to the legacy AOS statement and ready runtime pin.
- Include both archives and the extension in the existing signing, attestation and exact publication inventory. Refuse partial musl publication.

## Validation

- Metadata composition/validation: 18 tests passed.
- Publication inventory: 8 tests passed, including required musl and mismatched metadata.
- Static ELF validation: 6 tests passed.
- Workflow wiring/shell syntax: 3 tests passed.
- Release readiness: 16 tests passed.
- Channel and rehearsal workflow contract suites passed.
- Full package-release and installer suites passed after rebasing onto #152.
- actionlint and git diff --check passed.

## Release boundary

No tags, releases, dispatches, live-home changes or production pin changes. The checked-in musl runtime pin remains not ready, so actual release execution refuses until the authenticated Astrid musl metadata is available and pinned. Local aarch64 signed-QA volume rehearsal passed separately; x86_64 rehearsal is still running. These are not production signing claims.
