### PR TITLE
fix(macos): carry and install the signed filesystem app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
       - run: bash scripts/test-rehearsal-sign-workflow-contract.sh
       - run: python3 scripts/test_create_astrid_094_fixture.py
       - run: bash scripts/test-package-release.sh
+      - run: python3 scripts/test_package_macos_filesystem.py
       - run: bash scripts/test-install.sh
       - run: python3 scripts/capsule_release.py
       - run: python3 scripts/test_capsule_release.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,7 @@ jobs:
             bash -euxo pipefail -c '
               if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
                 rustup target add aarch64-unknown-linux-gnu
-                apt-get update
-                apt-get install -y --no-install-recommends \
+                bash scripts/ci/install_gnu_build_packages.sh \
                   gcc-aarch64-linux-gnu \
                   libc6-dev-arm64-cross
                 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
@@ -94,6 +93,7 @@ jobs:
       - run: python3 scripts/test_check_glibc.py
       - run: python3 scripts/validate-release-contract.py
       - run: python3 scripts/test_validate_release_contract.py
+      - run: python3 scripts/test_gnu_build_packages.py
       - run: python3 scripts/test_release_metadata.py
       - run: python3 scripts/test_musl_release_metadata.py
       - run: python3 scripts/test_check_static_elf.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,8 +208,7 @@ jobs:
             bash -euxo pipefail -c '
               if [[ "$TARGET" == aarch64-unknown-linux-gnu ]]; then
                 rustup target add aarch64-unknown-linux-gnu
-                apt-get update
-                apt-get install -y --no-install-recommends \
+                bash scripts/ci/install_gnu_build_packages.sh \
                   gcc-aarch64-linux-gnu \
                   libc6-dev-arm64-cross
                 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc

--- a/changes/macos-filesystem-bundle.fixed.md
+++ b/changes/macos-filesystem-bundle.fixed.md
@@ -1,0 +1,1 @@
+Darwin packages retain the upstream signed Astrid filesystem app and management scripts. The common AOS installer installs the app as AOS.app and requests extension enablement, covering website and Oracle bootstrap installations. Signed bundle contents and internal Astrid identities remain unchanged; incomplete macOS approval is reported with retry commands.

--- a/install.sh
+++ b/install.sh
@@ -1256,6 +1256,12 @@ chmod 700 "$release_stage/runtime" "$release_stage/runtime/bin" "$release_stage/
 for name in $runtime_binaries; do
   install -m 0700 "$bundle/runtime/bin/$name" "$release_stage/runtime/bin/$name"
 done
+if [ -d "$bundle/runtime/bin/AstridFS.app" ]; then
+  # The authenticated archive owns these signed bytes. Do not edit Info.plist,
+  # rename internal executables, or re-sign while installing the product.
+  cp -Rp "$bundle/runtime/bin/AstridFS.app" "$release_stage/runtime/bin/"
+  cp -Rp "$bundle/runtime/bin/macos" "$release_stage/runtime/bin/"
+fi
 install -m 0600 "$bundle/release-manifest.json" "$release_stage/release-manifest.json"
 install -m 0600 "$bundle/Distro.toml" "$release_stage/Distro.toml"
 if [ "$distro_archive_signed" -eq 1 ]; then
@@ -1292,6 +1298,17 @@ fi
 installation_started=0
 rm -rf "$release_backup"
 release_install_lock
+
+if [ -d "$release_dir/runtime/bin/AstridFS.app" ]; then
+  filesystem_manager="$release_dir/runtime/bin/macos/aos-filesystem.sh"
+  if ! /bin/sh "$filesystem_manager" install || ! /bin/sh "$filesystem_manager" enable; then
+    echo "AOS runtime is installed; macOS filesystem setup is incomplete." >&2
+    echo "Allow the Astrid filesystem extension in macOS settings, then run:" >&2
+    echo "/bin/sh '$filesystem_manager' install" >&2
+    echo "/bin/sh '$filesystem_manager' enable" >&2
+    exit 1
+  fi
+fi
 
 echo "Installed Unicity AOS $staged_version."
 case ":$PATH:" in

