### PR TITLE
fix(release): build clean-home probe in the GNU container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,10 @@ jobs:
               fi
               export CARGO_TARGET_DIR=/workspace/target/glibc-2.31
               cargo build --locked --release --target "$TARGET" -p unicity-aos-bootstrap
+              if [[ "$TARGET" == x86_64-unknown-linux-gnu ]]; then
+                cargo build --locked --release --target "$TARGET" \
+                  -p unicity-aos-bootstrap --example init_provenance
+              fi
             '
           AOS_BINARY="target/glibc-2.31/${{ matrix.target }}/release/aos"
           python3 scripts/check_glibc.py --max-version 2.34 "$AOS_BINARY"
@@ -306,7 +310,8 @@ jobs:
           mkdir "$RUNNER_TEMP/clean-home-bundle"
           tar -xzf "artifacts/unicity-aos-${GITHUB_REF_NAME}-${{ matrix.target }}.tar.gz" \
             -C "$RUNNER_TEMP/clean-home-bundle" --strip-components=1
-          scripts/test-clean-home-init.sh "$RUNNER_TEMP/clean-home-bundle"
+          scripts/test-clean-home-init.sh "$RUNNER_TEMP/clean-home-bundle" \
+            "$PWD/target/glibc-2.31/${{ matrix.target }}/release/examples/init_provenance"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aos-${{ matrix.target }}

--- a/scripts/test-clean-home-init.sh
+++ b/scripts/test-clean-home-init.sh
@@ -1,18 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-  echo "usage: $0 <extracted-product-bundle>" >&2
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "usage: $0 <extracted-product-bundle> [prebuilt-provenance-probe]" >&2
   exit 2
 fi
 
 bundle=$(cd "$1" && pwd -P)
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-cargo build --locked --manifest-path "$repo_root/Cargo.toml" \
-  -p unicity-aos-bootstrap --example init_provenance
-target_dir=$(cargo metadata --locked --manifest-path "$repo_root/Cargo.toml" \
-  --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')
-provenance_probe="$target_dir/debug/examples/init_provenance"
+if [[ $# -eq 2 ]]; then
+  # Release CI builds this in the same container as AOS. Do not compile into
+  # that container's root-owned target tree from the unprivileged host runner.
+  provenance_probe=$(cd "$(dirname "$2")" && pwd -P)/$(basename "$2")
+  [[ -f "$provenance_probe" && -x "$provenance_probe" && ! -L "$provenance_probe" ]] || {
+    echo "invalid prebuilt provenance probe: $provenance_probe" >&2
+    exit 1
+  }
+else
+  cargo build --locked --manifest-path "$repo_root/Cargo.toml" \
+    -p unicity-aos-bootstrap --example init_provenance
+  target_dir=$(cargo metadata --locked --manifest-path "$repo_root/Cargo.toml" \
+    --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])')
+  provenance_probe="$target_dir/debug/examples/init_provenance"
+fi
 for required in bin/aos runtime/bin/astrid runtime/bin/astrid-daemon Distro.toml capsule-assets.txt; do
   [[ -f "$bundle/$required" && ! -L "$bundle/$required" ]] || {
     echo "clean-home init bundle is missing $required" >&2

--- a/scripts/test_musl_release_workflow.py
+++ b/scripts/test_musl_release_workflow.py
@@ -2,8 +2,10 @@
 """Keep native musl production connected to signing and publication."""
 
 from pathlib import Path
+import os
 import re
 import subprocess
+import tempfile
 import unittest
 
 
@@ -13,6 +15,33 @@ ROOT = Path(__file__).resolve().parent.parent
 class MuslReleaseWorkflowTests(unittest.TestCase):
     def setUp(self):
         self.workflow = (ROOT / ".github/workflows/release.yml").read_text()
+
+    def test_gnu_clean_home_uses_container_built_probe(self):
+        build = self.workflow.split("- name: Build Linux product binary", 1)[1].split(
+            "- name: Build native static musl", 1)[0]
+        self.assertIn('-p unicity-aos-bootstrap --example init_provenance', build)
+        self.assertIn('if [[ "$TARGET" == x86_64-unknown-linux-gnu ]]', build)
+        test = self.workflow.split("- name: Test a clean Community Edition home", 1)[1]
+        self.assertIn('"$PWD/target/glibc-2.31/${{ matrix.target }}/release/examples/init_provenance"', test)
+
+    def test_prebuilt_probe_does_not_invoke_host_cargo(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            probe = root / "probe"
+            probe.write_text("#!/bin/sh\nexit 0\n")
+            probe.chmod(0o700)
+            cargo = root / "cargo"
+            marker = root / "cargo-invoked"
+            cargo.write_text(f'#!/bin/sh\ntouch "{marker}"\nexit 99\n')
+            cargo.chmod(0o700)
+            env = dict(os.environ, PATH=f"{root}:{os.environ['PATH']}")
+            result = subprocess.run(
+                ["bash", str(ROOT / "scripts/test-clean-home-init.sh"), str(root), str(probe)],
+                env=env, text=True, capture_output=True)
+            # Reach bundle validation without trying to write a host Cargo tree.
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("clean-home init bundle is missing bin/aos", result.stderr)
+            self.assertFalse(marker.exists())
 
     def test_native_architecture_matrix(self):
         build = self.workflow.split("\n  build:", 1)[1].split("\n  capsules:", 1)[0]


### PR DESCRIPTION
## Summary

Fix the x86_64 GNU release gate Permission denied creating target/debug. Docker creates the bind-mounted Cargo target as root; the clean-home test then tried compiling its probe as the unprivileged host runner.

Build init_provenance in the existing GNU container, sharing dependencies, and pass it to the clean-home test. Local tests retain the optional compile fallback. No runtime, capsule, version or signing changes.

## Verification

- Five workflow contract tests PASS, including executable regression proving a prebuilt probe skips host Cargo.
- Full packaged Darwin clean-home journey with the prebuilt probe PASS: 22 capsules, grants, health, reinitialization, and volume-only stop.
- Shell syntax and diff checks PASS.
- All seven exact-head CI checks PASS on 662b02c645f4748a442ea4880b4b1f975227f812.

## Test Plan

Rerun the GNU packaged release gate. No test is skipped and no elevated host test execution is introduced.

## AI / Tool Assistance

Assisted-by: Codex:Astra