### PR TITLE
fix(bootstrap): resume bounded Community initialization batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ implementations are consolidated into their final behavior.
 
 ## [Unreleased]
 
+### Fixed
+
+- Complete Community initialization in one AOS invocation by resuming the
+  runtime's bounded installation batches without reinstalling completed capsules.
+
 ## [2026.9.0] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ implementations are consolidated into their final behavior.
 ### Fixed
 
 - Complete Community initialization in one AOS invocation by resuming the
-  runtime's bounded installation batches without reinstalling completed capsules.
+  runtime's bounded installation batches without reinstalling completed capsules,
+  then finalizing the default system fleet's capsule grants.
 
 ## [2026.9.0] - 2026-09-09
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ aos init
 ```
 
 `aos init`, including `aos init --offline`, provisions from those local,
-product-versioned capsule assets. Re-running the installer performs a
+product-versioned capsule assets. A fresh Community installation automatically
+resumes Astrid's ten-capsule batches after each rate-limit window; installing
+all 22 capsules includes approximately two minutes of waiting. Completed
+installs are not repeated, and a stalled batch remains an error.
+Re-running the installer performs a
 coordinated product upgrade without
 rewriting a standalone runtime installation. Every release publishes
 checksums, Sigstore bundles, GitHub build-provenance attestations, and

--- a/crates/unicity-aos-bootstrap/examples/init_provenance.rs
+++ b/crates/unicity-aos-bootstrap/examples/init_provenance.rs
@@ -1,0 +1,22 @@
+//! Read-only release-test probe for the daemon-owned distro lock.
+
+use astrid_core::PrincipalId;
+use astrid_core::kernel_api::{AdminRequestKind, AdminResponseBody};
+use astrid_uplink::admin_client::AdminClient;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let principal = PrincipalId::default();
+    let mut client = AdminClient::connect(principal.clone()).await?;
+    match client
+        .request(AdminRequestKind::DistroLockGet { principal })
+        .await?
+    {
+        AdminResponseBody::DistroLock(lock) => {
+            let lock = lock.ok_or("default principal has no durable distro provenance")?;
+            println!("{}", serde_json::to_string(&lock)?);
+            Ok(())
+        }
+        response => Err(format!("unexpected distro provenance response: {response:?}").into()),
+    }
+}

--- a/crates/unicity-aos-bootstrap/src/init_resume.rs
+++ b/crates/unicity-aos-bootstrap/src/init_resume.rs
@@ -10,6 +10,19 @@ use std::time::Duration;
 const INSTALL_BATCH: usize = 10;
 const INSTALL_WINDOW: Duration = Duration::from_secs(61);
 
+// The preparation pass always installs the embedded fleet for default, not
+// the caller's Oracle principal. Do not extend host-specific grant sets here.
+pub(super) fn grant_args(assets: &[String]) -> Vec<String> {
+    let mut args = ["--principal", "default", "agent", "modify", "default"]
+        .map(str::to_owned)
+        .to_vec();
+    for asset in assets {
+        args.push("--add-capsule".to_owned());
+        args.push(asset.trim_end_matches(".capsule").to_owned());
+    }
+    args
+}
+
 pub(super) fn initialize(mut command: Command, expected: usize) -> io::Result<()> {
     resume(
         expected,
@@ -97,6 +110,24 @@ fn partial_progress(stderr: &str) -> Option<(usize, usize)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn final_grant_uses_only_the_embedded_default_fleet() {
+        assert_eq!(
+            grant_args(&["aos-cli.capsule".into(), "aos-mcp.capsule".into()]),
+            [
+                "--principal",
+                "default",
+                "agent",
+                "modify",
+                "default",
+                "--add-capsule",
+                "aos-cli",
+                "--add-capsule",
+                "aos-mcp"
+            ]
+        );
+    }
 
     fn partial(completed: usize) -> (bool, String) {
         (

--- a/crates/unicity-aos-bootstrap/src/init_resume.rs
+++ b/crates/unicity-aos-bootstrap/src/init_resume.rs
@@ -1,0 +1,166 @@
+//! Complete Astrid's bounded installer batches without reimplementing receipts.
+
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+// Astrid 2026.9.0's InstallCapsule protocol allows ten requests per minute.
+// This is compatibility with that published contract, not a new AOS limit.
+const INSTALL_BATCH: usize = 10;
+const INSTALL_WINDOW: Duration = Duration::from_secs(61);
+
+pub(super) fn initialize(mut command: Command, expected: usize) -> io::Result<()> {
+    resume(
+        expected,
+        || run_pass(&mut command),
+        || {
+            eprintln!(
+                "aos: continuing capsule installation after the runtime's rate-limit window..."
+            );
+            std::thread::sleep(INSTALL_WINDOW);
+        },
+    )
+}
+
+fn run_pass(command: &mut Command) -> io::Result<(bool, String)> {
+    let path = std::env::temp_dir().join(format!("aos-init-{}.log", uuid::Uuid::new_v4()));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options.open(&path)?;
+    // File-backed stderr avoids waiting for EOF from an inherited daemon pipe.
+    let result = (|| {
+        let status = command.stderr(Stdio::from(file)).status()?;
+        let stderr = fs::read_to_string(&path)?;
+        io::stderr().write_all(stderr.as_bytes())?;
+        Ok((status.success(), stderr))
+    })();
+    let _ = fs::remove_file(path);
+    result
+}
+
+fn resume(
+    expected: usize,
+    mut run: impl FnMut() -> io::Result<(bool, String)>,
+    mut wait: impl FnMut(),
+) -> io::Result<()> {
+    let mut previous = 0;
+    // At most ceil(N/10) incomplete passes plus a final successful pass.
+    // A partial existing installation may consume less than the first batch.
+    let max_passes = expected.div_ceil(INSTALL_BATCH) + 1;
+    for pass in 0..max_passes {
+        let (success, stderr) = run()?;
+        if success {
+            return Ok(());
+        }
+        let Some((completed, total)) = partial_progress(&stderr) else {
+            return Err(io::Error::other(
+                "bundled CE system-fleet initializer exited unsuccessfully; see runtime error above",
+            ));
+        };
+        if total != expected || completed <= previous || completed >= total {
+            return Err(io::Error::other(
+                "bundled CE initializer made no valid progress",
+            ));
+        }
+        previous = completed;
+        if pass + 1 == max_passes {
+            break;
+        }
+        wait();
+    }
+    Err(io::Error::other(
+        "bundled CE initializer exceeded its bounded resume passes",
+    ))
+}
+
+fn partial_progress(stderr: &str) -> Option<(usize, usize)> {
+    // Only the pinned CLI's explicit partial-batch result can be resumed.
+    // Ordinary package, validation or lifecycle failures must remain errors.
+    if stderr.contains("Failed to install ") || stderr.contains("Configuration for ") {
+        return None;
+    }
+    let (_, message) = stderr.rsplit_once("Installation incomplete: ")?;
+    let (counts, suffix) = message.split_once(" capsule(s) installed")?;
+    if !suffix.contains("re-run `astrid init` to retry the rest.") {
+        return None;
+    }
+    let (completed, total) = counts.split_once('/')?;
+    Some((completed.parse().ok()?, total.parse().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn partial(completed: usize) -> (bool, String) {
+        (
+            false,
+            format!(
+                "Installation incomplete: {completed}/22 capsule(s) installed — re-run `astrid init` to retry the rest."
+            ),
+        )
+    }
+
+    #[test]
+    fn completes_ten_ten_two_in_one_product_invocation() {
+        let mut passes = [partial(10), partial(20), (true, String::new())].into_iter();
+        let mut waits = 0;
+        resume(22, || Ok(passes.next().unwrap()), || waits += 1).unwrap();
+        assert_eq!(waits, 2);
+        assert!(passes.next().is_none());
+    }
+
+    #[test]
+    fn complete_install_never_waits() {
+        resume(
+            22,
+            || Ok((true, String::new())),
+            || panic!("unexpected wait"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn stalled_resume_stops_instead_of_looping() {
+        let mut calls = 0;
+        assert!(
+            resume(
+                22,
+                || {
+                    calls += 1;
+                    Ok(partial(10))
+                },
+                || {}
+            )
+            .is_err()
+        );
+        assert_eq!(calls, 2);
+    }
+
+    #[test]
+    fn package_failure_is_not_treated_as_batch_exhaustion() {
+        let (_, partial) = partial(10);
+        let error = format!("Failed to install aos-shell: invalid signature\n{partial}");
+        assert!(
+            resume(
+                22,
+                || Ok((false, error.clone())),
+                || panic!("unexpected wait")
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_inventory_and_unrelated_errors() {
+        assert!(resume(23, || Ok(partial(10)), || panic!("unexpected wait")).is_err());
+        assert!(partial_progress("connection refused").is_none());
+        assert!(partial_progress("Installation incomplete: 10/22 capsule(s) installed").is_none());
+    }
+}

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -230,7 +230,8 @@ impl AosHome {
     /// A completely fresh Astrid home has no capsule capable of accepting CLI
     /// connections. Astrid installs through the daemon in bounded batches.
     /// Resume partial batches after the kernel's rate-limit window, leaving
-    /// completed-install detection and grants to Astrid itself.
+    /// completed-install detection to Astrid itself. Finalize the default
+    /// system fleet's grants through Astrid's idempotent admin command.
     ///
     /// # Errors
     /// Returns an error when the bundled runtime or exact CE capsule set is
@@ -241,10 +242,17 @@ impl AosHome {
         S: AsRef<OsStr>,
     {
         self.ensure_runtime_available()?;
-        init_resume::initialize(
-            self.runtime_command_with_args(args)?,
-            capsule_assets_from_manifest()?.len(),
-        )
+        let assets = capsule_assets_from_manifest()?;
+        init_resume::initialize(self.runtime_command_with_args(args)?, assets.len())?;
+        let status = self
+            .runtime_command_with_args(init_resume::grant_args(&assets))?
+            .status()?;
+        if !status.success() {
+            return Err(io::Error::other(
+                "CE capsules installed but default fleet grant failed",
+            ));
+        }
+        Ok(())
     }
 
     /// The conventional standalone Astrid Runtime home that first-run AOS can offer

--- a/crates/unicity-aos-bootstrap/src/lib.rs
+++ b/crates/unicity-aos-bootstrap/src/lib.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus};
 
 pub mod health;
+mod init_resume;
 mod migration;
 pub mod status;
 pub use migration::{LegacyDistro, MigrationOutcome};
@@ -227,10 +228,9 @@ impl AosHome {
     /// daemon-backed grant preflight.
     ///
     /// A completely fresh Astrid home has no capsule capable of accepting CLI
-    /// connections. The first pass uses Astrid's normal distro initializer to
-    /// install the release-pinned CE fleet under `default` without starting the
-    /// daemon. The requested init can then boot Astrid, authorize its operator,
-    /// and apply grants through the normal kernel path.
+    /// connections. Astrid installs through the daemon in bounded batches.
+    /// Resume partial batches after the kernel's rate-limit window, leaving
+    /// completed-install detection and grants to Astrid itself.
     ///
     /// # Errors
     /// Returns an error when the bundled runtime or exact CE capsule set is
@@ -241,21 +241,10 @@ impl AosHome {
         S: AsRef<OsStr>,
     {
         self.ensure_runtime_available()?;
-        let status = self
-            .runtime_command_with_args(args)?
-            .status()
-            .map_err(|error| {
-                io::Error::new(
-                    error.kind(),
-                    format!("failed to initialize the bundled CE system fleet: {error}"),
-                )
-            })?;
-        if !status.success() {
-            return Err(io::Error::other(format!(
-                "bundled CE system-fleet initializer exited with {status}"
-            )));
-        }
-        Ok(())
+        init_resume::initialize(
+            self.runtime_command_with_args(args)?,
+            capsule_assets_from_manifest()?.len(),
+        )
     }
 
     /// The conventional standalone Astrid Runtime home that first-run AOS can offer

--- a/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
+++ b/crates/unicity-aos-bootstrap/tests/cli_boundary.rs
@@ -896,6 +896,20 @@ fn product_init_stops_before_runtime_dispatch_when_system_fleet_init_fails() {
 }
 
 #[test]
+fn product_init_stops_when_default_fleet_grant_fails() {
+    let fixture = Fixture::new("init-grant-failure");
+    fixture.install_runtime(&RECORDING_RUNTIME.replace(
+        "if [ \"$1\" = \"start\" ]; then",
+        "if [ \"$1\" = \"--principal\" ] && [ \"$3\" = \"agent\" ]; then\nexit 42\nelif [ \"$1\" = \"start\" ]; then",
+    ));
+    let output = fixture.command().arg("init").output().expect("run init");
+    assert!(!output.status.success());
+    assert!(fixture.bootstrap_args.exists());
+    assert!(!fixture.args.exists());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("default fleet grant failed"));
+}
+
+#[test]
 fn product_non_default_init_delegates_principal_and_capsule_grants() {
     let fixture = Fixture::new("init-principal");
     fixture.install_runtime(RECORDING_RUNTIME);

--- a/scripts/test-clean-home-init.sh
+++ b/scripts/test-clean-home-init.sh
@@ -90,10 +90,11 @@ manifest="$aos_home/distributions/unicity-ce/Distro.toml"
 run_aos agent show default --format json > "$work/default.before.json"
 snapshot_provenance > "$work/distro.before.json"
 
-python3 - "$bundle/capsule-assets.txt" "$work/default.before.json" "$work/distro.before.json" <<'PY'
+python3 - "$bundle/capsule-assets.txt" "$aos_home/runtime/etc/profiles/default.toml" "$work/distro.before.json" <<'PY'
 import json
 import pathlib
 import sys
+import tomllib
 
 assets_path, profile_path, lock_path = map(pathlib.Path, sys.argv[1:])
 expected = sorted(
@@ -103,13 +104,13 @@ expected = sorted(
 )
 if len(expected) != 22 or len(set(expected)) != 22:
     raise SystemExit("release capsule inventory is not the exact 22-capsule CE set")
-profile = json.loads(profile_path.read_text())
+profile = tomllib.loads(profile_path.read_text())
 lock = json.loads(lock_path.read_text())
 if lock.get("distro_id") != "unicity-ce":
     raise SystemExit("default principal has no CE distro provenance")
 if sorted(item["name"] for item in lock["capsules"]) != expected:
     raise SystemExit("durable distro provenance does not bind the exact release capsule set")
-granted = sorted(profile.get("grants", []))
+granted = sorted(profile.get("capsules", []))
 if granted != expected:
     raise SystemExit("default principal was not granted the exact release capsule set")
 PY
@@ -170,9 +171,15 @@ import fcntl
 import pathlib
 import sys
 
-with open(sys.argv[1], "r+b", buffering=0) as lock:
-    fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    fcntl.flock(lock, fcntl.LOCK_UN)
+lock_path = pathlib.Path(sys.argv[1])
+if lock_path.is_symlink():
+    raise SystemExit("stopped runtime lock is a symlink")
+# Successful retirement may remove the runtime lock entirely. If retained,
+# it must be unlocked; process exit and transient-marker checks precede this.
+if lock_path.exists():
+    with lock_path.open("r+b", buffering=0) as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(lock, fcntl.LOCK_UN)
 runtime = pathlib.Path(sys.argv[2])
 if sorted(path.name for path in runtime.iterdir()) != ["astrid.volume"]:
     raise SystemExit("stopped AOS runtime is not exactly astrid.volume")

--- a/scripts/test-clean-home-init.sh
+++ b/scripts/test-clean-home-init.sh
@@ -7,6 +7,12 @@ if [[ $# -ne 1 ]]; then
 fi
 
 bundle=$(cd "$1" && pwd -P)
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cargo build --locked --manifest-path "$repo_root/Cargo.toml" \
+  -p unicity-aos-bootstrap --example init_provenance
+target_dir=$(cargo metadata --locked --manifest-path "$repo_root/Cargo.toml" \
+  --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')
+provenance_probe="$target_dir/debug/examples/init_provenance"
 for required in bin/aos runtime/bin/astrid runtime/bin/astrid-daemon Distro.toml capsule-assets.txt; do
   [[ -f "$bundle/$required" && ! -L "$bundle/$required" ]] || {
     echo "clean-home init bundle is missing $required" >&2
@@ -18,7 +24,7 @@ done
   exit 1
 }
 
-work=$(mktemp -d)
+work=$(mktemp -d /tmp/aosinit.XXXXXX)
 aos_home="$work/user/.aos"
 project="$work/project"
 mkdir -p "$project"
@@ -32,6 +38,11 @@ run_aos() {
       UNICITY_AOS_CAPSULE_DIR="$bundle/capsules" \
       "$bundle/bin/aos" "$@"
   )
+}
+
+snapshot_provenance() {
+  ASTRID_HOME="$aos_home/runtime" ASTRID_RUN_DIR="$aos_home/run" \
+    "$provenance_probe"
 }
 
 assert_exact_ready_capsules() {
@@ -74,21 +85,17 @@ trap cleanup EXIT
 
 run_aos init --offline --yes --var openai_api_key=release-gate-not-a-real-key
 
-lock="$aos_home/runtime/home/default/.config/distro.lock"
-profile="$aos_home/runtime/etc/profiles/default.toml"
 manifest="$aos_home/distributions/unicity-ce/Distro.toml"
-[[ -f "$lock" && -f "$profile" && -f "$manifest" ]]
+[[ -f "$manifest" ]]
+run_aos agent show default --format json > "$work/default.before.json"
+snapshot_provenance > "$work/distro.before.json"
 
-python3 - "$bundle/capsule-assets.txt" "$lock" "$profile" <<'PY'
+python3 - "$bundle/capsule-assets.txt" "$work/default.before.json" "$work/distro.before.json" <<'PY'
+import json
 import pathlib
 import sys
 
-try:
-    import tomllib
-except ModuleNotFoundError:
-    import tomli as tomllib
-
-assets_path, lock_path, profile_path = map(pathlib.Path, sys.argv[1:])
+assets_path, profile_path, lock_path = map(pathlib.Path, sys.argv[1:])
 expected = sorted(
     line[:-len(".capsule")] if line.endswith(".capsule") else line
     for line in assets_path.read_text(encoding="utf-8").splitlines()
@@ -96,16 +103,13 @@ expected = sorted(
 )
 if len(expected) != 22 or len(set(expected)) != 22:
     raise SystemExit("release capsule inventory is not the exact 22-capsule CE set")
-with lock_path.open("rb") as file:
-    lock = tomllib.load(file)
-with profile_path.open("rb") as file:
-    profile = tomllib.load(file)
-if lock.get("distro", {}).get("id") != "unicity-ce":
-    raise SystemExit("clean home did not receive the Unicity CE distro lock")
-locked = sorted(item["name"] for item in lock.get("capsule", []))
-granted = sorted(profile.get("capsules", []))
-if locked != expected:
-    raise SystemExit("Distro.lock does not bind the exact release capsule set")
+profile = json.loads(profile_path.read_text())
+lock = json.loads(lock_path.read_text())
+if lock.get("distro_id") != "unicity-ce":
+    raise SystemExit("default principal has no CE distro provenance")
+if sorted(item["name"] for item in lock["capsules"]) != expected:
+    raise SystemExit("durable distro provenance does not bind the exact release capsule set")
+granted = sorted(profile.get("grants", []))
 if granted != expected:
     raise SystemExit("default principal was not granted the exact release capsule set")
 PY
@@ -113,19 +117,26 @@ PY
 assert_exact_ready_capsules
 run_aos doctor
 
-cp "$lock" "$work/distro.lock.before"
-cp "$profile" "$work/default.toml.before"
-pid_file="$aos_home/runtime/run/system.pid"
-cli_meta="$aos_home/runtime/home/default/.local/capsules/aos-cli/meta.json"
+pid_file="$aos_home/run/system.pid"
 [[ -f "$pid_file" && ! -L "$pid_file" ]]
-[[ -f "$cli_meta" && ! -L "$cli_meta" ]]
 cp "$pid_file" "$work/system.pid.before"
-cp "$cli_meta" "$work/cli-meta.json.before"
+run_aos capsule show aos-cli --format json > "$work/cli-meta.before.json"
 run_aos init --offline --yes --var openai_api_key=release-gate-not-a-real-key
-cmp "$work/distro.lock.before" "$lock"
-cmp "$work/default.toml.before" "$profile"
+snapshot_provenance > "$work/distro.after.json"
+python3 - "$work/distro.before.json" "$work/distro.after.json" <<'PY'
+import json
+import pathlib
+import sys
+before, after = [json.loads(pathlib.Path(path).read_text()) for path in sys.argv[1:]]
+for key in ("distro_id", "distro_version", "capsules", "manifest_hash"):
+    if before.get(key) != after.get(key):
+        raise SystemExit(f"reinitialization changed distro provenance: {key}")
+PY
+run_aos agent show default --format json > "$work/default.after.json"
+run_aos capsule show aos-cli --format json > "$work/cli-meta.after.json"
+cmp "$work/default.before.json" "$work/default.after.json"
 cmp "$work/system.pid.before" "$pid_file"
-cmp "$work/cli-meta.json.before" "$cli_meta"
+cmp "$work/cli-meta.before.json" "$work/cli-meta.after.json"
 assert_exact_ready_capsules
 
 [[ -d "$project/.aos" ]]
@@ -151,16 +162,20 @@ if kill -0 "$daemon_pid" 2>/dev/null; then
   exit 1
 fi
 for transient in system.sock system.pid system.ready system.token; do
-  [[ ! -e "$aos_home/runtime/run/$transient" && ! -L "$aos_home/runtime/run/$transient" ]]
+  [[ ! -e "$aos_home/run/$transient" && ! -L "$aos_home/run/$transient" ]]
 done
 
-python3 - "$aos_home/runtime/run/system.lock" <<'PY'
+python3 - "$aos_home/run/system.lock" "$aos_home/runtime" <<'PY'
 import fcntl
+import pathlib
 import sys
 
 with open(sys.argv[1], "r+b", buffering=0) as lock:
     fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
     fcntl.flock(lock, fcntl.LOCK_UN)
+runtime = pathlib.Path(sys.argv[2])
+if sorted(path.name for path in runtime.iterdir()) != ["astrid.volume"]:
+    raise SystemExit("stopped AOS runtime is not exactly astrid.volume")
 PY
 
 echo "clean AOS home initialized, loaded, rechecked, and stopped successfully"


### PR DESCRIPTION
## Summary

Related to #154. Complete clean-home Community initialization using published Astrid v2026.9.0 unchanged.

- Resume explicit partial batches after the existing runtime rate-limit window, with increasing progress and bounded attempts; ordinary failures remain errors.
- Finalize the embedded default system fleet through the existing idempotent agent-modify grant command only after successful installation. Oracle principal subsets are not expanded.
- Read daemon-owned distro provenance in the release test; verify all 22 capsules, exact default grants, readiness, stable reinitialization, and volume-only shutdown.

## Verification

- Full packaged Darwin clean-home test PASS with unchanged published Astrid CLI/daemon and release capsule assets; only AOS was replaced with the candidate build.
- 73 library tests PASS; 42 CLI boundary tests PASS plus the new grant-failure regression PASS separately. Updated hosted Product native covers the full test set.
- All-target clippy, formatting, diff checks PASS.
- Exact head a1e702211393bfb29785e77625ac46c5c075abf0: all seven CI checks PASS, including GNU x86_64 and aarch64 smoke.

## Test Plan

The actual GNU packaged release gate must pass before publication. This does not retag or change published Astrid.

## AI / Tool Assistance

Assisted-by: Codex:Astra