--- a/release/MACOS-FILESYSTEM.md
+++ b/release/MACOS-FILESYSTEM.md
@@ -1,0 +1,29 @@
+# macOS filesystem installation
+
+The AOS Darwin archive carries the signed, notarized AstridFS.app and its
+co-versioned companion from the authenticated Astrid archive. App contents,
+including the extension identity and signatures, are copied unchanged.
+
+The common installer retains these under the immutable release directory and
+uses `runtime/bin/macos/aos-filesystem.sh` to install and enable the container
+at `/Applications/AOS.app`. The outer installation name is product-owned;
+the filesystem remains Astrid. The wrapper honors `ASTRID_FSKIT_APP_DEST`
+for an explicit alternative. No icon or Info.plist is patched after signing.
+An existing `/Applications/AstridFS.app` is reused instead of creating a second
+registration of the same provider. If both default paths exist, setup requests
+an explicit selection; it does not remove either app. An existing destination
+must pass the upstream signature/identity validator before replacement.
+
+The website base installer and Oracle first-install bootstrap use this same
+path. Already-installed AOS versions need an AOS upgrade to receive it.
+macOS 26 and extension approval are required. A permission, signature, or
+election failure returns a nonzero installer result with explicit retry
+commands; the installed runtime is retained. No automatic sudo, Gatekeeper
+bypass, or fallback unsigned signing is performed.
+
+The managed app is not yet a general control UI. A future AOS command center
+can own menu-bar/tray status, MCP elicitations and registry management without
+changing the filesystem extension's identity or adding UI duties to it.
+
+Fixture tests establish byte/mode preservation and installer dispatch, not
+Apple notarization. Production signature and mount checks remain necessary.

--- a/scripts/aos-filesystem.sh
+++ b/scripts/aos-filesystem.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Product-facing installation name; signed Astrid identities remain unchanged.
+set -eu
+manager_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+if [ -z "${ASTRID_FSKIT_APP_DEST:-}" ]; then
+  # Reuse the existing provider rather than register its identity twice.
+  ASTRID_FSKIT_APP_DEST=/Applications/AOS.app
+  if [ -e /Applications/AstridFS.app ]; then
+    if [ -e /Applications/AOS.app ]; then
+      echo 'Both AOS.app and AstridFS.app exist; select the managed provider with ASTRID_FSKIT_APP_DEST.' >&2
+      exit 1
+    fi
+    ASTRID_FSKIT_APP_DEST=/Applications/AstridFS.app
+  fi
+fi
+ASTRID_FSKIT_BIN_DIR=${ASTRID_FSKIT_BIN_DIR:-"$manager_dir/.."}
+export ASTRID_FSKIT_APP_DEST ASTRID_FSKIT_BIN_DIR
+case "${1:-}" in
+  install|update)
+    if [ -e "$ASTRID_FSKIT_APP_DEST" ] || [ -L "$ASTRID_FSKIT_APP_DEST" ]; then
+      /bin/bash "$manager_dir/manage-macos-fskit.sh" validate
+    fi
+    ;;
+esac
+exec /bin/bash "$manager_dir/manage-macos-fskit.sh" "$@"

--- a/scripts/ci/install_gnu_build_packages.sh
+++ b/scripts/ci/install_gnu_build_packages.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bullseye supplies the glibc 2.31 build baseline, but LTS ended 2026-08-31.
+# Freeze its final package sources rather than raising the binary ABI floor.
+# Only these immutable snapshots waive freshness; APT still verifies Debian
+# signatures and package hashes. Do not apply this policy to live repositories.
+sources=$(mktemp)
+trap 'rm -f "$sources"' EXIT
+printf '%s\n' \
+  'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian/20260901T000000Z/ bullseye main' \
+  'deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260901T000000Z/ bullseye-security main' \
+  > "$sources"
+options=(-o "Dir::Etc::sourcelist=$sources" -o Dir::Etc::sourceparts=-)
+apt-get "${options[@]}" update
+apt-get "${options[@]}" install -y --no-install-recommends "$@"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -184,7 +184,16 @@ for relative in expected_executables:
     if type(record["mode"]) is not int or record["mode"] != 0o755:
         raise SystemExit(f"release manifest executable mode is not 0755: {relative}")
 for relative, record in release_files.items():
