### PR TITLE
feat(release): release AOS 2026.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
       - run: python3 scripts/test_check_glibc.py
       - run: python3 scripts/validate-release-contract.py
       - run: python3 scripts/test_validate_release_contract.py
+      - run: python3 scripts/test_changelog_notes.py
       - run: python3 scripts/test_release_metadata.py
       - run: python3 scripts/test_musl_release_metadata.py
       - run: python3 scripts/test_check_static_elf.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,7 @@ jobs:
             bash -euxo pipefail -c '
               if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
                 rustup target add aarch64-unknown-linux-gnu
-                apt-get update
-                apt-get install -y --no-install-recommends \
+                bash scripts/ci/install_gnu_build_packages.sh \
                   gcc-aarch64-linux-gnu \
                   libc6-dev-arm64-cross
                 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
@@ -95,6 +94,7 @@ jobs:
       - run: python3 scripts/validate-release-contract.py
       - run: python3 scripts/test_validate_release_contract.py
       - run: python3 scripts/test_changelog_notes.py
+      - run: python3 scripts/test_gnu_build_packages.py
       - run: python3 scripts/test_release_metadata.py
       - run: python3 scripts/test_musl_release_metadata.py
       - run: python3 scripts/test_check_static_elf.py

--- a/.github/workflows/rehearsal-sign-darwin.yml
+++ b/.github/workflows/rehearsal-sign-darwin.yml
@@ -203,7 +203,7 @@ jobs:
           text = path.read_text(encoding="utf-8")
           old = 'pub(crate) const ASTRID_RUNTIME_VERSION: &str = "0.10.4";'
           new = 'pub(crate) const ASTRID_RUNTIME_VERSION: &str = "2026.9.0";'
-          if text.count(old) != 1:
+          if text.count(old) != 1 and text.count(new) != 1:
               raise SystemExit("rehearsal runtime-version overlay did not find a unique production constant")
           path.write_text(text.replace(old, new, 1), encoding="utf-8")
           PY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,8 +208,7 @@ jobs:
             bash -euxo pipefail -c '
               if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
                 rustup target add aarch64-unknown-linux-gnu
-                apt-get update
-                apt-get install -y --no-install-recommends \
+                bash scripts/ci/install_gnu_build_packages.sh \
                   gcc-aarch64-linux-gnu \
                   libc6-dev-arm64-cross
                 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -640,6 +640,10 @@ jobs:
 
           Moving channel installs change only after a separate protected promotion.
           EOF
+          if [[ "$GITHUB_REF_NAME" != *-nightly.* ]]; then
+            printf '\n' >> release-notes.md
+            python3 scripts/changelog_notes.py --version "$GITHUB_REF_NAME" >> release-notes.md
+          fi
       - name: Refuse conflicting releases or authenticate a complete draft
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ implementations are consolidated into their final behavior.
 
 ### Added
 
+- Signed macOS filesystem app installation through the common installer,
+  including website and Oracle bootstrap paths. AOS.app retains Astrid's signed
+  internal identity; macOS approval failures include retry instructions.
 - Native Linux musl product archives for x86_64 and ARM64, authenticated platform
   selection, and bundled FUSE providers. GNU Linux and Darwin bundles include
   their corresponding filesystem providers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,57 @@
 # Changelog
 
+Release changes are compared with the preceding published tag. Repairs to
+unreleased implementations are consolidated into their final behavior.
+
 ## [2026.9.0] - Unreleased
 
 ### Added
 
-- A staged, fail-closed Linux musl runtime-compatibility contract and strict
-  metadata schema/validator. The pin keeps the current Astrid 0.10.4 identity
-  with `release-ready = false` and empty musl publication fields. Related #62.
-- An unpublished native Rust semantic catalog capsule that owns the finite v1
-  component inventory, complete primitive records, two complete theme packs,
-  hostile-value validation, fail-closed token fallback, safe unknown-component
-  fallback, A2UI declared-loss fixtures, and a catalog-owned Theme Lab matrix.
-- A bounded `aos-rhai` capsule with profile-scoped Rhai evaluation, strict
-  resource ceilings, cooperative cancellation, and no script-visible host
-  effects.
-- A product-owned `aos daemon foreground` supervisor path that runs the
-  persistent bundled daemon under the enforced CE distro, private runtime home,
-  `.aos` workspace layout, and stderr logging environment. On Unix the daemon
-  replaces the AOS process so it directly owns signals and exit status. Closes
-  #64.
+- Native Linux musl product archives for x86_64 and ARM64, authenticated platform
+  selection, and bundled FUSE providers. GNU Linux and Darwin bundles include
+  their corresponding filesystem providers.
+- `aos distro apply --principal P --yes` for applying the signed Community
+  inventory with the selected principal and an AOS activation receipt.
+- The AOS-owned MCP broker and host interaction bridge for Codex, Claude, and
+  Grok. Hosts retain separate principal capsule sets rather than receiving
+  every installed Community capsule.
+- Authenticated host hook ingress, protocol-specific adapters, and session-bound
+  meta-harness context delivery.
+- `aos daemon foreground` for supervisors, with signal and exit-status ownership.
+- Bounded Rhai evaluation and semantic surface/catalog components. Presence in
+  source does not imply inclusion in the default Community distribution.
+
+### Changed
+
+- Runtime executables live in immutable versioned release directories, separate
+  from durable runtime state. A stopped runtime contains only its private,
+  non-empty `astrid.volume`.
+- Community publication selects 22 capsule artifacts. Oracle packs independently
+  require `aos-mcp` and `aos-skills`, with `aos-forge` when present.
+- Signed release metadata binds packaged executable bytes and capsule inventory.
+  Installations preserve authenticated Distro manifests, locks, and signatures.
+- Agent skills remain distinct from capsule authority and installation.
+
+### Fixed
+
+- MCP forwarding preserves framing, workspace and request-timeout arguments,
+  stderr, and child exit/signal results.
+- Every delegated stop is confirmed before reporting successful shutdown.
+- Status uses the selected principal rather than silently assuming default.
+- GNU builds support enterprise Linux with glibc 2.34; musl targets use native
+  musl binaries rather than relabeled GNU archives.
+- Required filesystem provider executables survive installation and self-heal.
+
+### Compatibility
+
+- This release targets Astrid 2026.9.0 and Oracle 0.3.0.
+- Native mount availability depends on the platform frontend and its setup.
+  Windows AOS installation is not certified by this release preparation.
+
+## [2026.1.3] - Unreleased
+
+### Added
+
 - The `aos` product command and product-owned `~/.aos` state boundary.
 - A pinned Unicity CE distribution manifest over Astrid Runtime 0.10.4, emplaced
   as the bundled runtime's operator-enforced distro.
@@ -34,7 +67,7 @@
 - Runtime import holds the standalone daemon's existing singleton lock without
   changing the source, and interrupted unreceipted cutovers always roll back
   before recopying the current locked source.
-- A signed release path for the 22 installable `aos-*` artifacts
+- A signed release path for the 19 installable `aos-*` artifacts
   built from this source tree and selected locally by Community Edition, with
   exact source/manifest identity checks, product-archive inclusion, offline
   provisioning, archive safety validation, BLAKE3 checksums, SHA-256
@@ -46,46 +79,22 @@
   tools, capsules, traces, and evaluations as an improvable world. Agents reach
   for Forge proactively when real work reveals a useful new capability, while
   optional workers remain a use-case choice rather than a prerequisite.
-- An authenticated `aos hook` ingress and Community Edition Meta Harness
-  capsule that normalize Codex, Claude, and Grok host events onto the generic
-  hook bus, collect private same-turn prompt context, and route it back only to
-  the exact originating session. Adaptive, propose, automatic, and off modes
-  preserve the agent's judgment while respecting its existing authority.
 - Homebrew formula updates initiated by the tap's authenticated stable-release
   poll, eliminating the cross-repository dispatch credential.
 - Strict, signed stable/dev/nightly channel and immutable release metadata
   contracts with exact workflow identities, expiry, replay-resistant generation
   state, and fail-closed direct installer resolution.
 - A native release gate that initializes a clean AOS home, verifies the exact
-  22-capsule CE lock, grants, and ready set, repeats initialization without
+  19-capsule CE lock, grants, and ready set, repeats initialization without
   changing runtime state, and proves clean daemon shutdown before publication.
 - Native `aos status` output for authenticated running state and verified
   stopped state without invoking the runtime CLI.
-- A selected `aos distro apply --principal P --yes` path that verifies the
-  authenticated release inventory and bundled Distro.toml, Distro.lock, and
-  Distro.sig with Astrid 0.10.4's signed lock algorithm, seeds the runtime trust
-  pin, requires an exact non-empty private volume-only stop, and records an
-  AOS-owned activation receipt.
 - An opt-in daily nightly train with deterministic run-dated versions, exact
   Astrid compatibility pins, protected publication and promotion, and
   idempotent recovery after interrupted release or pointer updates. It is
   disabled by default; merging `main` never publishes a release.
 
 ### Changed
