### PR TITLE
fix(bootstrap): allow credential-free Oracle host setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ implementations are consolidated into their final behavior.
 
 ### Fixed
 
+- Allow Community and Oracle host setup without an OpenAI API key. Provider
+  credentials can be configured when needed; host MCP tools do not require them.
+
 - Read principal-scoped loaded capsule metadata for system inspection instead
   of an obsolete private capsule directory. Shared executable hashes remain
   references; missing metadata is reported instead of silently omitted.

--- a/capsules/capsule-openai-compat/Capsule.toml
+++ b/capsules/capsule-openai-compat/Capsule.toml
@@ -30,7 +30,7 @@ capabilities = { net = ["*"] }
 net = ["*"]
 
 [env]
-api_key = { type = "secret", request = "Enter your API key for the OpenAI-compatible provider", placeholder = "sk-..." }
+api_key = { type = "secret", request = "Enter your API key for the OpenAI-compatible provider", placeholder = "sk-...", default = "" }
 base_url = { type = "string", request = "Enter the API base URL", default = "https://api.openai.com", placeholder = "https://api.openai.com" }
 model = { type = "select", request = "Enter the default model ID", default = "gpt-5.4", placeholder = "gpt-5.4", options_from = { http = "{base_url}/v1/models", bearer = "{api_key}", select = "data[].id", after = ["base_url", "api_key"] } }
 context_window = { type = "integer", request = "Enter the model's context window size (tokens)", default = "128000", placeholder = "128000" }

--- a/distros/community/unicity-ce/Distro.toml
+++ b/distros/community/unicity-ce/Distro.toml
@@ -27,7 +27,9 @@ tool = "^1.0"
 pubkey = "ed25519:utH537RuOuqKwjGx/pHIUAkKapyqPUhHpZIVDU6Q0FA="
 
 [variables]
-openai_api_key = { secret = true, description = "API key for OpenAI-compatible LLM provider" }
+# Host MCP tools do not require an LLM credential. Configure a key when using
+# an authenticated provider; an empty value also supports keyless local servers.
+openai_api_key = { secret = true, description = "API key for OpenAI-compatible LLM provider (optional at setup)", default = "" }
 openai_base_url = { description = "API base URL", default = "https://api.openai.com" }
 openai_model = { description = "Default model ID", default = "gpt-5.4" }
 openai_temperature = { description = "Default temperature (0.0-2.0, blank = provider default)", default = "" }

--- a/scripts/test-clean-home-init.sh
+++ b/scripts/test-clean-home-init.sh
@@ -42,6 +42,8 @@ mkdir -p "$project"
 run_aos() {
   (
     cd "$project"
+    # First-run must work without a provider credential inherited from CI.
+    unset ASTRID_VAR_OPENAI_API_KEY
     HOME="$work/user" \
       AOS_HOME="$aos_home" \
       UNICITY_AOS_RUNTIME_BIN="$bundle/runtime/bin/astrid" \
@@ -93,7 +95,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-run_aos init --offline --yes --var openai_api_key=release-gate-not-a-real-key
+run_aos init --offline --yes
 
 manifest="$aos_home/distributions/unicity-ce/Distro.toml"
 [[ -f "$manifest" ]]
@@ -132,7 +134,7 @@ pid_file="$aos_home/run/system.pid"
 [[ -f "$pid_file" && ! -L "$pid_file" ]]
 cp "$pid_file" "$work/system.pid.before"
 run_aos capsule show aos-cli --format json > "$work/cli-meta.before.json"
-run_aos init --offline --yes --var openai_api_key=release-gate-not-a-real-key
+run_aos init --offline --yes
 snapshot_provenance > "$work/distro.after.json"
 python3 - "$work/distro.before.json" "$work/distro.after.json" <<'PY'
 import json

--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -165,6 +165,10 @@ class CapsuleReleaseTests(unittest.TestCase):
         self.assertEqual(variables["openai_api_key"]["default"], "")
         self.assertTrue(variables["openai_api_key"]["secret"])
         self.assertTrue(all("default" in value for value in variables.values()))
+        provider = distro.parents[3] / "capsules/capsule-openai-compat/Capsule.toml"
+        provider_key = tomllib.loads(provider.read_text())["env"]["api_key"]
+        self.assertEqual(provider_key["default"], "")
+        self.assertEqual(provider_key["type"], "secret")
 
     def test_source_contract_has_exact_community_set(self) -> None:
         self.assertEqual(len(self.specs), 22)

--- a/scripts/test_capsule_release.py
+++ b/scripts/test_capsule_release.py
@@ -7,6 +7,7 @@ import json
 import sys
 import tarfile
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 from typing import Optional
@@ -157,6 +158,13 @@ class CapsuleReleaseTests(unittest.TestCase):
     def fixture_set(self, directory: Path) -> None:
         for spec in self.specs:
             write_fixture(directory / spec.asset, spec)
+
+    def test_headless_setup_has_no_required_provider_credential(self) -> None:
+        distro = Path(__file__).resolve().parent.parent / "distros/community/unicity-ce/Distro.toml"
+        variables = tomllib.loads(distro.read_text())["variables"]
+        self.assertEqual(variables["openai_api_key"]["default"], "")
+        self.assertTrue(variables["openai_api_key"]["secret"])
+        self.assertTrue(all("default" in value for value in variables.values()))
 
     def test_source_contract_has_exact_community_set(self) -> None:
         self.assertEqual(len(self.specs), 22)


### PR DESCRIPTION
## Summary

Closes #160

Allow Oracle host setup without supplying an unrelated OpenAI credential. Declare the distro key optional and permit the provider capsule to load unconfigured. Actual LLM invocation still reports missing credentials; host MCP tools do not require them.

## Changes

- Default the optional key to empty in the distro and provider manifest.
- Remove the fake key from the clean-home installation test and clear an inherited test credential.
- Add manifest regressions for both declarations.
- Update the Unreleased changelog.

## Verification

- Repeated against the final Astrid `64e3f5db` release build: fresh credential-free all-host Oracle install (184.68s), successful Codex/Claude/Grok MCP calls, volume-only stop, and all three calls again after restart passed.

- `python3 scripts/test_capsule_release.py`: 28 passed.
- Shell syntax and diff checks passed.
- Rebuilt provider capsule and actual product package with the companion Astrid repair. Real QA-key signature verification, credential-free all-host Oracle installation, and actual MCP forge_guide calls from installed Codex/Claude/Grok launchers passed.
- The private clean installation took approximately 182 seconds including the existing capsule batch-resume waits.

## Dependency and Test Plan

Requires the optional-secret fix in astrid-runtime/astrid#1910. The published Astrid 2026.9.0 still rejects empty optional secret writes. This is not a version bump or release authorization; the release must select a runtime containing that fix before shipping this change. Do not weaken the credential-free test to accommodate the old runtime.

Private rehearsal used a disposable QA trust identity and preserved verification logic. It does not certify production release delivery, new macOS app installation, or desktop host plugin activation.

## AI / Tool Assistance

Assisted-by: Codex:gpt-6-astra

Used for implementation and tests, reviewed through actual private package installation and host MCP invocation.