-    if isinstance(record, dict) and record.get("mode") == 0o755 and relative not in expected_executables:
+    filesystem_executable = (
+        isinstance(target, str) and target.endswith("-apple-darwin")
+        and relative in {
+            "runtime/bin/AstridFS.app/Contents/MacOS/AstridFS",
+            "runtime/bin/AstridFS.app/Contents/Extensions/AstridFSAppEx.appex/Contents/MacOS/AstridFSAppEx",
+            "runtime/bin/macos/manage-macos-fskit.sh",
+            "runtime/bin/macos/validate-macos-fskit.sh",
+        }
+    )
+    if isinstance(record, dict) and record.get("mode") == 0o755 and relative not in expected_executables and not filesystem_executable:
         raise SystemExit(f"release manifest has an unlisted executable inventory record: {relative}")
 
 capsules = manifest.get("capsules")
@@ -572,6 +581,13 @@ for binary in "${runtime_binaries[@]}"; do
   install -m 0755 "$runtime_root/$binary" "$work/$root/runtime/bin/$binary"
 done
 
+if [[ "$target" == *-apple-darwin ]]; then
+  filesystem_requirement=optional
+  [[ "$runtime_version" != 2026.9.0 ]] || filesystem_requirement=required
+  python3 "$repo_root/scripts/package_macos_filesystem.py" \
+    "$runtime_root" "$work/$root/runtime/bin" "$filesystem_requirement"
+fi
+
 python3 "$repo_root/scripts/capsule_release.py" --print-assets > "$work/$root/capsule-assets.txt"
 chmod 0600 "$work/$root/capsule-assets.txt"
 while IFS= read -r capsule; do
@@ -609,6 +625,14 @@ for binary in "${runtime_binaries[@]}"; do
   record_release_file "runtime/bin/$binary" 755
 done
 record_release_file capsule-assets.txt 600
