### PR TITLE
fix(system): inspect principal capsule metadata instead of private files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ implementations are consolidated into their final behavior.
 
 ### Fixed
 
+- Read principal-scoped loaded capsule metadata for system inspection instead
+  of an obsolete private capsule directory. Shared executable hashes remain
+  references; missing metadata is reported instead of silently omitted.
+
 - Complete Community initialization in one AOS invocation by resuming the
   runtime's bounded installation batches without reinstalling completed capsules,
   then finalizing the default system fleet's capsule grants.

--- a/capsules/capsule-system/Capsule.toml
+++ b/capsules/capsule-system/Capsule.toml
@@ -21,6 +21,7 @@ fs_read  = ["home://"]
 # Interceptor bindings: a [subscribe] entry's `handler` binds the topic to a
 # `#[astrid::interceptor]` export. The keys also serve as the subscribe ACL.
 [subscribe]
+"astrid.v1.capsules_loaded" = { wit = "opaque", handler = "receive_inventory" }
 "tool.v1.execute.list_capsules" = { wit = "@unicity-astrid/wit/types/tool-call", handler = "tool_execute_list_capsules" }
 "tool.v1.execute.inspect_capsule" = { wit = "@unicity-astrid/wit/types/tool-call", handler = "tool_execute_inspect_capsule" }
 "tool.v1.execute.list_interfaces" = { wit = "@unicity-astrid/wit/types/tool-call", handler = "tool_execute_list_interfaces" }

--- a/capsules/capsule-system/Capsule.toml
+++ b/capsules/capsule-system/Capsule.toml
@@ -3,7 +3,8 @@ name = "aos-system"
 version = "0.2.0"
 description = "System management tools — lets the LLM inspect and manage its own runtime"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
-astrid-version = ">=0.1.0"
+# Principal-stamped capsules_loaded metadata is available from Astrid 0.9.0.
+astrid-version = ">=0.9.0"
 
 [[component]]
 id = "system-tools"

--- a/capsules/capsule-system/README.md
+++ b/capsules/capsule-system/README.md
@@ -5,32 +5,37 @@
 
 **System management tools for [Unicity AOS](https://github.com/unicity-aos/aos-ce) agents.**
 
-This capsule gives the LLM typed tools to inspect and manage its own runtime. It makes Unicity AOS self-inspecting: the agent can inspect installed capsules, read interface contracts, and understand the health of its own system.
+This capsule gives agents typed tools to inspect their principal's last observed loaded capsule view, read interface contracts, and check that view's interface coverage. It requires Astrid 0.9.0 or newer.
 
 ## Tools
 
 | Tool | Description |
 |---|---|
-| `list_capsules` | List installed capsules with names and versions (use `inspect_capsule` for exports, imports, capabilities) |
-| `inspect_capsule` | Read a capsule's Capsule.toml manifest and meta.json metadata |
+| `list_capsules` | List names and versions from the principal's last observed loaded snapshot |
+| `inspect_capsule` | Return runtime-supplied installed metadata, principal, and observation time; not Capsule.toml |
 | `list_interfaces` | List available WIT interface definitions |
 | `read_interface` | Read a WIT interface definition (typed contract between capsules) |
-| `system_status` | Runtime health: capsule count, interface coverage, unsatisfied imports |
+| `system_status` | Loaded-snapshot capsule count, interface coverage, unsatisfied imports, principal, and observation time |
 
 ## How it works
 
-All operations go through the kernel's VFS and capability system. The capsule reads from `home://capsules/` to discover installed capsules and from `home://wit/astrid/` to read interface definitions. It cannot bypass sandbox boundaries.
+Capsule inspection consumes Astrid's principal-stamped `astrid.v1.capsules_loaded` events and caches metadata in principal-and-capsule-scoped KV. Shared executable hashes remain references: no capsule binaries or private capsule directories are copied into a principal's home. Live tool descriptors are omitted from this inspection cache.
+
+The snapshot describes loaded capsules, not every installed artifact in the global store. An empty snapshot is a valid empty loaded view; an absent snapshot or unavailable installed metadata returns an error. A tools-only discovery result does not count as installed metadata. Observation time is not a live health probe or proof that a later load/unload has already been observed.
+
+WIT inspection still reads `home://wit/astrid/` through the kernel's VFS and capability system.
 
 The LLM uses these tools to understand its own runtime before making changes. A typical flow:
 
-1. `list_capsules` -- see what's installed
+1. `list_capsules` -- see the last observed loaded view
 2. `read_interface session` -- understand the session interface contract
-3. `inspect_capsule aos-session` -- read the current implementation
+3. `inspect_capsule aos-session` -- inspect its metadata and shared executable hash
 4. Build and install a replacement (via shell or future system tools)
 
 ## Security
 
 - Read-only VFS access (`fs_read = ["home://"]`)
+- Snapshot KV storage is scoped to the invocation principal and this capsule
 - Path traversal rejected on all inputs
 - No capability to modify capsules directly -- write operations require separate tools with approval gates
 

--- a/capsules/capsule-system/src/inventory.rs
+++ b/capsules/capsule-system/src/inventory.rs
@@ -46,6 +46,11 @@ impl Snapshot {
             // the installed metadata, including its shared WASM hash.
             if let Some(object) = meta.as_object_mut() {
                 object.remove("tools");
+                if object.is_empty() {
+                    // A successful live describe does not prove that the
+                    // runtime could read installed metadata.
+                    meta = Value::Null;
+                }
             }
             if capsules.insert(entry.name, meta).is_some() {
                 return Err(error("duplicate capsule in runtime inventory"));
@@ -64,7 +69,7 @@ impl Snapshot {
                 "capsule '{name}' is not in this principal's loaded snapshot"
             ))
         })?;