-
-- Own the host-facing `aos mcp serve` command, MCP server identity, constrained
-  interaction fallback, and `aos-mcp` broker capsule in AOS CE. Hosts with MCP
-  form elicitation continue to render their own approvals; hosts such as Grok
-  fall back to AppKit on macOS, native confirmation on Windows, or Pinentry on
-  Linux. Free-form and secret-shaped fields are refused by this bridge.
-- Pin the exact public root-command inventory of the bundled runtime and fail
-  validation when a runtime update adds or removes a verb before AOS classifies
-  it as inherited, product-owned, or shared. Runtime verbs remain direct
-  `aos <verb>` commands without a nested runtime namespace.
-- Launch bundled Astrid executables from the immutable versioned release
-  runtime/bin, keep `ASTRID_HOME` at the durable runtime home, and bind
-  `ASTRID_RUN_DIR` to the AOS-owned run root without copying shipped binaries
-  into mutable runtime state.
 
 - Keep agent Skills out of `Capsule.toml` and the generic capsule release
   contract. Host plugins may vendor trigger Skills, the AOS Skills service
@@ -102,17 +111,15 @@
 - Parse AOS-owned commands with Clap-generated validation and help while
   preserving byte-for-byte delegation of inherited runtime commands and their
   help surfaces.
-- Authenticate native `aos status` requests as the principal selected by
-  `--principal`, while preserving the single-user `default` when the flag is
-  omitted.
 - Initialize against the operator-enforced Community Edition manifest and ask
   the runtime to grant its installed capsule set to the resolved target
   principal.
 - Bootstrap the default CE system fleet through Astrid's canonical distro
   installer before the daemon-backed authorization pass, allowing a completely
   fresh AOS home and non-default targets to use the same runtime trust path.
-- Keep the authenticated init operator separate from its target principal and
-  fail closed while signed direct update channels remain unpublished.
+- Keep the authenticated init operator separate from its target principal,
+  prevent AOS distribution replacement, and fail closed while signed direct
+  update channels remain unpublished.
 - Require explicit machine-readable runtime-compatibility and upgrade/self-heal
   approvals before the tag-triggered workflow can package or publish a release,
   backed by a packaged migration/reinstall test over the frozen 2026-07-15
@@ -123,30 +130,3 @@
   `aos stop` only after every coordination marker is gone and the singleton
   lock is available; all other inherited runtime failures retain their output
   and exit status.
-- Confirm every delegated runtime shutdown before reporting success, preserving
-  child output and exit status when stopped-state confirmation fails.
-
-### Fixed
-
-- Require stopped AOS runtime homes to contain only a non-empty private `astrid.volume` (Unix mode `0600`).
-
-- Stable `github-release` signing discovers product archives by filename
-  `unicity-aos-*.tar.gz` and refuses to publish when none are signed. The
-  download-artifact pattern `aos-*-*-*` is unchanged because it names GitHub
-  artifacts, not archive files.
-
-- Build Linux product binaries on a pinned glibc 2.31 baseline and reject AOS
-  or bundled Astrid executables that require glibc newer than 2.34, restoring
-  support for RHEL, Oracle Linux, Rocky Linux, and AlmaLinux 9. Closes #58.
-
-### Removed
-
-- The vendored `capsules/capsule-telegram` copy. The capsule is maintained in
-  its own repository at `unicity-aos/capsule-telegram` and installs directly
-  from there with `aos capsule install @unicity-aos/capsule-telegram`, so the
-  in-tree duplicate had no consumer: it was absent from `Distro.toml` and
-  `release/community-capsules.txt`, and was therefore never built, signed, or
-  shipped. Keeping it only invited the drift it had already accumulated —
-  it was the sole workspace member still pinned to `astrid-sdk` 0.5.3 and
-  building for `wasm32-wasip1`, which is why CI had to exclude it from every
-  workspace job. Those exclusions and the `telegram-wasi` job go away with it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,20 @@ implementations are consolidated into their final behavior.
 - Signed release metadata binds packaged executable bytes and capsule inventory.
   Installations preserve authenticated Distro manifests, locks, and signatures.
 - Agent skills remain distinct from capsule authority and installation.
+- Community Edition's repository license is explicitly MIT OR Apache-2.0.
+- The AOS product advances from 2026.1.3 to 2026.9.0. The
+  [dependency version inventory](release/DEPENDENCIES-2026.9.0.md) records source
+  lockfile changes; production Astrid pins remain a release-time dependency.
+- Hosts without MCP form support use native approval fallbacks: AppKit on
+  macOS, native confirmation on Windows, or Pinentry on Linux. The interaction
+  bridge refuses free-form and secret-shaped fields.
 - Runtime compatibility targets Astrid 2026.9.0 and Oracle 2026.9.0. See the
   [release requirements](release/RELEASE-2026.9.0.md) for platform setup and
   publication dependencies; Windows installation is not certified by this cut.
+
+### Removed
+
+- The vendored Telegram capsule; it is maintained in its separate repository.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 # Changelog
 
-Release changes are compared with the preceding published tag. Repairs to
-unreleased implementations are consolidated into their final behavior.
+Notable changes to AOS are recorded here.
 
-## [2026.9.0] - Unreleased
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions follow [year.month.patch](release/VERSIONING.md). Repairs to unreleased
+implementations are consolidated into their final behavior.
+
+[Unreleased]: https://github.com/unicity-aos/aos-ce/compare/2026.9.0...HEAD
+[2026.9.0]: https://github.com/unicity-aos/aos-ce/compare/2026.1.3...2026.9.0
+[2026.1.3]: https://github.com/unicity-aos/aos-ce/releases/tag/2026.1.3
+
+## [Unreleased]
+
+## [2026.9.0] - 2026-09-08
 
 ### Added
 
@@ -31,6 +40,9 @@ unreleased implementations are consolidated into their final behavior.
 - Signed release metadata binds packaged executable bytes and capsule inventory.
   Installations preserve authenticated Distro manifests, locks, and signatures.
 - Agent skills remain distinct from capsule authority and installation.
+- Runtime compatibility targets Astrid 2026.9.0 and Oracle 2026.9.0. See the
+  [release requirements](release/RELEASE-2026.9.0.md) for platform setup and
+  publication dependencies; Windows installation is not certified by this cut.
 
 ### Fixed
 
@@ -41,13 +53,6 @@ unreleased implementations are consolidated into their final behavior.
 - GNU builds support enterprise Linux with glibc 2.34; musl targets use native
   musl binaries rather than relabeled GNU archives.
 - Required filesystem provider executables survive installation and self-heal.
-
-### Compatibility
-
-- This release targets Astrid 2026.9.0 and Oracle 2026.9.0.
-- Versions follow [year.month.patch](release/VERSIONING.md) from this release.
-- Native mount availability depends on the platform frontend and its setup.
-  Windows AOS installation is not certified by this release preparation.
 
 ## [2026.1.3] - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ unreleased implementations are consolidated into their final behavior.
 
 ### Compatibility
 
-- This release targets Astrid 2026.9.0 and Oracle 0.3.0.
+- This release targets Astrid 2026.9.0 and Oracle 2026.9.0.
+- Versions follow [year.month.patch](release/VERSIONING.md) from this release.
 - Native mount availability depends on the platform frontend and its setup.
   Windows AOS installation is not certified by this release preparation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ implementations are consolidated into their final behavior.
 
 ## [Unreleased]
 
-## [2026.9.0] - 2026-09-08
+## [2026.9.0] - 2026-09-09
 
 ### Added
 
@@ -35,6 +35,8 @@ implementations are consolidated into their final behavior.
 
 ### Changed
 