+if [[ -d "$work/$root/runtime/bin/AstridFS.app" ]]; then
+  while IFS= read -r -d '' member; do
+    relative=${member#"$work/$root/"}
+    mode=$(stat -c '%a' "$member" 2>/dev/null || stat -f '%Lp' "$member")
+    record_release_file "$relative" "$mode"
+  done < <(find "$work/$root/runtime/bin/AstridFS.app" \
+    "$work/$root/runtime/bin/macos" -type f -print0)
+fi
 record_release_file Distro.toml 600
 if [[ "$distro_signing" = yes ]]; then
   record_release_file Distro.lock 600

--- a/scripts/package_macos_filesystem.py
+++ b/scripts/package_macos_filesystem.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Carry the upstream signed filesystem bundle without modifying its contents."""
+
+from pathlib import Path
+import shutil
+import sys
+
+
+def stage(source: Path, destination: Path, required: bool) -> None:
+    app = source / "AstridFS.app"
+    if not app.exists() and not app.is_symlink():
+        if required:
+            raise ValueError("Darwin runtime archive is missing AstridFS.app")
+        return
+    if not app.is_dir() or app.is_symlink():
+        raise ValueError("AstridFS.app must be a regular directory")
+    scripts = [source / "macos" / name for name in (
+        "manage-macos-fskit.sh", "validate-macos-fskit.sh",
+    )]
+    required_members = [app / name for name in (
+        "Contents/Info.plist", "Contents/MacOS/AstridFS",
+        "Contents/_CodeSignature/CodeResources",
+        "Contents/Extensions/AstridFSAppEx.appex/Contents/Info.plist",
+        "Contents/Extensions/AstridFSAppEx.appex/Contents/MacOS/AstridFSAppEx",
+        "Contents/Extensions/AstridFSAppEx.appex/Contents/_CodeSignature/CodeResources",
+    )]
+    for member in [*required_members, *scripts]:
+        if not member.is_file() or member.is_symlink():
+            raise ValueError(f"missing filesystem bundle member: {member}")
+    for member in app.rglob("*"):
+        if member.is_symlink() or not (member.is_dir() or member.is_file()):
+            raise ValueError(f"unsupported filesystem bundle member: {member}")
+    destination.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(app, destination / "AstridFS.app", copy_function=shutil.copy2)
+    (destination / "macos").mkdir()
+    for script in scripts:
+        shutil.copy2(script, destination / "macos" / script.name)
+    shutil.copy2(Path(__file__).with_name("aos-filesystem.sh"),
+                 destination / "macos" / "aos-filesystem.sh")
+
+
+if __name__ == "__main__":
+    stage(Path(sys.argv[1]), Path(sys.argv[2]), sys.argv[3] == "required")

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -295,6 +295,9 @@ do
   cp "$runtime_root/$source_binary" "$darwin_runtime_root/$binary"
   chmod 755 "$darwin_runtime_root/$binary"
 done
+PYTHONPATH="$repo_root/scripts" python3 -c \
+  'from pathlib import Path; import sys; from test_package_macos_filesystem import fixture; fixture(Path(sys.argv[1]))' \
+  "$darwin_runtime_root"
 COPYFILE_DISABLE=1 tar -czf "$work/darwin-runtime.tar.gz" \
   -C "$work" "$(basename "$darwin_runtime_root")"
 bash "$repo_root/scripts/package-release.sh" \
@@ -343,10 +346,15 @@ HOME="$darwin_home" \
 AOS_TEST_FIXTURE="$darwin_fixture" \
 AOS_TEST_UNAME_S=Darwin \
 AOS_TEST_UNAME_M=arm64 \
+AOS_TEST_FSKIT_LOG="$work/fskit-calls" \
+ASTRID_FSKIT_APP_DEST="$work/AOS.app" \
 AOS_TEST_COSIGN_SHA256=94b42a9e697be95675f6160ab031a9a5f1ec1e646d6f648d7b2f5cd59ececbc5 \
 AOS_VERSION=2026.9.0 \
 sh "$repo_root/install.sh" --yes --no-migrate-prompt >/dev/null
 darwin_release_dir="$darwin_home/.aos/releases/2026.9.0"
+diff -r "$darwin_runtime_root/AstridFS.app" "$darwin_release_dir/runtime/bin/AstridFS.app"
+grep -Fx "$work/AOS.app|install" "$work/fskit-calls"
+grep -Fx "$work/AOS.app|enable" "$work/fskit-calls"
 for binary in \
   astrid astrid-daemon astrid-build astrid-emit \
   astrid-storage-provider-fskit

--- a/scripts/test-package-release.sh
+++ b/scripts/test-package-release.sh
@@ -508,6 +508,9 @@ do
   cp "$runtime_root/$source_binary" "$darwin_runtime_root/$binary"
   chmod 755 "$darwin_runtime_root/$binary"
 done
+PYTHONPATH="$repo_root/scripts" python3 -c \
+  'from pathlib import Path; import sys; from test_package_macos_filesystem import fixture; fixture(Path(sys.argv[1]))' \
+  "$darwin_runtime_root"
 COPYFILE_DISABLE=1 tar -czf "$work/darwin-runtime.tar.gz" \
   -C "$work" "$(basename "$darwin_runtime_root")"
 
@@ -525,6 +528,15 @@ mkdir "$darwin_extract"
 tar -xzf "$darwin_archive" -C "$darwin_extract"
 darwin_bundle="$darwin_extract/unicity-aos-$product_version-$darwin_target"
 darwin_provider="$darwin_bundle/runtime/bin/astrid-storage-provider-fskit"
+diff -r "$darwin_runtime_root/AstridFS.app" "$darwin_bundle/runtime/bin/AstridFS.app"
+test -f "$darwin_bundle/runtime/bin/macos/aos-filesystem.sh"
+python3 - "$darwin_bundle/release-manifest.json" <<'PY'
+import json, sys
+with open(sys.argv[1]) as source:
+    members = json.load(source)["release_files"]
+assert "runtime/bin/AstridFS.app/Contents/_CodeSignature/CodeResources" in members
+assert "runtime/bin/macos/aos-filesystem.sh" in members
+PY
 test -x "$darwin_provider"
 test "$(stat -c '%a' "$darwin_provider" 2>/dev/null || stat -f '%Lp' "$darwin_provider")" = 755
 python3 - "$darwin_bundle/release-manifest.json" "$darwin_provider" <<'PY'

--- a/scripts/test_gnu_build_packages.py
+++ b/scripts/test_gnu_build_packages.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Exercise package-source scope, argument forwarding and update failure."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).parent / "ci/install_gnu_build_packages.sh"
+
+
+class PackageSetupTests(unittest.TestCase):
+    def run_setup(self, fail_update=False):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "calls.jsonl"
+            apt = root / "apt-get"
+            apt.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, pathlib, sys\n"
+                "args = sys.argv[1:]\n"
+                "source = next(a.split('=', 1)[1] for a in args "
+                "if a.startswith('Dir::Etc::sourcelist='))\n"
+                "with open(os.environ['APT_TEST_LOG'], 'a') as log:\n"
+                " log.write(json.dumps({'args': args, 'path': source, "
+                "'sources': pathlib.Path(source).read_text()}) + '\\n')\n"
+                "if 'update' in args and os.environ['APT_TEST_FAIL'] == '1': "
+                "sys.exit(100)\n"
+            )
+            apt.chmod(0o755)
+            env = dict(os.environ, PATH=f"{root}:{os.environ['PATH']}",
+                       APT_TEST_LOG=str(log), APT_TEST_FAIL=str(int(fail_update)))
+            result = subprocess.run(
+                ["bash", str(SCRIPT), "cmake", "gcc-aarch64-linux-gnu"],
+                env=env, check=False,
+            )
+            calls = [json.loads(line) for line in log.read_text().splitlines()]
+            for call in calls:
+                self.assertFalse(Path(call["path"]).exists(), "temporary source leaked")
+            return result.returncode, calls
+
+    def test_signed_snapshot_sources_and_forwarded_packages(self):
+        code, calls = self.run_setup()
+        self.assertEqual(code, 0)
+        self.assertEqual(len(calls), 2)
+        for call in calls:
+            self.assertIn("Dir::Etc::sourceparts=-", call["args"])
+            self.assertNotIn("--allow-unauthenticated", call["args"])
+            lines = call["sources"].splitlines()
+            self.assertEqual(len(lines), 2)
+            for line in lines:
+                self.assertIn("https://snapshot.debian.org/archive/", line)
+                self.assertIn("/20260901T000000Z/", line)
+                self.assertIn("[check-valid-until=no]", line)
+                self.assertNotIn("trusted=yes", line)
+        self.assertEqual(calls[0]["sources"], calls[1]["sources"])
+        self.assertEqual(calls[1]["args"][-5:],
+                         ["install", "-y", "--no-install-recommends",
+                          "cmake", "gcc-aarch64-linux-gnu"])
+
+    def test_failed_update_never_installs(self):
+        code, calls = self.run_setup(fail_update=True)
+        self.assertEqual(code, 100)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["args"][-1], "update")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_package_macos_filesystem.py
+++ b/scripts/test_package_macos_filesystem.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Packaging fixtures prove byte preservation, not Apple signature validity."""
+
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+import unittest
+
+from package_macos_filesystem import stage
+
+
+def fixture(root: Path) -> None:
+    for prefix, binary in (
+        ("AstridFS.app", "AstridFS"),
+        ("AstridFS.app/Contents/Extensions/AstridFSAppEx.appex", "AstridFSAppEx"),
+    ):
+        for name in ("Info.plist", f"MacOS/{binary}", "_CodeSignature/CodeResources"):
+            path = root / prefix / "Contents" / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(f"fixture-only:{prefix}:{name}".encode())
+            path.chmod(0o755 if name.startswith("MacOS/") else 0o644)
+    for name in ("manage-macos-fskit.sh", "validate-macos-fskit.sh"):
+        path = root / "macos" / name
+        path.parent.mkdir(exist_ok=True)
+        path.write_text('#!/bin/sh\n[ -z "${AOS_TEST_FSKIT_LOG:-}" ] || printf "%s|%s\\n" "$ASTRID_FSKIT_APP_DEST" "$1" >> "$AOS_TEST_FSKIT_LOG"\n')
+        path.chmod(0o755)
+
+
+class PackagingTests(unittest.TestCase):
+    def test_preserves_every_member_and_mode(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source, output = root / "source", root / "output"
+            fixture(source)
+            stage(source, output, True)
+            for path in source.rglob("*"):
+                if path.is_file():
+                    copied = output / path.relative_to(source)
+                    self.assertEqual(path.read_bytes(), copied.read_bytes())
+                    self.assertEqual(path.stat().st_mode, copied.stat().st_mode)
+            log = root / "calls"
+            subprocess.run(["/bin/sh", str(output / "macos/aos-filesystem.sh"), "install"],
+                           check=True, env={**os.environ, "AOS_TEST_FSKIT_LOG": str(log),
+                                            "ASTRID_FSKIT_APP_DEST": str(root / "AOS.app")})
+            self.assertEqual(log.read_text(), f"{root}/AOS.app|install\n")
+
+    def test_missing_required_app(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            with self.assertRaises(ValueError):
+                stage(root / "source", root / "output", True)
+            stage(root / "source", root / "output", False)
+            self.assertFalse((root / "output").exists())
+
+    def test_existing_destination_validation_failure_stops_install(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture(root / "source")
+            stage(root / "source", root / "output", True)
+            destination = root / "AOS.app"
+            destination.mkdir()
+            manager = root / "output/macos/manage-macos-fskit.sh"
+            manager.write_text('#!/bin/sh\n[ "$1" != validate ] || exit 19\nexit 0\n')
+            result = subprocess.run(
+                ["/bin/sh", str(root / "output/macos/aos-filesystem.sh"), "install"],
+                env={**os.environ, "ASTRID_FSKIT_APP_DEST": str(destination)},
+                check=False,
+            )
+            self.assertEqual(result.returncode, 19)
+
+    def test_rejects_missing_signature_and_links(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fixture(root / "source")
+            signature = root / "source/AstridFS.app/Contents/_CodeSignature/CodeResources"
+            signature.unlink()
+            with self.assertRaises(ValueError):
+                stage(root / "source", root / "output", True)
+            signature.symlink_to(root / "outside")
+            with self.assertRaises(ValueError):
+                stage(root / "source", root / "output", True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Carry the signed Astrid filesystem app through Darwin AOS packaging and install it through the common base installer used by website and Oracle bootstrap paths.

## Changes

- Preserve upstream app/extension bytes, signatures and modes; include management scripts and member digests in the release archive.
- Require the app for the 2026.9.0 Darwin runtime; retain older fixture/runtime compatibility.
- Add an AOS wrapper using /Applications/AOS.app for new installations, without modifying signed internal names or identities. Reuse an existing AstridFS.app to avoid duplicate provider registration; refuse ambiguous defaults and validate existing destinations.
- Install and request enablement through the common installer. Report incomplete OS approval/setup with a nonzero result and retry commands; retain the installed runtime. No automatic sudo or unsigned fallback.
- Keep a future tray/control-center UI out of this change.

- Use signed, dated Bullseye package snapshots in CI and release builds to preserve the glibc 2.31 baseline after the live security repository expired.

## Verification

- `python3 scripts/test_gnu_build_packages.py`: 2 tests pass; failed APT updates stop installation and signature verification remains enabled.
- `python3 scripts/test_package_macos_filesystem.py`: 4 tests pass.
- `bash scripts/test-package-release.sh`: passes, including app byte preservation and inventory coverage.
- `bash scripts/test-install.sh`: passes, including Darwin app preservation and install/enable dispatch.
- `shellcheck scripts/aos-filesystem.sh`, shell syntax, actionlint and diff checks pass.
- Read-only source copy of the locally installed app retained a valid codesign after staging and an outer rename to AOS.app. The local source lacks a stapled ticket: this is byte/signature preservation evidence, not production notarization certification.

## Test Plan

Run hosted product contracts. During authorized production release, verify the actual signed/notarized Astrid archive and clean-host install/enable/mount. Unit fixtures do not assert Apple trust. The deployed website base installer must be refreshed with this version; existing AOS installs need an upgrade.

## AI / Tool Assistance

Assisted-by: Codex:Astra

Implementation and tests were checked against upstream manager contracts and the common installer path. Commits are GPG-signed with DCO.