-        if !meta.is_object() {
+        if meta.as_object().is_none_or(serde_json::Map::is_empty) {
             return Err(error(format!(
                 "runtime metadata is unavailable for capsule '{name}'"
             )));
@@ -81,6 +86,8 @@ pub(super) fn receive(payload: Value) -> Result<(), SysError> {
     let snapshot = Snapshot::from_event(payload, &principal, caller.timestamp)?;
     // The kernel scopes KV by invocation principal and capsule. Never persist
     // shared executable bytes or use a principal supplied by tool arguments.
+    // Snapshot broadcasts use the dispatcher's ordered per-(capsule, principal)
+    // consumer; it awaits this handler before processing the next event.
     kv::set_json(SNAPSHOT_KEY, &snapshot)
 }
 
@@ -141,5 +148,21 @@ mod tests {
         )
         .unwrap();
         assert!(missing.metadata("broken").is_err());
+    }
+
+    #[test]
+    fn live_tools_without_installed_metadata_are_not_health() {
+        // The runtime can discover tools even when reading meta.json fails.
+        for meta in [json!({"tools":[{"name":"read_file"}]}), json!({})] {
+            let snapshot = Snapshot::from_event(
+                json!({"capsules":[{
+                    "principal":"alice", "name":"broken", "meta":meta
+                }]}),
+                "alice",
+                "now".into(),
+            )
+            .unwrap();
+            assert!(snapshot.metadata("broken").is_err());
+        }
     }
 }