+- Pin the runtime and Rust client dependencies to published Astrid 2026.9.0,
+  including authenticated GNU, Darwin, and musl release metadata.
 - Runtime executables live in immutable versioned release directories, separate
   from durable runtime state. A stopped runtime contains only its private,
   non-empty `astrid.volume`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
  "astrid-sdk",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -170,7 +170,7 @@ dependencies = [
  "astrid-sdk",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -342,32 +342,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
-name = "astrid-core"
-version = "0.10.4"
+name = "astrid-config"
+version = "2026.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0aa2ffac20de974002f75a6eebdc78104ced0dc02fb1675ac624e88b4cf8778"
+checksum = "7097aa95fadbe6b19e2370f01bed64d50717740d79515ebe34a0c8ce7cb357fc"
+dependencies = [
+ "astrid-core",
+ "directories",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "toml 1.1.5+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "astrid-core"
+version = "2026.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fa407cca120aff3338aa36cfb32219433840d97942aeb60a11afbbbde9cfba"
 dependencies = [
  "async-trait",
  "base64",
  "blake3",
  "chrono",
+ "directories",
+ "fs2",
  "getrandom 0.4.3",
  "hex",
+ "nix",
  "rand",
  "serde",
  "serde_json",
  "subtle",
  "thiserror",
  "tokio",
- "toml",
+ "toml 1.1.5+spec-1.1.0",
  "uuid",
+ "windows-sys",
 ]
 
 [[package]]
 name = "astrid-crypto"
-version = "0.10.4"
+version = "2026.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f4493c26daf8a264038d04bdff547a6cd0914c3f89f530f0dd42e5480444ed"
+checksum = "aa8c3fbf840e6acecf6c31cf3ed118296101b21babcfe6afe7bc1a371c908f7b"
 dependencies = [
  "base64",
  "blake3",
@@ -378,6 +397,42 @@ dependencies = [
  "serde",
  "thiserror",
  "zeroize",
+]
+
+[[package]]
+name = "astrid-events"
+version = "2026.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165fb23ee8def835e77a95daf824ee5c19af0d2ae59eba27bbdebd00965742c1"
+dependencies = [
+ "astrid-core",
+ "astrid-runtime",
+ "astrid-types 2026.9.0",
+ "async-trait",
+ "chrono",
+ "dashmap",
+ "metrics",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "astrid-runtime"
+version = "2026.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293ce62d4d404ed921652f8f9fcd09af348306e03de3f28d80b81ebe862d9085"
+dependencies = [
+ "futures",
+ "tokio",
+ "wasm-bindgen-futures",
+ "wasmtimer",
+ "web-time",
 ]
 
 [[package]]
@@ -405,7 +460,7 @@ checksum = "e27a1e737fa44cd1ae08cdddf4bc513cc84e710225395529556cffe5ce842446"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wit-parser 0.227.1",
 ]
 
@@ -435,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "0.10.4"
+version = "2026.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f5bb8ef314d3f7bde8217edfd488f4fb81ed64cb91864c9f1f5823849b9238"
+checksum = "19d2355246f76f192645ea22886e814cedf41dbd94272ded1e1f9a60f253e9e0"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -449,14 +504,18 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "0.10.4"
+version = "2026.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bff7f3a8bc9cc39f001d02e3db29af1e38e81f1df1193cfa5184b0a6a6308e8"
+checksum = "5f6fc176d16cba5fc1265379e3d0cf20afc99ff38995a41b10410270240a5932"
 dependencies = [
  "anyhow",
+ "astrid-config",
  "astrid-core",
  "astrid-crypto",
- "astrid-types 0.10.4",
+ "astrid-events",
+ "astrid-types 2026.9.0",
+ "hex",
+ "rand",
  "serde",
  "serde_json",
  "thiserror",
@@ -473,7 +532,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -548,9 +607,9 @@ checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bitflags"
@@ -602,7 +661,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -721,7 +780,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -778,6 +837,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,7 +883,21 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -829,6 +908,27 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
 ]
 
 [[package]]
@@ -927,12 +1027,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -940,6 +1056,40 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
@@ -953,8 +1103,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -995,6 +1150,12 @@ dependencies = [
  "rand_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1168,9 +1329,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1188,6 +1349,24 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1208,6 +1387,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1411,18 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1297,6 +1498,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1537,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
@@ -1321,7 +1557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1381,6 +1617,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "rhai"
 version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,7 +1671,7 @@ checksum = "3cd3a7535e50bf36857e7be7bec276d334e8c2dfa469c2201226fd01638ea5ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1451,8 +1716,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1487,7 +1758,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1498,7 +1769,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1532,6 +1803,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1664,6 +1944,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,7 +1983,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1728,7 +2019,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1738,9 +2029,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1769,7 +2075,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -1789,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.3",
 ]
@@ -1801,6 +2107,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -1850,7 +2162,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1874,7 +2186,7 @@ version = "2026.9.0"
 dependencies = [
  "astrid-core",
  "astrid-crypto",
- "astrid-types 0.10.4",
+ "astrid-types 2026.9.0",
  "astrid-uplink",
  "axum",
  "blake3",
@@ -1886,7 +2198,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tower",
  "uuid",
  "windows-sys",
@@ -1912,9 +2224,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -1926,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-rng-internal"
-version = "1.23.5"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6efce083520d7da9ab3967f98d9124bb89d3269ef2c528a3da7b34e4857190b6"
+checksum = "ee9ad27c58031a66157ac3b5c93e65068357eeeaceaa658a6163d4e5befb4a06"
 dependencies = [
  "getrandom 0.4.3",
 ]
@@ -1956,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1968,10 +2280,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.126"
+name = "wasm-bindgen-futures"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1979,22 +2301,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2042,6 +2364,20 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2097,7 +2433,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2108,7 +2444,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2198,7 +2534,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2214,7 +2550,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2292,7 +2628,7 @@ checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2312,7 +2648,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 astrid-sdk = { version = "=0.7.1", features = ["derive"] }
-astrid-core = "=0.10.4"
-astrid-crypto = "=0.10.4"
-astrid-types = { version = "=0.10.4", features = ["clock"] }
-astrid-uplink = "=0.10.4"
+astrid-core = "=2026.9.0"
+astrid-crypto = "=2026.9.0"
+astrid-types = { version = "=2026.9.0", features = ["clock"] }
+astrid-uplink = "=2026.9.0"
 axum = "0.8"
 blake3 = "1.8.5"
 clap = { version = "4.6", features = ["derive"] }

--- a/changes/114.fixed.md
+++ b/changes/114.fixed.md
@@ -1,6 +1,0 @@
-- Made `aos mcp serve` release-grade for Claude and Grok hosts: exact
-  `--workspace` and `--request-timeout` forwarding, byte-preserving
-  newline-framed relay with unchanged initialize frames kept byte-exact,
-  isolated stderr, child exit/signal status
-  preservation, and parent-interruption cleanup without orphaning the runtime.
-  Persistent `mcp attach` remains the Codex default. Closes #114.

--- a/changes/capsule-release-durable-format.fixed.md
+++ b/changes/capsule-release-durable-format.fixed.md
@@ -1,2 +1,0 @@
-- Require Community capsule archives to use Astrid 2026.9 durable members, including the signed provenance envelope and canonical WIT dependency tree, with fail-closed member types and structural provenance validation.
-- Emit that exact durable archive from the authenticated publication inventory fixture so the release contract rejects stale Capsule.toml-plus-wasm positives.

--- a/changes/darwin-fskit-artifact.fixed.md
+++ b/changes/darwin-fskit-artifact.fixed.md
@@ -1,1 +1,0 @@
-- Include the authenticated FSKit storage provider in Darwin product archives and installations while retaining the portable four-binary runtime contract on Linux.

--- a/changes/gnu-fuse-artifact.fixed.md
+++ b/changes/gnu-fuse-artifact.fixed.md
@@ -1,1 +1,0 @@
-- Require authenticated GNU 2026.9.0 rehearsal archives to carry the `astrid-storage-provider-fuse` runtime member while preserving the historical GNU 0.10.4 four-binary portable contract; this archive-only rehearsal requirement does not imply installer persistence or release shipment.

--- a/changes/gnu-fuse-installer.fixed.md
+++ b/changes/gnu-fuse-installer.fixed.md
@@ -1,1 +1,0 @@
-- Select GNU runtime members from the signed runtime version during installation, persisting the `astrid-storage-provider-fuse` executable with immutable `0700` permissions for 2026.9.0 while preserving the 0.10.4 four-binary and Darwin FSKit contracts; installer and self-heal tests cover signed positives and fail-closed missing-provider transactions without activating a release.

--- a/changes/install-plant-signed-distro.fixed.md
+++ b/changes/install-plant-signed-distro.fixed.md
@@ -1,3 +1,0 @@
-- Updated the installer to detect signed release inventories and atomically
-  plant authenticated `Distro.toml`, `Distro.lock`, and `Distro.sig` members
-  with immutable `0600` permissions and matching BLAKE3 records.

--- a/changes/macos-filesystem-bundle.fixed.md
+++ b/changes/macos-filesystem-bundle.fixed.md
@@ -1,1 +1,0 @@
-Darwin packages retain the upstream signed Astrid filesystem app and management scripts. The common AOS installer installs the app as AOS.app and requests extension enablement, covering website and Oracle bootstrap installations. Signed bundle contents and internal Astrid identities remain unchanged; incomplete macOS approval is reported with retry commands.

--- a/changes/rehearsal-astrid-source-repin-220c6923.fixed.md
+++ b/changes/rehearsal-astrid-source-repin-220c6923.fixed.md
@@ -1,1 +1,0 @@
-- Re-pin the Darwin rehearsal to Astrid source commit 220c692336aac89f035134c1399e1d91fab3b3d5 for reproducible signing.

--- a/changes/rehearsal-astrid-source-repin.fixed.md
+++ b/changes/rehearsal-astrid-source-repin.fixed.md
@@ -1,1 +1,0 @@
-- Re-pin the prepare-only Darwin rehearsal Astrid source commit from 3de333f1 to 1897e086, keeping rehearsal overlays, product version, and production runtime/trust pins unchanged.

--- a/changes/rehearsal-bind-exec-mode.fixed.md
+++ b/changes/rehearsal-bind-exec-mode.fixed.md
@@ -1,1 +1,0 @@
-- Restore executable mode on downloaded Darwin rehearsal AOS binaries with chmod 0755 before the execute-bit bind, and reject missing, symlink, or non-regular artifact paths.

--- a/changes/rehearsal-python3-validator.fixed.md
+++ b/changes/rehearsal-python3-validator.fixed.md
@@ -1,1 +1,0 @@
-- Run the runtime archive validator through Python during Darwin rehearsal composition so mode-0644 sources execute reliably.

--- a/changes/rehearsal-sign-darwin.fixed.md
+++ b/changes/rehearsal-sign-darwin.fixed.md
@@ -1,9 +1,0 @@
-- Added a dispatch-only, prepare-only Darwin rehearsal workflow that builds hosted
-  artifacts, composes the 22-capsule Community bundle, and signs with an
-  ephemeral QA key while keeping rehearsal evidence out of publication channels.
-- Rehearsal AOS compiles from disposable overlays that bind runtime-compatibility,
-  Distro astrid-version, QA pubkey, and ASTRID_RUNTIME_VERSION to 2026.9.0 without
-  changing production source.
-- After signing, overlay-built GNU AOS executes a fail-before-runtime Distro Apply
-  against the signed Distro members in a disposable AOS_HOME, proving
-  verify_selected_release accepts 2026.9.0 without starting runtime or FSKit.

--- a/changes/schema-v2-exec-membership.fixed.md
+++ b/changes/schema-v2-exec-membership.fixed.md
@@ -1,1 +1,0 @@
-- Added schema-v2 release-manifest executable membership and explicit required `aos-mcp` capsule metadata, with fail-closed validation during native sealer extraction and archive signing.

--- a/crates/unicity-aos-bootstrap/src/distro_trust.rs
+++ b/crates/unicity-aos-bootstrap/src/distro_trust.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use unicity_aos_bootstrap::AosHome;
 
 pub(crate) const SELECTED_DISTRO_ID: &str = "unicity-ce";
-pub(crate) const ASTRID_RUNTIME_VERSION: &str = "0.10.4";
+pub(crate) const ASTRID_RUNTIME_VERSION: &str = "2026.9.0";
 const SIG_DOMAIN_TAG: &[u8] = b"astrid-distro-lock-sig-v1\x00";
 const RECEIPT_SCHEMA_VERSION: u32 = 1;
 const RECEIPT_KIND: &str = "aos-distro-apply-active-v1";

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -38,8 +38,13 @@ pub(crate) const RUNTIME_EXECUTABLE_NAMES: &[&str] = &[
 ];
 
 #[cfg(all(not(windows), not(target_os = "macos")))]
-pub(crate) const RUNTIME_EXECUTABLE_NAMES: &[&str] =
-    &["astrid", "astrid-daemon", "astrid-build", "astrid-emit"];
+pub(crate) const RUNTIME_EXECUTABLE_NAMES: &[&str] = &[
+    "astrid",
+    "astrid-daemon",
+    "astrid-build",
+    "astrid-emit",
+    "astrid-storage-provider-fuse",
+];
 
 /// Product-owned per-project state directory selected for all AOS runtime access.
 pub const AOS_WORKSPACE_STATE_DIR: &str = ".aos";
@@ -845,10 +850,16 @@ mod tests {
 
     #[cfg(all(not(windows), not(target_os = "macos")))]
     #[test]
-    fn runtime_inventory_keeps_the_portable_four_binary_contract() {
+    fn runtime_inventory_includes_the_linux_storage_provider() {
         assert_eq!(
             RUNTIME_EXECUTABLE_NAMES,
-            ["astrid", "astrid-daemon", "astrid-build", "astrid-emit"]
+            [
+                "astrid",
+                "astrid-daemon",
+                "astrid-build",
+                "astrid-emit",
+                "astrid-storage-provider-fuse"
+            ]
         );
     }
 

--- a/crates/unicity-aos-bootstrap/src/migration.rs
+++ b/crates/unicity-aos-bootstrap/src/migration.rs
@@ -713,6 +713,11 @@ fn validate_release_runtime_bin(release_runtime_bin: &Path) -> io::Result<()> {
             )
         })?;
         let metadata = fs::symlink_metadata(entry.path())?;
+        #[cfg(target_os = "macos")]
+        if matches!(name.as_str(), "AstridFS.app" | "macos") {
+            validate_packaged_filesystem_directory(&entry.path())?;
+            continue;
+        }
         if !expected.contains(name.as_str())
             || metadata.file_type().is_symlink()
             || !metadata.is_file()
@@ -723,6 +728,27 @@ fn validate_release_runtime_bin(release_runtime_bin: &Path) -> io::Result<()> {
     }
     if actual.len() != expected.len() {
         return invalid("bundled product release runtime executable set is incomplete");
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn validate_packaged_filesystem_directory(path: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return invalid("packaged filesystem support must be a real directory");
+    }
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let metadata = fs::symlink_metadata(entry.path())?;
+        if metadata.file_type().is_symlink() {
+            return invalid("packaged filesystem support contains a symlink");
+        }
+        if metadata.is_dir() {
+            validate_packaged_filesystem_directory(&entry.path())?;
+        } else if !metadata.is_file() {
+            return invalid("packaged filesystem support contains special data");
+        }
     }
     Ok(())
 }
@@ -1210,6 +1236,24 @@ mod tests {
     fn install_product_runtime(product: &AosHome) {
         fs::create_dir_all(product.runtime_home()).expect("create product runtime home");
         install_runtime_at(&product.release_runtime_bin_dir());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn release_inventory_admits_packaged_app_but_rejects_redirects_and_unknown_entries() {
+        use std::os::unix::fs::symlink;
+        let root = fixture_root("packaged-filesystem");
+        let bin = root.join("release-bin");
+        install_runtime_at(&bin);
+        write(&bin, "AstridFS.app/Contents/Info.plist", b"app fixture");
+        write(&bin, "macos/manage-macos-fskit.sh", b"manager fixture");
+        super::validate_release_runtime_bin(&bin).expect("packaged support is admitted");
+        write(&bin, "unexpected", b"not a shipped member");
+        assert!(super::validate_release_runtime_bin(&bin).is_err());
+        fs::remove_file(bin.join("unexpected")).unwrap();
+        symlink(root.join("outside"), bin.join("AstridFS.app/redirect")).unwrap();
+        assert!(super::validate_release_runtime_bin(&bin).is_err());
+        fs::remove_dir_all(root).unwrap();
     }
 
     fn install_runtime_at(runtime_bin: &Path) {

--- a/crates/unicity-aos-bootstrap/src/status.rs
+++ b/crates/unicity-aos-bootstrap/src/status.rs
@@ -318,7 +318,7 @@ mod tests {
         let status = confirm_stopped(&home).expect("read stopped status");
         assert_eq!(status.state, "stopped");
         assert_eq!(status.pid, 0);
-        assert_eq!(status.runtime_version, "0.10.4");
+        assert_eq!(status.runtime_version, "2026.9.0");
 
         fs::remove_dir_all(root).expect("remove stopped status fixture");
     }

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -1298,7 +1298,7 @@ fn signed_distro_apply_stops_to_a_volume_and_writes_a_bound_receipt() {
     assert_eq!(receipt["distro_id"], "unicity-ce");
     assert_eq!(receipt["distro_version"], env!("CARGO_PKG_VERSION"));
     assert_eq!(receipt["principal"], "operator");
-    assert_eq!(receipt["astrid_runtime_version"], "0.10.4");
+    assert_eq!(receipt["astrid_runtime_version"], "2026.9.0");
     assert!(receipt["signing_pubkey"].as_str().unwrap().len() > 8);
     assert!(
         receipt["manifest_blake3"]
@@ -1689,7 +1689,7 @@ fn native_status_reports_stopped_without_invoking_the_runtime_cli() {
         assert!(output.stderr.is_empty());
         let stdout = String::from_utf8(output.stdout).expect("utf8 stdout");
         assert!(stdout.contains("stopped"));
-        assert!(stdout.contains("0.10.4"));
+        assert!(stdout.contains("2026.9.0"));
     }
 }
 

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -15,7 +15,7 @@ support = "https://github.com/unicity-aos/aos-ce/discussions"
 bug-tracker = "https://github.com/unicity-aos/aos-ce/issues"
 repository = "https://github.com/unicity-aos/aos-ce"
 license = "MIT OR Apache-2.0"
-astrid-version = "=0.10.4"  # Product releases pin the exact bundled runtime; update this with release/runtime-compatibility.toml.
+astrid-version = "=2026.9.0"  # Product releases pin the exact bundled runtime; update this with release/runtime-compatibility.toml.
 
 [distro.requires.astrid]
 llm = "^1.0"

--- a/release/DEPENDENCIES-2026.9.0.md
+++ b/release/DEPENDENCIES-2026.9.0.md
@@ -1,0 +1,86 @@
+# Release dependency version inventory
+
+Baseline: `2026.1.3`. Candidate: `aa22ecb`.
+
+Generated from Cargo.lock. Includes direct, transitive, workspace,
+test, and platform-specific packages; inclusion is not a claim that
+every package ships in every binary. Multiple versions are listed.
+
+## Updated (8)
+
+| Package | Previous | Candidate |
+| --- | --- | --- |
+| `astrid-sdk` | 0.5.3, 0.7.1 | 0.7.1 |
+| `astrid-sdk-macros` | 0.5.3, 0.7.1 | 0.7.1 |
+| `astrid-sys` | 0.5.3, 0.7.1 | 0.7.1 |
+| `astrid-types` | 0.10.4, 0.4.0, 0.7.0 | 0.10.4, 0.7.0 |
+| `getrandom` | 0.4.3 | 0.2.17, 0.3.4, 0.4.3 |
+| `r-efi` | 6.0.0 | 5.3.0, 6.0.0 |
+| `unicity-aos-bootstrap` | 2026.1.3 | 2026.9.0 |
+| `wit-bindgen` | 0.54.0 | 0.54.0, 0.57.1 |
+
+## Added (33)
+
+| Package | Previous | Candidate |
+| --- | --- | --- |
+| `adaptive-shell` | — | 0.1.0 |
+| `ahash` | — | 0.8.12 |
+| `aos-hook-adapter-oracle` | — | 0.1.0 |
+| `aos-mcp` | — | 0.1.0 |
+| `aos-mcp-broker` | — | 0.1.0 |
+| `aos-meta-harness` | — | 0.1.0 |
+| `aos-rhai` | — | 0.1.0 |
+| `capsule-surface-catalog` | — | 0.1.0 |
+| `capsule-surface-model` | — | 0.1.0 |
+| `capsule-workspace-recipes` | — | 0.1.0 |
+| `const-random` | — | 0.1.18 |
+| `const-random-macro` | — | 0.1.16 |
+| `crunchy` | — | 0.2.4 |
+| `dispatch2` | — | 0.3.1 |
+| `errno` | — | 0.3.14 |
+| `objc2` | — | 0.6.4 |
+| `objc2-app-kit` | — | 0.3.2 |
+| `objc2-core-foundation` | — | 0.3.2 |
+| `objc2-encode` | — | 4.1.0 |
+| `objc2-foundation` | — | 0.3.2 |
+| `portable-atomic` | — | 1.15.0 |
+| `rhai` | — | 1.26.0 |
+| `rhai_codegen` | — | 3.2.0 |
+| `signal-hook-registry` | — | 1.4.8 |
+| `smartstring` | — | 1.0.1 |
+| `static_assertions` | — | 1.1.0 |
+| `thin-vec` | — | 0.2.19 |
+| `tiny-keccak` | — | 2.0.2 |
+| `version_check` | — | 0.9.5 |
+| `wasip2` | — | 1.0.4+wasi-0.2.12 |
+| `web-time` | — | 1.1.0 |
+| `zerocopy` | — | 0.8.56 |
+| `zerocopy-derive` | — | 0.8.56 |
+
+## Removed (20)
+
+| Package | Previous | Candidate |
+| --- | --- | --- |
+| `aho-corasick` | 1.1.4 | — |
+| `aos-telegram` | 0.1.0 | — |
+| `bytemuck` | 1.25.1 | — |
+| `either` | 1.16.0 | — |
+| `extism-convert` | 1.30.0 | — |
+| `extism-convert-macros` | 1.30.0 | — |
+| `extism-manifest` | 1.30.0 | — |
+| `extism-pdk` | 1.4.1 | — |
+| `extism-pdk-derive` | 1.4.1 | — |
+| `itertools` | 0.14.0 | — |
+| `manyhow` | 0.11.4 | — |
+| `manyhow-macros` | 0.11.4 | — |
+| `proc-macro-utils` | 0.10.0 | — |
+| `prost` | 0.14.4 | — |
+| `prost-derive` | 0.14.4 | — |
+| `regex` | 1.13.0 | — |
+| `regex-automata` | 0.4.15 | — |
+| `regex-syntax` | 0.8.11 | — |
+| `rmp` | 0.8.15 | — |
+| `rmp-serde` | 1.3.1 | — |
+
+Unchanged version sets are omitted. Source/checksum changes with unchanged
+versions remain visible in the linked repository comparison, not this version inventory.

--- a/release/DEPENDENCIES-2026.9.0.md
+++ b/release/DEPENDENCIES-2026.9.0.md
@@ -1,25 +1,39 @@
 # Release dependency version inventory
 
-Baseline: `2026.1.3`. Candidate: `aa22ecb`.
+Baseline: `2026.1.3`. Candidate: final `2026.9.0` release PR Cargo.lock.
 
-Generated from Cargo.lock. Includes direct, transitive, workspace,
-test, and platform-specific packages; inclusion is not a claim that
-every package ships in every binary. Multiple versions are listed.
+Includes direct, transitive, workspace, test, and platform-specific packages. Inclusion does not mean every package ships in every binary.
 
-## Updated (8)
+## Updated (24)
 
 | Package | Previous | Candidate |
 | --- | --- | --- |
+| `astrid-core` | 0.10.4 | 2026.9.0 |
+| `astrid-crypto` | 0.10.4 | 2026.9.0 |
 | `astrid-sdk` | 0.5.3, 0.7.1 | 0.7.1 |
 | `astrid-sdk-macros` | 0.5.3, 0.7.1 | 0.7.1 |
 | `astrid-sys` | 0.5.3, 0.7.1 | 0.7.1 |
-| `astrid-types` | 0.10.4, 0.4.0, 0.7.0 | 0.10.4, 0.7.0 |
+| `astrid-types` | 0.10.4, 0.4.0, 0.7.0 | 0.7.0, 2026.9.0 |
+| `astrid-uplink` | 0.10.4 | 2026.9.0 |
+| `base64` | 0.22.1 | 0.23.1 |
 | `getrandom` | 0.4.3 | 0.2.17, 0.3.4, 0.4.3 |
+| `hashbrown` | 0.16.1, 0.17.1 | 0.14.5, 0.16.1, 0.17.1 |
+| `js-sys` | 0.3.103 | 0.3.105 |
 | `r-efi` | 6.0.0 | 5.3.0, 6.0.0 |
+| `serde_spanned` | 0.6.9 | 0.6.9, 1.1.1 |
+| `syn` | 2.0.118 | 2.0.118, 3.0.5 |
+| `toml` | 0.8.23 | 0.8.23, 1.1.5+spec-1.1.0 |
+| `toml_parser` | 1.1.2+spec-1.1.0 | 1.1.3+spec-1.1.0 |
 | `unicity-aos-bootstrap` | 2026.1.3 | 2026.9.0 |
+| `uuid` | 1.23.5 | 1.25.0 |
+| `uuid-rng-internal` | 1.23.5 | 1.26.0 |
+| `wasm-bindgen` | 0.2.126 | 0.2.128 |
+| `wasm-bindgen-macro` | 0.2.126 | 0.2.128 |
+| `wasm-bindgen-macro-support` | 0.2.126 | 0.2.128 |
+| `wasm-bindgen-shared` | 0.2.126 | 0.2.128 |
 | `wit-bindgen` | 0.54.0 | 0.54.0, 0.57.1 |
 
-## Added (33)
+## Added (60)
 
 | Package | Previous | Candidate |
 | --- | --- | --- |
@@ -30,29 +44,56 @@ every package ships in every binary. Multiple versions are listed.
 | `aos-mcp-broker` | — | 0.1.0 |
 | `aos-meta-harness` | — | 0.1.0 |
 | `aos-rhai` | — | 0.1.0 |
+| `astrid-config` | — | 2026.9.0 |
+| `astrid-events` | — | 2026.9.0 |
+| `astrid-runtime` | — | 2026.9.0 |
 | `capsule-surface-catalog` | — | 0.1.0 |
 | `capsule-surface-model` | — | 0.1.0 |
 | `capsule-workspace-recipes` | — | 0.1.0 |
 | `const-random` | — | 0.1.18 |
 | `const-random-macro` | — | 0.1.16 |
+| `crossbeam-utils` | — | 0.8.23 |
 | `crunchy` | — | 0.2.4 |
+| `dashmap` | — | 6.2.1 |
+| `directories` | — | 6.0.0 |
+| `dirs-sys` | — | 0.5.0 |
 | `dispatch2` | — | 0.3.1 |
 | `errno` | — | 0.3.14 |
+| `futures` | — | 0.3.32 |
+| `futures-executor` | — | 0.3.32 |
+| `futures-io` | — | 0.3.34 |
+| `futures-macro` | — | 0.3.32 |
+| `futures-sink` | — | 0.3.34 |
+| `libredox` | — | 0.1.23 |
+| `lock_api` | — | 0.4.14 |
+| `metrics` | — | 0.24.6 |
+| `nix` | — | 0.31.3 |
 | `objc2` | — | 0.6.4 |
 | `objc2-app-kit` | — | 0.3.2 |
 | `objc2-core-foundation` | — | 0.3.2 |
 | `objc2-encode` | — | 4.1.0 |
 | `objc2-foundation` | — | 0.3.2 |
+| `option-ext` | — | 0.2.0 |
+| `parking_lot` | — | 0.12.5 |
+| `parking_lot_core` | — | 0.9.12 |
+| `pin-utils` | — | 0.1.0 |
 | `portable-atomic` | — | 1.15.0 |
+| `rapidhash` | — | 4.5.1 |
+| `redox_syscall` | — | 0.5.18 |
+| `redox_users` | — | 0.5.2 |
 | `rhai` | — | 1.26.0 |
 | `rhai_codegen` | — | 3.2.0 |
+| `scopeguard` | — | 1.2.0 |
 | `signal-hook-registry` | — | 1.4.8 |
 | `smartstring` | — | 1.0.1 |
 | `static_assertions` | — | 1.1.0 |
 | `thin-vec` | — | 0.2.19 |
 | `tiny-keccak` | — | 2.0.2 |
+| `toml_writer` | — | 1.1.2+spec-1.1.0 |
 | `version_check` | — | 0.9.5 |
 | `wasip2` | — | 1.0.4+wasi-0.2.12 |
+| `wasm-bindgen-futures` | — | 0.4.78 |
+| `wasmtimer` | — | 0.4.3 |
 | `web-time` | — | 1.1.0 |
 | `zerocopy` | — | 0.8.56 |
 | `zerocopy-derive` | — | 0.8.56 |
@@ -82,5 +123,4 @@ every package ships in every binary. Multiple versions are listed.
 | `rmp` | 0.8.15 | — |
 | `rmp-serde` | 1.3.1 | — |
 
-Unchanged version sets are omitted. Source/checksum changes with unchanged
-versions remain visible in the linked repository comparison, not this version inventory.
+Unchanged version sets are omitted. Source and checksum changes remain visible in Cargo.lock.

--- a/release/RELEASE-2026.9.0.md
+++ b/release/RELEASE-2026.9.0.md
@@ -1,7 +1,7 @@
 # AOS 2026.9.0 release preparation
 
 This source PR is not publication authorization. Publish in dependency order:
-Astrid 2026.9.0, AOS 2026.9.0, then Oracle 0.3.0.
+Astrid 2026.9.0, AOS 2026.9.0, then Oracle 2026.9.0.
 
 ## Before enabling publication
 

--- a/release/RELEASE-2026.9.0.md
+++ b/release/RELEASE-2026.9.0.md
@@ -33,6 +33,16 @@ temporary source repins, fixture repairs, and fixes to newly introduced
 features are folded into the final behavior, not advertised as separate fixes
 to an older public release. Source history retains those details.
 
-The current compatibility files retain the last published runtime until its
-replacement can be authenticated. This PR therefore remains draft until the
-upstream pin step is complete. No Windows product certification is implied.
+## Published upstream identity
+
+Astrid v2026.9.0 is an immutable published release at
+`7bad449122c08373e8fe4024a80f97a8787c2a44`. Both metadata bundles were verified
+against the release workflow's Sigstore identity before pinning:
+
+- GNU/Darwin metadata BLAKE3: `66f7c7b9fabb17cc521e542fc524b9e9deca42826809306f6fd0096685d9e62e`.
+- Musl metadata BLAKE3: `92fba87b0c94ff4bc41e9558e65295c2b37ef0174f875b6460be984fd9963de2`.
+
+The four direct Rust client dependencies and Cargo.lock now use published
+2026.9.0 crates. Distro, bootstrap constant and command inventory agree; the
+inventory includes inherited `storage`. Production publication still executes
+the signing and archive checks. No Windows product certification is implied.

--- a/release/RELEASE-2026.9.0.md
+++ b/release/RELEASE-2026.9.0.md
@@ -1,0 +1,38 @@
+# AOS 2026.9.0 release preparation
+
+This source PR is not publication authorization. Publish in dependency order:
+Astrid 2026.9.0, AOS 2026.9.0, then Oracle 0.3.0.
+
+## Before enabling publication
+
+- Rehearse the selected candidate on macOS and GNU/musl x86_64 and ARM64:
+  installation, old-layout migration, start/stop, and filesystem write/sync/
+  unmount. Record source identities and rehearsal digests separately from
+  future production bytes.
+- Exercise Codex, Claude, and Grok through their real Oracle adapters. The
+  host-specific capsule grants are not the whole Community distribution.
+- Confirm first-install batching and installation from a project directory;
+  retries or runtime-directory workarounds are not one-shot success.
+- After Astrid publication, authenticate both its legacy and musl metadata.
+  Update the exact runtime compatibility pins, Cargo dependencies and lock,
+  Distro Astrid requirement, runtime command inventory, and bootstrap runtime
+  constant together to 2026.9.0. Do not invent missing production hashes or
+  replace production trust with the disposable rehearsal key.
+- Run `python3 scripts/validate-release-contract.py --require-release-ready`
+  and the package/installer contracts with those actual inputs. Set readiness
+  flags only when the corresponding evidence exists.
+- Confirm all 22 selected capsule artifacts and filesystem providers are in
+  the authenticated archives. Verify production signatures during authorized
+  release execution; a failure blocks publication/downstream consumption.
+
+## Changelog policy for this cut
+
+`CHANGELOG.md` describes net changes since tag `2026.1.3`; its historical
+section is restored from that tag. Development-only signing rehearsals,
+temporary source repins, fixture repairs, and fixes to newly introduced
+features are folded into the final behavior, not advertised as separate fixes
+to an older public release. Source history retains those details.
+
+The current compatibility files retain the last published runtime until its
+replacement can be authenticated. This PR therefore remains draft until the
+upstream pin step is complete. No Windows product certification is implied.

--- a/release/VERSIONING.md
+++ b/release/VERSIONING.md
@@ -1,0 +1,29 @@
+# Release versioning
+
+Starting with the September 2026 release, Astrid, AOS, and Oracle use
+`YEAR.MONTH.PATCH` (calendar year, calendar month, patch number), called
+CalSemVer here. The month is not zero-padded.
+
+- The first release in a calendar-month series is `2026.9.0`.
+- Follow-up fixes to that series are `2026.9.1`, `2026.9.2`, and so on.
+- A new monthly series starts at patch zero, for example `2026.10.0`.
+- A later maintenance release for an older series keeps that series' year/month
+  and increments its patch; it does not rename an existing release.
+- Version alignment does not replace explicit runtime compatibility requirements.
+  Document breaking changes and migrations in release notes; the year component
+  is not a traditional SemVer compatibility-major guarantee.
+
+All three products target `2026.9.0` for this release. Git tags retain their
+existing repository conventions: Astrid and Oracle use `v2026.9.0`; AOS uses
+`2026.9.0`.
+
+Previously published versions are immutable. AOS `2026.1.x` was not a
+calendar-month series; do not reinterpret it as January. Astrid `0.10.x` and
+Oracle `0.2.x` likewise retain their historical identities. The unreleased
+Oracle `0.3.0` preparation is superseded by `2026.9.0`, not an additional
+published release.
+
+Changelogs describe the net user-facing change from the preceding published
+release. Fold repairs to unreleased implementations into the final behavior;
+keep historical published sections and consequential migration limitations.
+

--- a/release/runtime-command-surface.toml
+++ b/release/runtime-command-surface.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-runtime-version = "0.10.4"
+runtime-version = "2026.9.0"
 
 [roots]
 # Public runtime roots delegated byte-for-byte as `aos <verb>`.
@@ -25,6 +25,7 @@ inherited = [
   "start",
   "stop",
   "restart",
+  "storage",
   "logs",
   "ps",
   "top",

--- a/release/runtime-compatibility.toml
+++ b/release/runtime-compatibility.toml
@@ -8,14 +8,14 @@ version = "2026.9.0"
 repository = "astrid-runtime/astrid"
 release-ready = true
 upgrade-self-heal-ready = true
-version = "0.10.4"
-tag = "v0.10.4"
-version-requirement = "=0.10.4"
-release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v0.10.4"
+version = "2026.9.0"
+tag = "v2026.9.0"
+version-requirement = "=2026.9.0"
+release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v2026.9.0"
 release-metadata-available = true
-source-commit = "b6bf5d1d579915eb5d3c944857d84e62a4fcc878"
-release-metadata-asset = "astrid-0.10.4-release.toml"
-release-metadata-blake3 = "25f4de92aa2db9db81e84902db479adf8bae68256fe3656db2c1673dfb302c0b"
+source-commit = "7bad449122c08373e8fe4024a80f97a8787c2a44"
+release-metadata-asset = "astrid-2026.9.0-release.toml"
+release-metadata-blake3 = "66f7c7b9fabb17cc521e542fc524b9e9deca42826809306f6fd0096685d9e62e"
 
 [contracts]
 repository = "astrid-runtime/wit"

--- a/release/runtime-musl-compatibility.toml
+++ b/release/runtime-musl-compatibility.toml
@@ -6,12 +6,12 @@ schema-version = 1
 # two-target musl extension.
 [runtime]
 repository = "astrid-runtime/astrid"
-release-ready = false
-version = "0.10.4"
-tag = "v0.10.4"
-release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v0.10.4"
-source-commit = "b6bf5d1d579915eb5d3c944857d84e62a4fcc878"
-legacy-release-metadata-asset = "astrid-0.10.4-release.toml"
-legacy-release-metadata-blake3 = "25f4de92aa2db9db81e84902db479adf8bae68256fe3656db2c1673dfb302c0b"
-musl-release-metadata-asset = ""
-musl-release-metadata-blake3 = ""
+release-ready = true
+version = "2026.9.0"
+tag = "v2026.9.0"
+release-workflow-identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v2026.9.0"
+source-commit = "7bad449122c08373e8fe4024a80f97a8787c2a44"
+legacy-release-metadata-asset = "astrid-2026.9.0-release.toml"
+legacy-release-metadata-blake3 = "66f7c7b9fabb17cc521e542fc524b9e9deca42826809306f6fd0096685d9e62e"
+musl-release-metadata-asset = "astrid-2026.9.0-musl-release.toml"
+musl-release-metadata-blake3 = "92fba87b0c94ff4bc41e9558e65295c2b37ef0174f875b6460be984fd9963de2"

--- a/scripts/changelog_notes.py
+++ b/scripts/changelog_notes.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Extract a curated release section without rewriting published history."""
+
+import argparse
+from pathlib import Path
+import re
+
+
+def notes(text: str, version: str) -> str:
+    matches = list(re.finditer(r"^## \[([^]]+)\].*$", text, re.MULTILINE))
+    selected = [i for i, match in enumerate(matches) if match[1] == version]
+    if len(selected) != 1:
+        raise ValueError(f"expected one changelog section for {version}")
+    index = selected[0]
+    end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+    result = text[matches[index].end():end].strip()
+    if not result:
+        raise ValueError(f"empty changelog section for {version}")
+    return result + "\n"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
+    args = parser.parse_args()
+    try:
+        print(notes(args.changelog.read_text(), args.version), end="")
+    except ValueError as error:
+        parser.exit(1, f"{error}\n")

--- a/scripts/ci/install_gnu_build_packages.sh
+++ b/scripts/ci/install_gnu_build_packages.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bullseye supplies the glibc 2.31 build baseline, but LTS ended 2026-08-31.
+# Freeze its final package sources rather than raising the binary ABI floor.
+# Only these immutable snapshots waive freshness; APT still verifies Debian
+# signatures and package hashes. Do not apply this policy to live repositories.
+sources=$(mktemp)
+trap 'rm -f "$sources"' EXIT
+printf '%s\n' \
+  'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main' \
+  'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main' \
+  > "$sources"
+options=(-o "Dir::Etc::sourcelist=$sources" -o Dir::Etc::sourceparts=-)
+apt-get "${options[@]}" update
+apt-get "${options[@]}" install -y --no-install-recommends "$@"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -73,7 +73,7 @@ PY
 
 runtime_root="$work/astrid-$runtime_version-x86_64-unknown-linux-gnu"
 mkdir -p "$runtime_root"
-for binary in astrid astrid-daemon astrid-build astrid-emit; do
+for binary in astrid astrid-daemon astrid-build astrid-emit astrid-storage-provider-fuse; do
   printf '#!/bin/sh\necho %s\n' "$binary" > "$runtime_root/$binary"
   chmod 755 "$runtime_root/$binary"
 done
@@ -256,12 +256,12 @@ sh "$repo_root/install.sh" --yes --no-migrate-prompt
 test -x "$work/home/.aos/bin/aos"
 source "$repo_root/scripts/test-install-musl.sh"
 release_dir="$work/home/.aos/releases/2026.9.0"
-test "$runtime_version" = 0.10.4
+test "$runtime_version" = 2026.9.0
 for binary in astrid astrid-daemon astrid-build astrid-emit; do
   test -x "$release_dir/runtime/bin/$binary"
   test ! -e "$work/home/.aos/runtime/bin/$binary"
 done
-test ! -e "$release_dir/runtime/bin/astrid-storage-provider-fuse"
+test -x "$release_dir/runtime/bin/astrid-storage-provider-fuse"
 test -f "$release_dir/release-manifest.json"
 test -f "$release_dir/Distro.toml"
 test -f "$release_dir/capsule-assets.txt"
@@ -364,7 +364,7 @@ do
 done
 
 # Build a second package through the real composer with an isolated
-# compatibility overlay.  The checked-in 0.10.4 contract above remains the
+# compatibility overlay.  The checked-in production contract above remains the
 # historical control; this fixture exercises the versioned 2026.9.0 GNU
 # membership that requires the FUSE provider.
 fuse_repo="$work/aos-2026.9.0-contract"

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -184,7 +184,7 @@ for spec in source_contract():
     write_fixture(output / spec.asset, spec)
 PY
 
-for binary in astrid astrid-daemon astrid-build astrid-emit; do
+for binary in astrid astrid-daemon astrid-build astrid-emit astrid-storage-provider-fuse; do
   if [[ "$binary" == astrid ]]; then
     cat > "$runtime_root/$binary" <<'RUNTIME'
 #!/bin/sh
@@ -276,10 +276,7 @@ tar -tzf "$archive" > "$work/files"
 grep -q '/bin/aos$' "$work/files"
 grep -q '/libexec/install.sh$' "$work/files"
 grep -q '/runtime/bin/astrid-daemon$' "$work/files"
-if grep -q '/runtime/bin/astrid-storage-provider-fuse$' "$work/files"; then
-  echo "0.10.4 GNU release archive unexpectedly contains the FUSE provider" >&2
-  exit 1
-fi
+grep -q '/runtime/bin/astrid-storage-provider-fuse$' "$work/files"
 grep -q '/runtime-compatibility.toml$' "$work/files"
 test "$(grep -c '/capsules/aos-.*\.capsule$' "$work/files")" -eq 22
 grep -q '/capsule-assets.txt$' "$work/files"
@@ -315,6 +312,7 @@ expected_executables = [
     "runtime/bin/astrid-daemon",
     "runtime/bin/astrid-build",
     "runtime/bin/astrid-emit",
+    "runtime/bin/astrid-storage-provider-fuse",
 ]
 assert manifest["executables"] == expected_executables
 assert manifest["layout"] == {
@@ -333,6 +331,7 @@ expected_inventory = {
     "runtime/bin/astrid-build",
     "runtime/bin/astrid-daemon",
     "runtime/bin/astrid-emit",
+    "runtime/bin/astrid-storage-provider-fuse",
     *(f"capsules/{asset}" for asset in manifest["capsules"]["assets"]),
 }
 assert set(manifest["release_files"]) == expected_inventory, (
@@ -369,7 +368,7 @@ assert manifest["verifier"] == {
 PY
 
 # Rehearsal runtime 2026.9.0 has an explicit GNU FUSE provider contract while
-# the stable 0.10.4 GNU archive above remains the four portable binaries.
+# the pinned stable GNU archive above includes its FUSE provider.
 versioned_repo="$work/aos-2026.9.0-contract"
 mkdir -p \
   "$versioned_repo/scripts" \

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -394,7 +394,9 @@ test "$(find "$legacy/run" -type f | wc -l | tr -d ' ')" -eq 5
 install_candidate
 test -x "$aos_home/bin/aos"
 test -x "$aos_home/releases/2026.9.0/runtime/bin/astrid-daemon"
-test ! -e "$aos_home/releases/2026.9.0/runtime/bin/astrid-storage-provider-fuse"
+if [[ "$host_os" == Linux ]]; then
+  test -x "$aos_home/releases/2026.9.0/runtime/bin/astrid-storage-provider-fuse"
+fi
 for name in $runtime_binaries; do
   test ! -e "$aos_home/runtime/bin/$name"
 done
@@ -545,6 +547,8 @@ cp "$repo_root/distros/community/unicity-ce/Distro.toml" \
 cp "$repo_root/install.sh" "$repo_root/README.md" "$fuse_repo/"
 cp "$repo_root/scripts/capsule_release.py" \
   "$repo_root/scripts/package-release.sh" \
+  "$repo_root/scripts/package_macos_filesystem.py" \
+  "$repo_root/scripts/aos-filesystem.sh" \
   "$repo_root/scripts/validate-runtime-archive.py" \
   "$fuse_repo/scripts/"
 python3 - "$fuse_repo/release/runtime-compatibility.toml" \

--- a/scripts/test-upgrade-self-heal.sh
+++ b/scripts/test-upgrade-self-heal.sh
@@ -197,11 +197,13 @@ case "$host_os:$host_arch" in
     runtime_binaries="$runtime_binaries astrid-storage-provider-fskit"
     ;;
   Linux:aarch64|Linux:arm64)
+    runtime_binaries="$runtime_binaries astrid-storage-provider-fuse"
     target=aarch64-unknown-linux-gnu
     cosign_asset=cosign-linux-arm64
     cosign_sha256=2ec865872e331c32fd12b08dae15332d3f92c0aa029219589684a4903ca85d11
     ;;
   Linux:x86_64|Linux:amd64)
+    runtime_binaries="$runtime_binaries astrid-storage-provider-fuse"
     target=x86_64-unknown-linux-gnu
     cosign_asset=cosign-linux-amd64
     cosign_sha256=ae1ecd212663f3693ad9edf8b1a183900c9a52d3155ba6e354237f9a0f6463fc
@@ -253,6 +255,11 @@ for name in $runtime_binaries; do
   printf '#!/bin/sh\necho packaged-%s\n' "$name" > "$runtime_root/$name"
   chmod 755 "$runtime_root/$name"
 done
+if [[ "$host_os" == Darwin ]]; then
+  PYTHONPATH="$repo_root/scripts" python3 -c \
+    'from pathlib import Path; import sys; from test_package_macos_filesystem import fixture; fixture(Path(sys.argv[1]))' \
+    "$runtime_root"
+fi
 COPYFILE_DISABLE=1 tar -czf "$work/runtime.tar.gz" -C "$work" "$(basename "$runtime_root")"
 bash "$repo_root/scripts/package-release.sh" \
   "$target" \
@@ -518,7 +525,7 @@ test ! -e "$aos_home/runtime/run"
 
 echo "sanitized packaged migration, reinstall, and self-heal checks passed"
 
-# Keep the historical 0.10.4 GNU control above, then perform an upgrade to a
+# Keep the legacy-layout migration control above, then perform an upgrade to a
 # real 2026.9.0 GNU package composed through an isolated compatibility overlay.
 # The strict provider is included in the shipped-asset snapshot so the
 # self-heal reinstall proves its immutable persistence rather than merely
@@ -716,4 +723,4 @@ for directory in \
   test "$(mode_of "$directory")" = 700
 done
 
-echo "historical 0.10.4 control and 2026.9.0 GNU FUSE self-heal checks passed"
+echo "legacy-layout migration and 2026.9.0 GNU FUSE self-heal checks passed"

--- a/scripts/test_changelog_notes.py
+++ b/scripts/test_changelog_notes.py
@@ -1,0 +1,18 @@
+import unittest
+
+from changelog_notes import notes
+
+
+class ChangelogNotesTests(unittest.TestCase):
+    def test_only_selected_release_is_emitted(self):
+        text = "# Changelog\n\n## [2026.9.0] - Unreleased\n\nNew behavior\n\n## [2026.1.3] - Unreleased\n\nOld behavior\n"
+        self.assertEqual(notes(text, "2026.9.0"), "New behavior\n")
+
+    def test_missing_duplicate_and_empty_sections_fail(self):
+        for text in ("", "## [v]\n", "## [v]\none\n## [v]\ntwo\n"):
+            with self.subTest(text=text), self.assertRaises(ValueError):
+                notes(text, "v")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_gnu_build_packages.py
+++ b/scripts/test_gnu_build_packages.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Exercise package-source scope, argument forwarding and update failure."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).parent / "ci/install_gnu_build_packages.sh"
+
+
+class PackageSetupTests(unittest.TestCase):
+    def run_setup(self, fail_update=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "calls.jsonl"
+            apt = root / "apt-get"
+            apt.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, pathlib, sys\n"
+                "args = sys.argv[1:]\n"
+                "source = next(a.split('=', 1)[1] for a in args "
+                "if a.startswith('Dir::Etc::sourcelist='))\n"
+                "with open(os.environ['APT_TEST_LOG'], 'a') as log:\n"
+                " log.write(json.dumps({'args': args, 'path': source, "
+                "'sources': pathlib.Path(source).read_text()}) + '\\n')\n"
+                "if 'update' in args and os.environ['APT_TEST_FAIL'] == '1': "
+                "sys.exit(100)\n"
+            )
+            apt.chmod(0o755)
+            env = dict(os.environ, PATH=f"{root}:{os.environ['PATH']}",
+                       APT_TEST_LOG=str(log), APT_TEST_FAIL=str(int(fail_update)))
+            result = subprocess.run(
+                ["bash", str(SCRIPT), "cmake", "gcc-aarch64-linux-gnu"],
+                env=env, check=False,
+            )
+            calls = [json.loads(line) for line in log.read_text().splitlines()]
+            for call in calls:
+                self.assertFalse(Path(call["path"]).exists(), "temporary source leaked")
+            return result.returncode, calls
+
+    def test_signed_snapshot_sources_and_forwarded_packages(self):
+        code, calls = self.run_setup()
+        self.assertEqual(code, 0)
+        self.assertEqual(len(calls), 2)
+        for call in calls:
+            self.assertIn("Dir::Etc::sourceparts=-", call["args"])
+            self.assertNotIn("--allow-unauthenticated", call["args"])
+            lines = call["sources"].splitlines()
+            self.assertEqual(len(lines), 2)
+            for line in lines:
+                self.assertIn("https://snapshot.debian.org/archive/", line)
+                self.assertIn("/20260901T000000Z/", line)
+                self.assertIn("[check-valid-until=no]", line)
+                self.assertNotIn("trusted=yes", line)
+        self.assertEqual(calls[0]["sources"], calls[1]["sources"])
+        self.assertEqual(calls[1]["args"][-5:],
+                         ["install", "-y", "--no-install-recommends",
+                          "cmake", "gcc-aarch64-linux-gnu"])
+
+    def test_failed_update_never_installs(self):
+        code, calls = self.run_setup(fail_update=True)
+        self.assertEqual(code, 100)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["args"][-1], "update")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_musl_release_metadata.py
+++ b/scripts/test_musl_release_metadata.py
@@ -257,11 +257,15 @@ class ExtensionTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unknown keys"):
             MUSL.validate_extension(extension)
 
-    def test_checked_in_pin_is_staged_and_fail_closed(self) -> None:
+    def test_checked_in_pin_is_ready_and_false_fixture_fails_closed(self) -> None:
         path = Path(__file__).resolve().parent.parent / "release/runtime-musl-compatibility.toml"
         pin = release_metadata.load(path)
         runtime = MUSL.validate_runtime_pin(pin, require_ready=False)
-        self.assertFalse(runtime["release-ready"])
+        self.assertTrue(runtime["release-ready"])
+        MUSL.validate_runtime_pin(pin, require_ready=True)
+        pin["runtime"]["release-ready"] = False
+        pin["runtime"]["musl-release-metadata-asset"] = ""
+        pin["runtime"]["musl-release-metadata-blake3"] = ""
         with self.assertRaisesRegex(ValueError, "release-ready gate is false"):
             MUSL.validate_runtime_pin(pin, require_ready=True)
 

--- a/scripts/test_validate_release_contract.py
+++ b/scripts/test_validate_release_contract.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 from pathlib import Path
 
 import musl_release_metadata
@@ -155,10 +156,13 @@ class ReleaseReadinessTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "refusing to publish|musl runtime"):
                 VALIDATOR.main(["--require-release-ready"])
 
-    def test_main_admits_checked_in_false_ready_musl_pin(self) -> None:
+    def test_staged_validation_admits_false_ready_musl_pin(self) -> None:
         pin = VALIDATOR.readiness_metadata(
             ROOT / "release/runtime-musl-compatibility.toml"
         )
+        pin["runtime"]["release-ready"] = False
+        pin["runtime"]["musl-release-metadata-asset"] = ""
+        pin["runtime"]["musl-release-metadata-blake3"] = ""
         runtime = musl_release_metadata.validate_runtime_pin(
             pin, require_ready=False
         )
@@ -173,9 +177,15 @@ class ReleaseReadinessTests(unittest.TestCase):
             ROOT / "release/runtime-musl-compatibility.toml"
         )["runtime"]
         self.assertTrue(gnu["release-ready"])
-        self.assertFalse(musl["release-ready"])
-        with self.assertRaisesRegex(ValueError, "musl runtime compatibility release-ready"):
-            VALIDATOR.main(["--require-release-ready"])
+        musl["release-ready"] = False
+        original = VALIDATOR.readiness_metadata
+        def fixture(path):
+            if Path(path).name == "runtime-musl-compatibility.toml":
+                return {"schema-version": 1, "runtime": musl}
+            return original(path)
+        with patch.object(VALIDATOR, "readiness_metadata", side_effect=fixture):
+            with self.assertRaisesRegex(ValueError, "musl runtime compatibility release-ready"):
+                VALIDATOR.main(["--require-release-ready"])
 
     def test_musl_pin_rejects_identity_extra_keys_and_empty_ready_fields(self) -> None:
         pin = VALIDATOR.readiness_metadata(


### PR DESCRIPTION
## Summary

Release AOS 2026.9.0 against the published immutable Astrid v2026.9.0 release.
Related to #110 and #63. This supersedes the earlier staged-runtime notes.

## Changes

- Keep a Changelog release notes describe net changes since 2026.1.3, preserve
  its historical section, and consolidate fixes to unreleased implementations.
- Pin GNU/Darwin and musl runtime metadata to published source
  `7bad449122c08373e8fe4024a80f97a8787c2a44`; both Sigstore bundles verified.
- Pin the four Astrid client dependencies and lockfile to crates.io 2026.9.0.
  Align Distro, bootstrap constant, and command inventory, including storage.
- Ship six native target archives with their filesystem providers, including
  x86_64/ARM64 musl and the upstream signed/notarized macOS app.
- Preserve the 22-capsule Community inventory and separate Oracle host grants.
- Refresh the dependency inventory against the last public release.
- Retarget current-version packaging/installer/status fixtures; retain
  negative readiness and missing-provider tests and legacy migration coverage.
- Admit the shipped Linux FUSE provider and macOS app/support directories
  during migration, retaining rejection of unknown entries and symlinks.

## Verification

- Published Astrid GNU/Darwin and musl metadata: cosign verification passed.
- Release validator with --require-release-ready passed.
- Package and installer shell contracts passed (including musl and macOS).
- Bootstrap cargo test and all-target clippy passed against published crates.
- Release metadata, publication, channel, capsule, archive, command-surface,
  macOS packaging and rehearsal contract tests passed.
- Actual released Astrid CLI matches the updated command inventory.
- Packaged migration, reinstall and self-heal passed; 67 bootstrap unit tests
  passed, including the packaged-app inventory regression.
- Exact-head hosted CI must pass before landing.

## Publication order

Astrid is published. After this PR lands and its release checks pass, tag AOS
2026.9.0, authenticate the produced assets, then finalize Oracle 2026.9.0.
No Windows support is claimed. No rehearsal digests substitute for production.

## AI / Tool Assistance

Assisted-by: Codex:Astra

Release composition, fixture updates and verification assisted by Codex.
