### PR TITLE
fix(release): drain tar listing when checking Distro signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -494,7 +494,9 @@ jobs:
             exit 1
           }
           for asset in "${assets[@]}"; do
-            if tar -tzf "$asset" | grep -q '/Distro.sig$'; then
+            # Consume the full listing: grep -q closes early and makes tar fail
+            # with SIGPIPE under pipefail even when Distro.sig is present.
+            if tar -tzf "$asset" | grep '/Distro.sig$' > /dev/null; then
               continue
             fi
             signed="$RUNNER_TEMP/$(basename "$asset")"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -510,7 +510,7 @@ jobs:
           done
           signed_archives=0
           for asset in "${assets[@]}"; do
-            if tar -tzf "$asset" | grep -q '/Distro.sig$'; then
+            if tar -tzf "$asset" | grep '/Distro.sig$' > /dev/null; then
               signed_archives=$((signed_archives + 1))
             fi
           done

--- a/scripts/test_musl_release_workflow.py
+++ b/scripts/test_musl_release_workflow.py
@@ -6,6 +6,8 @@ import os
 import re
 import subprocess
 import tempfile
+import tarfile
+import textwrap
 import unittest
 
 
@@ -15,6 +17,24 @@ ROOT = Path(__file__).resolve().parent.parent
 class MuslReleaseWorkflowTests(unittest.TestCase):
     def setUp(self):
         self.workflow = (ROOT / ".github/workflows/release.yml").read_text()
+
+    def test_signed_archive_listing_drains_tar_and_rejects_missing_signature(self):
+        block = self.workflow.split("          signed_archives=0\n", 1)[1].split(
+            "      - name: Generate checksums", 1)[0]
+        script = 'set -euo pipefail\nassets=("$1")\nsigned_archives=0\n' + textwrap.dedent(block)
+        with tempfile.TemporaryDirectory() as temp:
+            for signed in (True, False):
+                archive = Path(temp) / f"bundle-{signed}.tar.gz"
+                with tarfile.open(archive, "w:gz") as tar:
+                    if signed:
+                        tar.addfile(tarfile.TarInfo("product/Distro.sig"))
+                    # Larger than a pipe buffer, with the signature first.
+                    for index in range(10000):
+                        tar.addfile(tarfile.TarInfo(f"product/capsules/member-{index:05d}"))
+                result = subprocess.run(["bash", "-c", script, "check", str(archive)],
+                                        text=True, capture_output=True)
+                self.assertEqual(result.returncode, 0 if signed else 1, result.stderr)
+                self.assertNotIn("write error", result.stderr)
 
     def test_gnu_clean_home_uses_container_built_probe(self):
         build = self.workflow.split("- name: Build Linux product binary", 1)[1].split(


### PR DESCRIPTION
## Summary

Fix false missing-Distro.sig failures in both pre-signing and post-signing archive checks. grep -q closes the pipe early; under pipefail a tar write failure makes an existing signature look absent.

Both checks now consume the complete listing. No product binary, signing identity, version, or test waiver.

## Verification

- Six workflow tests PASS locally.
- GNU/Linux Docker reproduction: actual post-signing workflow block PASS with the fix on a 10,000-member archive; old grep -q pipeline FAIL on that same signed fixture.
- Unsigned archive remains rejected.
- Shell syntax and diff checks PASS.

## Test Plan

Require updated-head CI before release retry. Preserve signing and publication gates.

## AI / Tool Assistance

Assisted-by: Codex:Astra