--- a/capsules/capsule-system/src/inventory.rs
+++ b/capsules/capsule-system/src/inventory.rs
@@ -1,0 +1,145 @@
+//! Principal-scoped metadata snapshots, never private copies of capsule bytes.
+
+use astrid_sdk::{SysError, kv, runtime};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+const SNAPSHOT_KEY: &str = "system.loaded_inventory";
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(super) struct Snapshot {
+    pub principal: String,
+    pub observed_at: String,
+    pub capsules: BTreeMap<String, Value>,
+}
+
+#[derive(Deserialize)]
+struct LoadedView {
+    capsules: Vec<LoadedCapsule>,
+}
+
+#[derive(Deserialize)]
+struct LoadedCapsule {
+    principal: String,
+    name: String,
+    meta: Value,
+}
+
+fn error(message: impl Into<String>) -> SysError {
+    SysError::ApiError(message.into())
+}
+
+impl Snapshot {
+    fn from_event(payload: Value, principal: &str, observed_at: String) -> Result<Self, SysError> {
+        let view: LoadedView = serde_json::from_value(payload)?;
+        let mut capsules = BTreeMap::new();
+        for entry in view.capsules {
+            if entry.principal != principal {
+                return Err(error("capsule inventory belongs to a different principal"));
+            }
+            if entry.name.is_empty() || entry.name.contains(['/', '\\']) || entry.name == ".." {
+                return Err(error("invalid capsule name in runtime inventory"));
+            }
+            let mut meta = entry.meta;
+            // Descriptors are large, live broker data. Inspection needs only
+            // the installed metadata, including its shared WASM hash.
+            if let Some(object) = meta.as_object_mut() {
+                object.remove("tools");
+            }
+            if capsules.insert(entry.name, meta).is_some() {
+                return Err(error("duplicate capsule in runtime inventory"));
+            }
+        }
+        Ok(Self {
+            principal: principal.to_owned(),
+            observed_at,
+            capsules,
+        })
+    }
+
+    pub(super) fn metadata(&self, name: &str) -> Result<&Value, SysError> {
+        let meta = self.capsules.get(name).ok_or_else(|| {
+            error(format!(
+                "capsule '{name}' is not in this principal's loaded snapshot"
+            ))
+        })?;
+        if !meta.is_object() {
+            return Err(error(format!(
+                "runtime metadata is unavailable for capsule '{name}'"
+            )));
+        }
+        Ok(meta)
+    }
+}
+
+pub(super) fn receive(payload: Value) -> Result<(), SysError> {
+    let caller = runtime::caller()?;
+    let principal = caller
+        .principal
+        .ok_or_else(|| error("inventory event has no principal"))?;
+    let snapshot = Snapshot::from_event(payload, &principal, caller.timestamp)?;
+    // The kernel scopes KV by invocation principal and capsule. Never persist
+    // shared executable bytes or use a principal supplied by tool arguments.
+    kv::set_json(SNAPSHOT_KEY, &snapshot)
+}
+
+pub(super) fn load() -> Result<Snapshot, SysError> {
+    let caller = runtime::caller()?;
+    let snapshot: Snapshot = kv::get_json_opt(SNAPSHOT_KEY)?
+        .ok_or_else(|| error("runtime capsule inventory has not been observed yet"))?;
+    if caller.principal.as_deref() != Some(snapshot.principal.as_str()) {
+        return Err(error(
+            "capsule inventory principal does not match this invocation",
+        ));
+    }
+    Ok(snapshot)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn references_shared_bytes_without_private_capsule_directories() {
+        let snapshot = Snapshot::from_event(json!({"capsules":[{
+            "principal":"alice", "name":"aos-fs",
+            "meta":{"version":"1.0.0", "wasm_hash":"shared-hash", "tools":[{"name":"read_file"}]}
+        }]}), "alice", "now".into()).unwrap();
+        assert_eq!(
+            snapshot.metadata("aos-fs").unwrap()["wasm_hash"],
+            "shared-hash"
+        );
+        assert!(snapshot.metadata("aos-fs").unwrap().get("tools").is_none());
+        assert!(snapshot.metadata("missing").is_err());
+    }
+
+    #[test]
+    fn rejects_other_principals_and_malformed_or_duplicate_inventory() {
+        for payload in [
+            json!({}),
+            json!({"capsules":[{"principal":"bob","name":"cap","meta":{}}]}),
+            json!({"capsules":[{"principal":"alice","name":"../cap","meta":{}}]}),
+            json!({"capsules":[{"principal":"alice","name":"cap","meta":{}},
+                                {"principal":"alice","name":"cap","meta":{}}]}),
+        ] {
+            assert!(Snapshot::from_event(payload, "alice", "now".into()).is_err());
+        }
+    }
+
+    #[test]
+    fn empty_snapshot_removes_previous_entries_but_unavailable_metadata_is_not_health() {
+        let empty = Snapshot::from_event(json!({"capsules":[]}), "alice", "now".into()).unwrap();
+        assert!(empty.capsules.is_empty());
+        let missing = Snapshot::from_event(
+            json!({"capsules":[{
+                "principal":"alice","name":"broken","meta":null
+            }]}),
+            "alice",
+            "now".into(),
+        )
+        .unwrap();
+        assert!(missing.metadata("broken").is_err());
+    }
+}

--- a/capsules/capsule-system/src/lib.rs
+++ b/capsules/capsule-system/src/lib.rs
@@ -11,8 +11,8 @@
 //!
 //! # Tools
 //!
-//! - `list_capsules` — enumerate installed capsules with names and versions
-//! - `inspect_capsule` — read a capsule's manifest and metadata
+//! - `list_capsules` — enumerate the principal's last loaded capsule snapshot
+//! - `inspect_capsule` — read metadata referencing a shared capsule artifact
 //! - `list_interfaces` — list available WIT interface contracts
 //! - `read_interface` — read a WIT interface definition
 //! - `system_status` — runtime health and interface coverage summary
@@ -21,8 +21,7 @@ use astrid_sdk::prelude::*;
 use astrid_sdk::schemars;
 use serde::{Deserialize, Serialize};
 
-/// Capsule directory under the principal home (FHS layout).
-const CAPSULES_DIR: &str = "home://.local/capsules";
+mod inventory;
 
 /// Standard WIT interface directory — per-principal, accessible via `home://wit/`.
 const WIT_DIR: &str = "home://wit";
@@ -65,6 +64,9 @@ struct CapsuleSummary {
 
 #[derive(Debug, Serialize)]
 struct SystemStatusResponse {
+    view: &'static str,
+    principal: String,
+    observed_at: String,
     capsule_count: usize,
     exports: Vec<String>,
     imports_satisfied: Vec<String>,
@@ -74,11 +76,6 @@ struct SystemStatusResponse {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Parse a `meta.json` file content into a serde_json::Value.
-fn parse_meta(content: &str) -> Option<serde_json::Value> {
-    serde_json::from_str(content).ok()
-}
 
 /// Extract `namespace/interface` strings from the nested exports/imports map
 /// in meta.json: `{ "astrid": { "session": "1.0.0" } }` → `["astrid/session 1.0.0"]`
@@ -111,26 +108,22 @@ fn list_entries(path: &str) -> Result<Vec<String>, SysError> {
 
 #[capsule]
 impl SystemTools {
-    /// List all installed capsules with their names and versions. Use `inspect_capsule`
-    /// for a capsule's manifest, exports, imports, and capabilities.
+    /// Receive the runtime-stamped, principal-scoped loaded metadata view.
+    #[astrid::interceptor("receive_inventory")]
+    pub fn receive_inventory(&self, payload: serde_json::Value) -> Result<(), SysError> {
+        inventory::receive(payload)
+    }
+
+    /// List capsules in the last runtime-loaded snapshot for this principal. Use `inspect_capsule`
+    /// for its metadata and shared WASM identity, exports, and imports.
     /// Returns a JSON array of capsule summaries.
     #[astrid::tool("list_capsules")]
     pub fn list_capsules(&self, _args: EmptyArgs) -> Result<String, SysError> {
-        let capsule_names = list_entries(CAPSULES_DIR)?;
+        let snapshot = inventory::load()?;
         let mut summaries = Vec::new();
 
-        for name in &capsule_names {
-            let meta_path = format!("{CAPSULES_DIR}/{name}/meta.json");
-            let meta_content = match astrid_sdk::fs::read_to_string(&meta_path) {
-                Ok(c) => c,
-                Err(_) => continue,
-            };
-
-            let meta = match parse_meta(&meta_content) {
-                Some(m) => m,
-                None => continue,
-            };
-
+        for name in snapshot.capsules.keys() {
+            let meta = snapshot.metadata(name)?;
             let version = meta
                 .get("version")
                 .and_then(|v| v.as_str())
@@ -159,8 +152,8 @@ impl SystemTools {
             .map_err(|e| SysError::ApiError(format!("serialize: {e}")))
     }
 
-    /// Read a capsule's full manifest and installation metadata.
-    /// Returns the Capsule.toml content and meta.json as a combined response.
+    /// Read loaded capsule metadata, including its shared WASM identity.
+    /// Returns the last observed principal snapshot entry, not a private manifest copy.
     #[astrid::tool("inspect_capsule")]
     pub fn inspect_capsule(&self, args: InspectCapsuleArgs) -> Result<String, SysError> {
         let name = args.name.trim();
@@ -175,18 +168,16 @@ impl SystemTools {
             ));
         }
 
-        let manifest_path = format!("{CAPSULES_DIR}/{name}/Capsule.toml");
-        let meta_path = format!("{CAPSULES_DIR}/{name}/meta.json");
-
-        let manifest = astrid_sdk::fs::read_to_string(&manifest_path)
-            .unwrap_or_else(|_| format!("(Capsule.toml not found for {name})"));
-
-        let meta = astrid_sdk::fs::read_to_string(&meta_path)
-            .unwrap_or_else(|_| format!("(meta.json not found for {name})"));
-
-        Ok(format!(
-            "=== Capsule.toml ===\n{manifest}\n\n=== meta.json ===\n{meta}"
-        ))
+        let snapshot = inventory::load()?;
+        let metadata = snapshot.metadata(name)?;
+        serde_json::to_string_pretty(&serde_json::json!({
+            "view": "last_observed_loaded_capsules",
+            "principal": snapshot.principal,
+            "observed_at": snapshot.observed_at,
+            "name": name,
+            "metadata": metadata,
+        }))
+        .map_err(|e| SysError::ApiError(format!("serialize: {e}")))
     }
 
     /// List all WIT interface definitions available in the system.
@@ -238,27 +229,18 @@ impl SystemTools {
         })
     }
 
-    /// Show runtime status: capsule count, interface coverage, satisfied and
+    /// Show the last loaded principal snapshot: capsule count, interface coverage, satisfied and
     /// unsatisfied imports. Helps you understand the health of the system.
     #[astrid::tool("system_status")]
     pub fn system_status(&self, _args: EmptyArgs) -> Result<String, SysError> {
-        let capsule_names = list_entries(CAPSULES_DIR)?;
+        let snapshot = inventory::load()?;
 
         // Collect all exports and imports across all capsules
         let mut all_exports: Vec<String> = Vec::new();
         let mut all_imports: Vec<(String, String)> = Vec::new(); // (interface, capsule_name)
 
-        for name in &capsule_names {
-            let meta_path = format!("{CAPSULES_DIR}/{name}/meta.json");
-            let meta_content = match astrid_sdk::fs::read_to_string(&meta_path) {
-                Ok(c) => c,
-                Err(_) => continue,
-            };
-            let meta = match parse_meta(&meta_content) {
-                Some(m) => m,
-                None => continue,
-            };
-
+        for name in snapshot.capsules.keys() {
+            let meta = snapshot.metadata(name)?;
             if let Some(exports) = meta.get("exports") {
                 for iface in flatten_interface_map(exports) {
                     // Strip version for matching: "astrid/session 1.0.0" → "astrid/session"
@@ -289,7 +271,10 @@ impl SystemTools {
         }
 
         let status = SystemStatusResponse {
-            capsule_count: capsule_names.len(),
+            view: "last_observed_loaded_capsules",
+            principal: snapshot.principal.clone(),
+            observed_at: snapshot.observed_at.clone(),
+            capsule_count: snapshot.capsules.len(),
             exports: all_exports,
             imports_satisfied: satisfied,
             imports_unsatisfied: unsatisfied,


### PR DESCRIPTION
## Summary

Fix `system_status`, `list_capsules`, and `inspect_capsule` reading the obsolete `home://.local/capsules` layout. Consume the existing principal-scoped `astrid.v1.capsules_loaded` metadata signal instead. No runtime, SDK, WIT, or storage format changes.

The response describes the last observed **loaded** capsule view, not all artifacts in the global store. Metadata preserves the shared WASM hash; no executable bytes are copied into principal homes. Inspection returns metadata rather than pretending to provide a private Capsule.toml.

## Verification

- Regression tests cover shared-hash preservation, other-principal rejection, malformed/duplicate inventories, empty snapshots, and unavailable metadata.
- `cargo test -p aos-system --lib`: 4 passed. The tools-only producer-shaped regression fails before the repair and passes afterward; empty installed metadata is also rejected.
- `cargo clippy -p aos-system --all-targets -- -D warnings`: passed.
- `cargo fmt --all --check`: passed.
- Built the installable `.capsule` with `astrid capsule build`, installed into a disposable runtime, and exercised real MCP with explicit session consent. Previously `system_status` returned NotFound. The repaired tool returns 22 loaded capsules; `list_capsules` returns 22 entries; `inspect_capsule(aos-fs)` returns the default principal and its nonempty shared WASM hash.

## Boundaries

Requires Astrid >=0.9.0, verified against the tagged principal-stamped payload producer. README now describes the loaded snapshot and metadata-only inspection. Tools-only discovery is preserved as unavailable installed metadata, not a healthy empty object.

The suggested pooled-interceptor race does not match the inspected dispatch path: `dispatch_to_capsule_queues` routes same-priority broadcasts through `dispatch_single`, and `run_consumer` awaits the handler before receiving the next event for that capsule/principal. Both v0.9.0 and current Astrid have this serialization. No redundant lock or non-atomic timestamp guard was added. This is an observation cache, not a claim of transactional freshness across runtime mutations.

The executable test uses candidate Astrid #1908 and the published AOS 2026.9.0 Distro, with only this capsule replaced locally. This is not a published patch or a complete Oracle-host certification. KV is scoped by the kernel to the invocation principal and capsule. Observation time is included in detailed inspection and status; absent/unavailable metadata errors instead of silently producing a healthy empty inventory. Existing WIT inspection and the separate forge diagnostics are not changed.

## AI / Tool Assistance

Assisted-by: OpenAI Codex:gpt-6-astra

Implementation, regression tests, and executable MCP verification.
